### PR TITLE
feat: GraviScan handler modules — Increment 3a

### DIFF
--- a/docs/superpowers/plans/2026-04-09-graviscan-handler-modules.md
+++ b/docs/superpowers/plans/2026-04-09-graviscan-handler-modules.md
@@ -61,12 +61,18 @@ git show origin/graviscan/4-main-process:src/main/graviscan-path-utils.ts > src/
 git show origin/graviscan/4-main-process:src/main/box-backup.ts > src/main/box-backup.ts
 ```
 
-- [ ] **Step 4: Verify all three files compile**
+- [ ] **Step 4: Create the graviscan module directory**
 
-Run: `npx tsc --noEmit`
-Expected: No errors (these files only depend on Node builtins, `@prisma/client`, and `../types/graviscan` which already exist on `main`)
+```bash
+mkdir -p src/main/graviscan
+```
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Verify all three files compile**
+
+Run: `npx prisma generate && npx tsc --noEmit`
+Expected: No errors. Cherry-picked files depend on Prisma models (GraviScan, GraviImage, GraviScanner) that exist in the schema. `prisma generate` ensures the client types are up to date.
+
+- [ ] **Step 6: Commit**
 
 ```bash
 git add src/main/lsusb-detection.ts src/main/graviscan-path-utils.ts src/main/box-backup.ts
@@ -87,7 +93,7 @@ origin/graviscan/4-main-process. Required as imports for handler modules."
 
 ```typescript
 // @vitest-environment node
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Module-mock detectEpsonScanners before importing the module under test
 vi.mock('../../../src/main/lsusb-detection', () => ({
@@ -95,9 +101,18 @@ vi.mock('../../../src/main/lsusb-detection', () => ({
 }));
 
 import { detectEpsonScanners } from '../../../src/main/lsusb-detection';
+import {
+  detectScanners,
+  saveScannersToDB,
+  getConfig,
+  saveConfig,
+  getPlatformInfo,
+  validateConfig,
+  runStartupScannerValidation,
+  getSessionValidationState,
+  resetSessionValidation,
+} from '../../../src/main/graviscan/scanner-handlers';
 import type { DetectedScanner } from '../../../src/types/graviscan';
-
-// Import will be added after implementation exists — for now these are the test specs
 
 const mockDetect = vi.mocked(detectEpsonScanners);
 
@@ -147,9 +162,6 @@ describe('scanner-handlers', () => {
         count: 1,
       });
 
-      const { detectScanners } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await detectScanners(db);
 
       expect(result.success).toBe(true);
@@ -163,9 +175,6 @@ describe('scanner-handlers', () => {
         { id: 'db-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a', usb_bus: 1, usb_device: 1, usb_port: '1-1', enabled: true },
       ]);
 
-      const { detectScanners } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await detectScanners(db);
 
       expect(result.success).toBe(true);
@@ -181,9 +190,6 @@ describe('scanner-handlers', () => {
         count: 0,
       });
 
-      const { detectScanners } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await detectScanners(db);
 
       expect(result.success).toBe(false);
@@ -199,9 +205,6 @@ describe('scanner-handlers', () => {
         usb_bus: 1, usb_device: 2, usb_port: '1-2', enabled: true,
       });
 
-      const { saveScannersToDB } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await saveScannersToDB(db, [{
         name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
         usb_bus: 1, usb_device: 2, usb_port: '1-2',
@@ -213,24 +216,26 @@ describe('scanner-handlers', () => {
     });
 
     it('should update existing scanner matched by USB port', async () => {
-      db.graviScanner.findFirst
-        .mockResolvedValueOnce(null) // bus+device match
-        .mockResolvedValueOnce({ id: 'existing-1', name: 'Old Name', usb_port: '1-2' }); // port match
+      // findFirst returns null for bus+device, then returns existing for port match
+      db.graviScanner.findFirst.mockImplementation(async ({ where }: any) => {
+        if (where?.usb_port === '1-2') {
+          return { id: 'existing-1', name: 'Old Name', usb_port: '1-2', display_name: null };
+        }
+        return null;
+      });
       db.graviScanner.update.mockResolvedValue({
         id: 'existing-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
         usb_bus: 1, usb_device: 2, usb_port: '1-2', enabled: true,
       });
 
-      const { saveScannersToDB } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await saveScannersToDB(db, [{
         name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
         usb_bus: 1, usb_device: 2, usb_port: '1-2',
       }]);
 
       expect(result.success).toBe(true);
-      expect(db.graviScanner.update).toHaveBeenCalled();
+      expect(result.scanners[0].id).toBe('existing-1');
+      expect(result.scanners[0].name).toBe('Scanner 1');
     });
   });
 
@@ -240,9 +245,6 @@ describe('scanner-handlers', () => {
         id: '1', grid_mode: '2grid', resolution: 600, format: 'tiff',
       });
 
-      const { getConfig } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await getConfig(db);
 
       expect(result.success).toBe(true);
@@ -252,9 +254,6 @@ describe('scanner-handlers', () => {
     it('should return null when no config exists', async () => {
       db.graviConfig.findFirst.mockResolvedValue(null);
 
-      const { getConfig } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await getConfig(db);
 
       expect(result.success).toBe(true);
@@ -269,9 +268,6 @@ describe('scanner-handlers', () => {
         id: '1', grid_mode: '4grid', resolution: 1200, format: 'tiff',
       });
 
-      const { saveConfig } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await saveConfig(db, { grid_mode: '4grid', resolution: 1200 });
 
       expect(result.success).toBe(true);
@@ -284,9 +280,6 @@ describe('scanner-handlers', () => {
         id: '1', grid_mode: '2grid', resolution: 600, format: 'tiff',
       });
 
-      const { saveConfig } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await saveConfig(db, { grid_mode: '2grid', resolution: 600 });
 
       expect(result.success).toBe(true);
@@ -295,40 +288,30 @@ describe('scanner-handlers', () => {
   });
 
   describe('getPlatformInfo', () => {
-    it('should return sane backend on linux', async () => {
-      const originalPlatform = process.platform;
-      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    const originalPlatform = process.platform;
 
-      const { getPlatformInfo } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    });
+
+    it('should return sane backend on linux', async () => {
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
       const result = await getPlatformInfo();
 
       expect(result.success).toBe(true);
       expect(result.backend).toBe('sane');
-      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
     });
 
     it('should return unsupported on darwin', async () => {
-      const originalPlatform = process.platform;
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
-
-      const { getPlatformInfo } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await getPlatformInfo();
 
       expect(result.supported).toBe(false);
       expect(result.backend).toBe('unsupported');
-      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
     });
 
     it('should return mock platform info when GRAVISCAN_MOCK is true', async () => {
       vi.stubEnv('GRAVISCAN_MOCK', 'true');
-
-      const { getPlatformInfo } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await getPlatformInfo();
 
       expect(result.success).toBe(true);
@@ -341,9 +324,6 @@ describe('scanner-handlers', () => {
     it('should return no-config when no saved scanners', async () => {
       db.graviScanner.findMany.mockResolvedValue([]);
 
-      const { validateConfig } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await validateConfig(db);
 
       expect(result.success).toBe(true);
@@ -360,9 +340,6 @@ describe('scanner-handlers', () => {
         count: 1,
       });
 
-      const { validateConfig } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await validateConfig(db);
 
       expect(result.success).toBe(true);
@@ -377,9 +354,6 @@ describe('scanner-handlers', () => {
       ]);
       mockDetect.mockReturnValue({ success: true, scanners: [], count: 0 });
 
-      const { validateConfig } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       const result = await validateConfig(db);
 
       expect(result.status).toBe('mismatch');
@@ -389,11 +363,7 @@ describe('scanner-handlers', () => {
 
   describe('runStartupScannerValidation', () => {
     it('should skip validation when no cached scanners', async () => {
-      const { runStartupScannerValidation, resetSessionValidation } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       resetSessionValidation();
-
       const result = await runStartupScannerValidation(db, []);
 
       expect(result.isValidated).toBe(false);
@@ -410,11 +380,7 @@ describe('scanner-handlers', () => {
         count: 1,
       });
 
-      const { runStartupScannerValidation, resetSessionValidation } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
       resetSessionValidation();
-
       const result = await runStartupScannerValidation(db, ['s1']);
 
       expect(result.isValidated).toBe(true);
@@ -423,10 +389,7 @@ describe('scanner-handlers', () => {
   });
 
   describe('getSessionValidationState / resetSessionValidation', () => {
-    it('should return current state and reset', async () => {
-      const { getSessionValidationState, resetSessionValidation } = await import(
-        '../../../src/main/graviscan/scanner-handlers'
-      );
+    it('should return current state and reset', () => {
       resetSessionValidation();
       const state = getSessionValidationState();
       expect(state.isValidating).toBe(false);
@@ -560,6 +523,14 @@ function createMockSessionFns() {
   };
 }
 
+// Static imports — added after implementation exists
+import {
+  startScan,
+  getScanStatus,
+  markJobRecorded,
+  cancelScan,
+} from '../../../src/main/graviscan/session-handlers';
+
 describe('session-handlers', () => {
   let coordinator: ReturnType<typeof createMockCoordinator>;
   let sessionFns: ReturnType<typeof createMockSessionFns>;
@@ -586,9 +557,6 @@ describe('session-handlers', () => {
     };
 
     it('should reject when coordinator is null', async () => {
-      const { startScan } = await import(
-        '../../../src/main/graviscan/session-handlers'
-      );
       const result = await startScan(null as any, baseParams, sessionFns, onError);
 
       expect(result.success).toBe(false);
@@ -598,9 +566,6 @@ describe('session-handlers', () => {
     it('should reject when scan already in progress', async () => {
       coordinator = createMockCoordinator({ isScanning: true } as any);
 
-      const { startScan } = await import(
-        '../../../src/main/graviscan/session-handlers'
-      );
       const result = await startScan(coordinator, baseParams, sessionFns, onError);
 
       expect(result.success).toBe(false);
@@ -608,9 +573,6 @@ describe('session-handlers', () => {
     });
 
     it('should initialize coordinator and call scanOnce for one-shot', async () => {
-      const { startScan } = await import(
-        '../../../src/main/graviscan/session-handlers'
-      );
       const result = await startScan(coordinator, baseParams, sessionFns, onError);
 
       expect(result.success).toBe(true);
@@ -625,9 +587,6 @@ describe('session-handlers', () => {
         interval: { intervalSeconds: 300, durationSeconds: 3600 },
       };
 
-      const { startScan } = await import(
-        '../../../src/main/graviscan/session-handlers'
-      );
       const result = await startScan(coordinator, continuousParams, sessionFns, onError);
 
       expect(result.success).toBe(true);
@@ -639,9 +598,6 @@ describe('session-handlers', () => {
     });
 
     it('should build correct session state with jobs map', async () => {
-      const { startScan } = await import(
-        '../../../src/main/graviscan/session-handlers'
-      );
       await startScan(coordinator, baseParams, sessionFns, onError);
 
       const sessionArg = sessionFns.setScanSession.mock.calls[0][0];
@@ -657,9 +613,6 @@ describe('session-handlers', () => {
         interval: { intervalSeconds: 60, durationSeconds: 300 },
       };
 
-      const { startScan } = await import(
-        '../../../src/main/graviscan/session-handlers'
-      );
       await startScan(coordinator, continuousParams, sessionFns, onError);
 
       const sessionArg = sessionFns.setScanSession.mock.calls[0][0];
@@ -675,27 +628,21 @@ describe('session-handlers', () => {
         scanOnce: vi.fn().mockReturnValue(scanPromise),
       } as any);
 
-      const { startScan } = await import(
-        '../../../src/main/graviscan/session-handlers'
-      );
       const result = await startScan(coordinator, baseParams, sessionFns, onError);
       expect(result.success).toBe(true);
 
       // Now reject the detached promise
       deferred.reject(new Error('Subprocess crashed'));
-      // Let microtasks flush
-      await new Promise((r) => setTimeout(r, 10));
-
+      // Wait for the .catch() handler to execute
+      await vi.waitFor(() => {
+        expect(onError).toHaveBeenCalled();
+      });
       expect(sessionFns.setScanSession).toHaveBeenCalledWith(null);
-      expect(onError).toHaveBeenCalled();
     });
   });
 
   describe('getScanStatus', () => {
-    it('should return isActive false when no session', async () => {
-      const { getScanStatus } = await import(
-        '../../../src/main/graviscan/session-handlers'
-      );
+    it('should return isActive false when no session', () => {
       const result = getScanStatus(sessionFns);
 
       expect(result.isActive).toBe(false);
@@ -720,9 +667,6 @@ describe('session-handlers', () => {
         waveNumber: 0,
       });
 
-      const { getScanStatus } = await import(
-        '../../../src/main/graviscan/session-handlers'
-      );
       const result = getScanStatus(sessionFns);
 
       expect(result.isActive).toBe(true);
@@ -732,10 +676,7 @@ describe('session-handlers', () => {
   });
 
   describe('markJobRecorded', () => {
-    it('should delegate to injected markScanJobRecorded', async () => {
-      const { markJobRecorded } = await import(
-        '../../../src/main/graviscan/session-handlers'
-      );
+    it('should delegate to injected markScanJobRecorded', () => {
       markJobRecorded(sessionFns, 's1:00');
 
       expect(sessionFns.markScanJobRecorded).toHaveBeenCalledWith('s1:00');
@@ -744,9 +685,6 @@ describe('session-handlers', () => {
 
   describe('cancelScan', () => {
     it('should call cancelAll and shutdown then clear session', async () => {
-      const { cancelScan } = await import(
-        '../../../src/main/graviscan/session-handlers'
-      );
       const result = await cancelScan(coordinator, sessionFns);
 
       expect(result.success).toBe(true);
@@ -756,13 +694,18 @@ describe('session-handlers', () => {
     });
 
     it('should return error when coordinator is null', async () => {
-      const { cancelScan } = await import(
-        '../../../src/main/graviscan/session-handlers'
-      );
       const result = await cancelScan(null as any, sessionFns);
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('not initialized');
+    });
+
+    it('should return success when no scan session is active', async () => {
+      // Coordinator exists but no scan in progress
+      coordinator = createMockCoordinator({ isScanning: false } as any);
+      const result = await cancelScan(coordinator, sessionFns);
+
+      expect(result.success).toBe(true);
     });
   });
 });
@@ -900,19 +843,23 @@ function createMockDb() {
   } as any;
 }
 
+import {
+  getOutputDir,
+  readScanImage,
+  uploadAllScans,
+  downloadImages,
+  resetUploadState,
+} from '../../../src/main/graviscan/image-handlers';
+
 describe('image-handlers', () => {
   let db: ReturnType<typeof createMockDb>;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     db = createMockDb();
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
     mockResolvePath.mockReset();
     mockRunBoxBackup.mockReset();
-    // Reset upload state
-    const { resetUploadState } = await import(
-      '../../../src/main/graviscan/image-handlers'
-    );
     resetUploadState();
   });
 
@@ -921,10 +868,7 @@ describe('image-handlers', () => {
       vi.stubEnv('NODE_ENV', 'development');
       vi.mocked(app.getAppPath).mockReturnValue('/project/root');
 
-      const { getOutputDir } = await import(
-        '../../../src/main/graviscan/image-handlers'
-      );
-      const result = getOutputDir();
+            const result = getOutputDir();
 
       expect(result.success).toBe(true);
       expect(result.path).toContain('.graviscan');
@@ -934,10 +878,7 @@ describe('image-handlers', () => {
       vi.stubEnv('NODE_ENV', 'production');
       vi.mocked(app.getPath).mockReturnValue('/home/user');
 
-      const { getOutputDir } = await import(
-        '../../../src/main/graviscan/image-handlers'
-      );
-      const result = getOutputDir();
+            const result = getOutputDir();
 
       expect(result.success).toBe(true);
       expect(result.path).toContain('.bloom');
@@ -946,10 +887,7 @@ describe('image-handlers', () => {
     it('should create directory if missing', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-      const { getOutputDir } = await import(
-        '../../../src/main/graviscan/image-handlers'
-      );
-      getOutputDir();
+            getOutputDir();
 
       expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
     });
@@ -958,10 +896,7 @@ describe('image-handlers', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       vi.mocked(fs.mkdirSync).mockImplementation(() => { throw new Error('EACCES'); });
 
-      const { getOutputDir } = await import(
-        '../../../src/main/graviscan/image-handlers'
-      );
-      const result = getOutputDir();
+            const result = getOutputDir();
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('EACCES');
@@ -972,10 +907,15 @@ describe('image-handlers', () => {
     it('should return base64 data URI for thumbnail', async () => {
       mockResolvePath.mockReturnValue('/scan/image.tiff');
 
-      const { readScanImage } = await import(
-        '../../../src/main/graviscan/image-handlers'
-      );
-      const result = await readScanImage('/scan/image.tiff');
+            const result = await readScanImage('/scan/image.tiff');
+
+      expect(result.success).toBe(true);
+      expect(result.dataUri).toMatch(/^data:image\/jpeg;base64,/);
+    });
+
+    it('should return full-resolution data URI when full option is true', async () => {
+      mockResolvePath.mockReturnValue('/scan/image.tiff');
+      const result = await readScanImage('/scan/image.tiff', { full: true });
 
       expect(result.success).toBe(true);
       expect(result.dataUri).toMatch(/^data:image\/jpeg;base64,/);
@@ -984,10 +924,7 @@ describe('image-handlers', () => {
     it('should return error when file not found', async () => {
       mockResolvePath.mockReturnValue(null);
 
-      const { readScanImage } = await import(
-        '../../../src/main/graviscan/image-handlers'
-      );
-      const result = await readScanImage('/missing/image.tiff');
+            const result = await readScanImage('/missing/image.tiff');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('not found');
@@ -1000,10 +937,7 @@ describe('image-handlers', () => {
         success: true, experiments: 1, filesCopied: 5, errors: [],
       } as any);
 
-      const { uploadAllScans } = await import(
-        '../../../src/main/graviscan/image-handlers'
-      );
-      const onProgress = vi.fn();
+            const onProgress = vi.fn();
       const result = await uploadAllScans(db, onProgress);
 
       expect(result.success).toBe(true);
@@ -1015,10 +949,7 @@ describe('image-handlers', () => {
       // Make first upload hang
       mockRunBoxBackup.mockReturnValue(new Promise(() => {}));
 
-      const { uploadAllScans } = await import(
-        '../../../src/main/graviscan/image-handlers'
-      );
-      // Start first upload (will hang)
+            // Start first upload (will hang)
       const first = uploadAllScans(db);
       // Try second immediately
       const second = await uploadAllScans(db);
@@ -1032,10 +963,7 @@ describe('image-handlers', () => {
     it('should return zero counts when no images found', async () => {
       db.graviScan.findMany.mockResolvedValue([]);
 
-      const { downloadImages } = await import(
-        '../../../src/main/graviscan/image-handlers'
-      );
-      const result = await downloadImages(db, {
+            const result = await downloadImages(db, {
         experimentId: 'exp-1',
         experimentName: 'Test Exp',
         targetDir: '/tmp/download',
@@ -1058,10 +986,7 @@ describe('image-handlers', () => {
       }]);
       mockResolvePath.mockReturnValue('/scan/image.tiff');
 
-      const { downloadImages } = await import(
-        '../../../src/main/graviscan/image-handlers'
-      );
-      const onProgress = vi.fn();
+            const onProgress = vi.fn();
       const result = await downloadImages(db, {
         experimentId: 'exp-1',
         experimentName: 'Test Exp',

--- a/docs/superpowers/plans/2026-04-09-graviscan-handler-modules.md
+++ b/docs/superpowers/plans/2026-04-09-graviscan-handler-modules.md
@@ -30,6 +30,7 @@ tests/unit/graviscan/
 ```
 
 Cherry-picked dependencies (already exist in Ben's branch, need to land on our branch):
+
 - `src/main/lsusb-detection.ts`
 - `src/main/graviscan-path-utils.ts`
 - `src/main/box-backup.ts`
@@ -39,6 +40,7 @@ Cherry-picked dependencies (already exist in Ben's branch, need to land on our b
 ### Task 0: Cherry-Pick Dependencies
 
 **Files:**
+
 - Create: `src/main/lsusb-detection.ts` (from Ben's branch)
 - Create: `src/main/graviscan-path-utils.ts` (from Ben's branch)
 - Create: `src/main/box-backup.ts` (from Ben's branch)
@@ -87,6 +89,7 @@ origin/graviscan/4-main-process. Required as imports for handler modules."
 ### Task 1: Scanner Handlers — Tests
 
 **Files:**
+
 - Create: `tests/unit/graviscan/scanner-handlers.test.ts`
 
 - [ ] **Step 1: Write scanner-handlers test file with mocks and detectScanners tests**
@@ -172,7 +175,16 @@ describe('scanner-handlers', () => {
     it('should return mock scanners when GRAVISCAN_MOCK is true', async () => {
       vi.stubEnv('GRAVISCAN_MOCK', 'true');
       db.graviScanner.findMany.mockResolvedValue([
-        { id: 'db-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a', usb_bus: 1, usb_device: 1, usb_port: '1-1', enabled: true },
+        {
+          id: 'db-1',
+          name: 'Scanner 1',
+          vendor_id: '04b8',
+          product_id: '013a',
+          usb_bus: 1,
+          usb_device: 1,
+          usb_port: '1-1',
+          enabled: true,
+        },
       ]);
 
       const result = await detectScanners(db);
@@ -201,14 +213,26 @@ describe('scanner-handlers', () => {
     it('should create new scanner records', async () => {
       db.graviScanner.findFirst.mockResolvedValue(null);
       db.graviScanner.create.mockResolvedValue({
-        id: 'new-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
-        usb_bus: 1, usb_device: 2, usb_port: '1-2', enabled: true,
+        id: 'new-1',
+        name: 'Scanner 1',
+        vendor_id: '04b8',
+        product_id: '013a',
+        usb_bus: 1,
+        usb_device: 2,
+        usb_port: '1-2',
+        enabled: true,
       });
 
-      const result = await saveScannersToDB(db, [{
-        name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
-        usb_bus: 1, usb_device: 2, usb_port: '1-2',
-      }]);
+      const result = await saveScannersToDB(db, [
+        {
+          name: 'Scanner 1',
+          vendor_id: '04b8',
+          product_id: '013a',
+          usb_bus: 1,
+          usb_device: 2,
+          usb_port: '1-2',
+        },
+      ]);
 
       expect(result.success).toBe(true);
       expect(result.scanners).toHaveLength(1);
@@ -219,19 +243,36 @@ describe('scanner-handlers', () => {
       // findFirst returns null for bus+device, then returns existing for port match
       db.graviScanner.findFirst.mockImplementation(async ({ where }: any) => {
         if (where?.usb_port === '1-2') {
-          return { id: 'existing-1', name: 'Old Name', usb_port: '1-2', display_name: null };
+          return {
+            id: 'existing-1',
+            name: 'Old Name',
+            usb_port: '1-2',
+            display_name: null,
+          };
         }
         return null;
       });
       db.graviScanner.update.mockResolvedValue({
-        id: 'existing-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
-        usb_bus: 1, usb_device: 2, usb_port: '1-2', enabled: true,
+        id: 'existing-1',
+        name: 'Scanner 1',
+        vendor_id: '04b8',
+        product_id: '013a',
+        usb_bus: 1,
+        usb_device: 2,
+        usb_port: '1-2',
+        enabled: true,
       });
 
-      const result = await saveScannersToDB(db, [{
-        name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
-        usb_bus: 1, usb_device: 2, usb_port: '1-2',
-      }]);
+      const result = await saveScannersToDB(db, [
+        {
+          name: 'Scanner 1',
+          vendor_id: '04b8',
+          product_id: '013a',
+          usb_bus: 1,
+          usb_device: 2,
+          usb_port: '1-2',
+        },
+      ]);
 
       expect(result.success).toBe(true);
       expect(result.scanners[0].id).toBe('existing-1');
@@ -242,7 +283,10 @@ describe('scanner-handlers', () => {
   describe('getConfig', () => {
     it('should return config from database', async () => {
       db.graviConfig.findFirst.mockResolvedValue({
-        id: '1', grid_mode: '2grid', resolution: 600, format: 'tiff',
+        id: '1',
+        grid_mode: '2grid',
+        resolution: 600,
+        format: 'tiff',
       });
 
       const result = await getConfig(db);
@@ -265,10 +309,16 @@ describe('scanner-handlers', () => {
     it('should create config when none exists', async () => {
       db.graviConfig.findFirst.mockResolvedValue(null);
       db.graviConfig.create.mockResolvedValue({
-        id: '1', grid_mode: '4grid', resolution: 1200, format: 'tiff',
+        id: '1',
+        grid_mode: '4grid',
+        resolution: 1200,
+        format: 'tiff',
       });
 
-      const result = await saveConfig(db, { grid_mode: '4grid', resolution: 1200 });
+      const result = await saveConfig(db, {
+        grid_mode: '4grid',
+        resolution: 1200,
+      });
 
       expect(result.success).toBe(true);
       expect(db.graviConfig.create).toHaveBeenCalled();
@@ -277,10 +327,16 @@ describe('scanner-handlers', () => {
     it('should update existing config', async () => {
       db.graviConfig.findFirst.mockResolvedValue({ id: '1' });
       db.graviConfig.update.mockResolvedValue({
-        id: '1', grid_mode: '2grid', resolution: 600, format: 'tiff',
+        id: '1',
+        grid_mode: '2grid',
+        resolution: 600,
+        format: 'tiff',
       });
 
-      const result = await saveConfig(db, { grid_mode: '2grid', resolution: 600 });
+      const result = await saveConfig(db, {
+        grid_mode: '2grid',
+        resolution: 600,
+      });
 
       expect(result.success).toBe(true);
       expect(db.graviConfig.update).toHaveBeenCalled();
@@ -291,11 +347,17 @@ describe('scanner-handlers', () => {
     const originalPlatform = process.platform;
 
     afterEach(() => {
-      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
     });
 
     it('should return sane backend on linux', async () => {
-      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
       const result = await getPlatformInfo();
 
       expect(result.success).toBe(true);
@@ -303,7 +365,10 @@ describe('scanner-handlers', () => {
     });
 
     it('should return unsupported on darwin', async () => {
-      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        configurable: true,
+      });
       const result = await getPlatformInfo();
 
       expect(result.supported).toBe(false);
@@ -332,7 +397,14 @@ describe('scanner-handlers', () => {
 
     it('should match saved scanners by USB port', async () => {
       db.graviScanner.findMany.mockResolvedValue([
-        { id: 's1', name: 'Scanner 1', usb_port: '1-2', vendor_id: '04b8', product_id: '013a', enabled: true },
+        {
+          id: 's1',
+          name: 'Scanner 1',
+          usb_port: '1-2',
+          vendor_id: '04b8',
+          product_id: '013a',
+          enabled: true,
+        },
       ]);
       mockDetect.mockReturnValue({
         success: true,
@@ -350,7 +422,14 @@ describe('scanner-handlers', () => {
 
     it('should report missing scanners', async () => {
       db.graviScanner.findMany.mockResolvedValue([
-        { id: 's1', name: 'Scanner 1', usb_port: '1-2', vendor_id: '04b8', product_id: '013a', enabled: true },
+        {
+          id: 's1',
+          name: 'Scanner 1',
+          usb_port: '1-2',
+          vendor_id: '04b8',
+          product_id: '013a',
+          enabled: true,
+        },
       ]);
       mockDetect.mockReturnValue({ success: true, scanners: [], count: 0 });
 
@@ -372,7 +451,13 @@ describe('scanner-handlers', () => {
 
     it('should validate cached scanners against detected hardware', async () => {
       db.graviScanner.findMany.mockResolvedValue([
-        { id: 's1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a', enabled: true },
+        {
+          id: 's1',
+          name: 'Scanner 1',
+          vendor_id: '04b8',
+          product_id: '013a',
+          enabled: true,
+        },
       ]);
       mockDetect.mockReturnValue({
         success: true,
@@ -421,11 +506,13 @@ validation state accessors. All tests fail — implementation next."
 ### Task 2: Scanner Handlers — Implementation
 
 **Files:**
+
 - Create: `src/main/graviscan/scanner-handlers.ts`
 
 - [ ] **Step 1: Implement scanner-handlers.ts**
 
 Extract and adapt the following handlers from `origin/graviscan/4-main-process:src/main/graviscan-handlers.ts`:
+
 - `graviscan:detect-scanners` (lines 236-352)
 - `graviscan:get-config` (lines 362-380)
 - `graviscan:save-config` (lines 383-424)
@@ -436,6 +523,7 @@ Extract and adapt the following handlers from `origin/graviscan/4-main-process:s
 - Plus: `runStartupScannerValidation` (lines 56-190), `getSessionValidationState` (lines 191-196), `resetSessionValidation` (lines 198-206)
 
 Key adaptations from Ben's code:
+
 - Remove `ipcMain.handle()` wrappers — export naked async functions
 - Replace module-level `db` with `db: PrismaClient` parameter on every function
 - Keep module-level `sessionValidation` state + exported `resetSessionValidation()`
@@ -483,6 +571,7 @@ graviscan-handlers.ts. Pure exports with db injection, no ipcMain."
 ### Task 3: Session Handlers — Tests
 
 **Files:**
+
 - Create: `tests/unit/graviscan/session-handlers.test.ts`
 
 - [ ] **Step 1: Write session-handlers test file**
@@ -496,13 +585,19 @@ interface ScanCoordinatorLike {
   readonly isScanning: boolean;
   initialize(scanners: any[]): Promise<void>;
   scanOnce(platesPerScanner: Map<string, any[]>): Promise<void>;
-  scanInterval(platesPerScanner: Map<string, any[]>, intervalMs: number, durationMs: number): Promise<void>;
+  scanInterval(
+    platesPerScanner: Map<string, any[]>,
+    intervalMs: number,
+    durationMs: number
+  ): Promise<void>;
   cancelAll(): void;
   shutdown(): Promise<void>;
   on(event: string, listener: (...args: any[]) => void): this;
 }
 
-function createMockCoordinator(overrides: Partial<ScanCoordinatorLike> = {}): ScanCoordinatorLike {
+function createMockCoordinator(
+  overrides: Partial<ScanCoordinatorLike> = {}
+): ScanCoordinatorLike {
   return {
     isScanning: false,
     initialize: vi.fn().mockResolvedValue(undefined),
@@ -544,11 +639,20 @@ describe('session-handlers', () => {
 
   describe('startScan', () => {
     const baseParams = {
-      scanners: [{
-        scannerId: 's1',
-        saneName: 'epkowa:interpreter:001:002',
-        plates: [{ plate_index: '00', grid_mode: '2grid', resolution: 600, output_path: '/tmp/scan' }],
-      }],
+      scanners: [
+        {
+          scannerId: 's1',
+          saneName: 'epkowa:interpreter:001:002',
+          plates: [
+            {
+              plate_index: '00',
+              grid_mode: '2grid',
+              resolution: 600,
+              output_path: '/tmp/scan',
+            },
+          ],
+        },
+      ],
       metadata: {
         experimentId: 'exp-1',
         phenotyperId: 'pheno-1',
@@ -557,7 +661,12 @@ describe('session-handlers', () => {
     };
 
     it('should reject when coordinator is null', async () => {
-      const result = await startScan(null as any, baseParams, sessionFns, onError);
+      const result = await startScan(
+        null as any,
+        baseParams,
+        sessionFns,
+        onError
+      );
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('not initialized');
@@ -566,14 +675,24 @@ describe('session-handlers', () => {
     it('should reject when scan already in progress', async () => {
       coordinator = createMockCoordinator({ isScanning: true } as any);
 
-      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+      const result = await startScan(
+        coordinator,
+        baseParams,
+        sessionFns,
+        onError
+      );
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('already in progress');
     });
 
     it('should initialize coordinator and call scanOnce for one-shot', async () => {
-      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+      const result = await startScan(
+        coordinator,
+        baseParams,
+        sessionFns,
+        onError
+      );
 
       expect(result.success).toBe(true);
       expect(coordinator.initialize).toHaveBeenCalled();
@@ -587,13 +706,18 @@ describe('session-handlers', () => {
         interval: { intervalSeconds: 300, durationSeconds: 3600 },
       };
 
-      const result = await startScan(coordinator, continuousParams, sessionFns, onError);
+      const result = await startScan(
+        coordinator,
+        continuousParams,
+        sessionFns,
+        onError
+      );
 
       expect(result.success).toBe(true);
       expect(coordinator.scanInterval).toHaveBeenCalledWith(
         expect.any(Map),
         300000,
-        3600000,
+        3600000
       );
     });
 
@@ -628,7 +752,12 @@ describe('session-handlers', () => {
         scanOnce: vi.fn().mockReturnValue(scanPromise),
       } as any);
 
-      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+      const result = await startScan(
+        coordinator,
+        baseParams,
+        sessionFns,
+        onError
+      );
       expect(result.success).toBe(true);
 
       // Now reject the detached promise
@@ -731,17 +860,20 @@ error), getScanStatus, markJobRecorded, cancelScan. All fail."
 ### Task 4: Session Handlers — Implementation
 
 **Files:**
+
 - Create: `src/main/graviscan/session-handlers.ts`
 
 - [ ] **Step 1: Implement session-handlers.ts**
 
 Extract and adapt from Ben's `graviscan-handlers.ts`:
+
 - `graviscan:start-scan` (lines 784-938)
 - `graviscan:get-scan-status` (lines 940-968)
 - `graviscan:mark-job-recorded` (lines 968-978)
 - `graviscan:cancel-scan` (lines 979-1010)
 
 Key adaptations:
+
 - Define locally: `ScanCoordinatorLike` interface (`cancelAll()` not `cancelScan()`), `ScannerConfig`, `PlateConfig` (with `resolution: number`)
 - Remove `ipcMain.handle()` wrappers
 - Replace `getCoordinator?.()` with injected `coordinator` parameter
@@ -750,6 +882,7 @@ Key adaptations:
 - Fire-and-forget `.catch()` calls `onError` and `sessionFns.setScanSession(null)`
 
 The module exports:
+
 - `startScan(coordinator, params, sessionFns, onError)`
 - `getScanStatus(sessionFns)`
 - `markJobRecorded(sessionFns, jobKey)`
@@ -781,6 +914,7 @@ ScanCoordinatorLike interface based on Ben's ScanCoordinator."
 ### Task 5: Image Handlers — Tests
 
 **Files:**
+
 - Create: `tests/unit/graviscan/image-handlers.test.ts`
 
 - [ ] **Step 1: Write image-handlers test file**
@@ -868,7 +1002,7 @@ describe('image-handlers', () => {
       vi.stubEnv('NODE_ENV', 'development');
       vi.mocked(app.getAppPath).mockReturnValue('/project/root');
 
-            const result = getOutputDir();
+      const result = getOutputDir();
 
       expect(result.success).toBe(true);
       expect(result.path).toContain('.graviscan');
@@ -878,7 +1012,7 @@ describe('image-handlers', () => {
       vi.stubEnv('NODE_ENV', 'production');
       vi.mocked(app.getPath).mockReturnValue('/home/user');
 
-            const result = getOutputDir();
+      const result = getOutputDir();
 
       expect(result.success).toBe(true);
       expect(result.path).toContain('.bloom');
@@ -887,16 +1021,20 @@ describe('image-handlers', () => {
     it('should create directory if missing', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
-            getOutputDir();
+      getOutputDir();
 
-      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), {
+        recursive: true,
+      });
     });
 
     it('should return error when mkdirSync fails', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
-      vi.mocked(fs.mkdirSync).mockImplementation(() => { throw new Error('EACCES'); });
+      vi.mocked(fs.mkdirSync).mockImplementation(() => {
+        throw new Error('EACCES');
+      });
 
-            const result = getOutputDir();
+      const result = getOutputDir();
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('EACCES');
@@ -907,7 +1045,7 @@ describe('image-handlers', () => {
     it('should return base64 data URI for thumbnail', async () => {
       mockResolvePath.mockReturnValue('/scan/image.tiff');
 
-            const result = await readScanImage('/scan/image.tiff');
+      const result = await readScanImage('/scan/image.tiff');
 
       expect(result.success).toBe(true);
       expect(result.dataUri).toMatch(/^data:image\/jpeg;base64,/);
@@ -924,7 +1062,7 @@ describe('image-handlers', () => {
     it('should return error when file not found', async () => {
       mockResolvePath.mockReturnValue(null);
 
-            const result = await readScanImage('/missing/image.tiff');
+      const result = await readScanImage('/missing/image.tiff');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('not found');
@@ -934,10 +1072,13 @@ describe('image-handlers', () => {
   describe('uploadAllScans', () => {
     it('should trigger box backup and report results', async () => {
       mockRunBoxBackup.mockResolvedValue({
-        success: true, experiments: 1, filesCopied: 5, errors: [],
+        success: true,
+        experiments: 1,
+        filesCopied: 5,
+        errors: [],
       } as any);
 
-            const onProgress = vi.fn();
+      const onProgress = vi.fn();
       const result = await uploadAllScans(db, onProgress);
 
       expect(result.success).toBe(true);
@@ -949,7 +1090,7 @@ describe('image-handlers', () => {
       // Make first upload hang
       mockRunBoxBackup.mockReturnValue(new Promise(() => {}));
 
-            // Start first upload (will hang)
+      // Start first upload (will hang)
       const first = uploadAllScans(db);
       // Try second immediately
       const second = await uploadAllScans(db);
@@ -963,7 +1104,7 @@ describe('image-handlers', () => {
     it('should return zero counts when no images found', async () => {
       db.graviScan.findMany.mockResolvedValue([]);
 
-            const result = await downloadImages(db, {
+      const result = await downloadImages(db, {
         experimentId: 'exp-1',
         experimentName: 'Test Exp',
         targetDir: '/tmp/download',
@@ -975,23 +1116,29 @@ describe('image-handlers', () => {
     });
 
     it('should copy images and write metadata CSV', async () => {
-      db.graviScan.findMany.mockResolvedValue([{
-        wave_number: 0,
-        plate_barcode: 'PLATE-001',
-        plate_index: '00',
-        grid_mode: '2grid',
-        capture_date: new Date('2026-04-01'),
-        experiment: { accession: { graviPlateAccessions: [] } },
-        images: [{ path: '/scan/image.tiff' }],
-      }]);
+      db.graviScan.findMany.mockResolvedValue([
+        {
+          wave_number: 0,
+          plate_barcode: 'PLATE-001',
+          plate_index: '00',
+          grid_mode: '2grid',
+          capture_date: new Date('2026-04-01'),
+          experiment: { accession: { graviPlateAccessions: [] } },
+          images: [{ path: '/scan/image.tiff' }],
+        },
+      ]);
       mockResolvePath.mockReturnValue('/scan/image.tiff');
 
-            const onProgress = vi.fn();
-      const result = await downloadImages(db, {
-        experimentId: 'exp-1',
-        experimentName: 'Test Exp',
-        targetDir: '/tmp/download',
-      }, onProgress);
+      const onProgress = vi.fn();
+      const result = await downloadImages(
+        db,
+        {
+          experimentId: 'exp-1',
+          experimentName: 'Test Exp',
+          targetDir: '/tmp/download',
+        },
+        onProgress
+      );
 
       expect(result.total).toBe(1);
       expect(result.copied).toBe(1);
@@ -1023,17 +1170,20 @@ upload guard), downloadImages (incl metadata CSV). All fail."
 ### Task 6: Image Handlers — Implementation
 
 **Files:**
+
 - Create: `src/main/graviscan/image-handlers.ts`
 
 - [ ] **Step 1: Implement image-handlers.ts**
 
 Extract and adapt from Ben's `graviscan-handlers.ts`:
+
 - `graviscan:get-output-dir` (lines 1014-1050)
 - `graviscan:read-scan-image` (lines 1055-1093)
 - `graviscan:upload-all-scans` (lines 1095-1155)
 - `graviscan:download-images` (lines 1159-1338)
 
 Key adaptations:
+
 - Remove `ipcMain.handle()` wrappers
 - `getOutputDir()` — keep Electron `app` import (module-mocked in tests)
 - `readScanImage(filePath, options?)` — same as Ben's but no `_event` param
@@ -1066,6 +1216,7 @@ resetUploadState() for testing. Dialog handling deferred to 3c."
 ### Task 7: Barrel Export + Full Verification
 
 **Files:**
+
 - Create: `src/main/graviscan/index.ts`
 
 - [ ] **Step 1: Create index.ts barrel export**
@@ -1142,13 +1293,13 @@ Expected: All existing tests still pass + new graviscan tests pass
 
 ## Summary
 
-| Task | Module | What | Commit message prefix |
-|------|--------|------|-----------------------|
-| 0 | deps | Cherry-pick lsusb-detection, path-utils, box-backup | `chore:` |
-| 1 | scanner-handlers | Tests (red) | `test:` |
-| 2 | scanner-handlers | Implementation (green) | `feat:` |
-| 3 | session-handlers | Tests (red) | `test:` |
-| 4 | session-handlers | Implementation (green) | `feat:` |
-| 5 | image-handlers | Tests (red) | `test:` |
-| 6 | image-handlers | Implementation (green) | `feat:` |
-| 7 | index.ts | Barrel export + full verification | `feat:` |
+| Task | Module           | What                                                | Commit message prefix |
+| ---- | ---------------- | --------------------------------------------------- | --------------------- |
+| 0    | deps             | Cherry-pick lsusb-detection, path-utils, box-backup | `chore:`              |
+| 1    | scanner-handlers | Tests (red)                                         | `test:`               |
+| 2    | scanner-handlers | Implementation (green)                              | `feat:`               |
+| 3    | session-handlers | Tests (red)                                         | `test:`               |
+| 4    | session-handlers | Implementation (green)                              | `feat:`               |
+| 5    | image-handlers   | Tests (red)                                         | `test:`               |
+| 6    | image-handlers   | Implementation (green)                              | `feat:`               |
+| 7    | index.ts         | Barrel export + full verification                   | `feat:`               |

--- a/docs/superpowers/plans/2026-04-09-graviscan-handler-modules.md
+++ b/docs/superpowers/plans/2026-04-09-graviscan-handler-modules.md
@@ -1,0 +1,1229 @@
+# GraviScan Handler Modules (Increment 3a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the monolithic `graviscan-handlers.ts` (1,338 lines) from PR #138 into 3 focused, testable service modules with comprehensive unit tests.
+
+**Architecture:** Extract 15 IPC handlers from `origin/graviscan/4-main-process:src/main/graviscan-handlers.ts` into `src/main/graviscan/scanner-handlers.ts`, `session-handlers.ts`, and `image-handlers.ts`. Each module exports async functions testable via direct import — no `ipcMain` dependency. Key deps (Prisma, coordinator, session fns) injected as parameters; external deps (`detectEpsonScanners`, `sharp`, `fs`) module-mocked in tests.
+
+**Tech Stack:** TypeScript, Vitest, Prisma (mocked), sharp (mocked), Electron `app` API (mocked)
+
+**Source branch:** `origin/graviscan/4-main-process` (PR #138, Ben's branch)
+
+**Reference:** `openspec/changes/add-graviscan-handler-modules/` (proposal, design, tasks, spec)
+
+---
+
+## File Structure
+
+```
+src/main/graviscan/
+├── scanner-handlers.ts     # ~500 LOC — scanner detection, config, validation, platform
+├── session-handlers.ts     # ~400 LOC — scan lifecycle: start, status, cancel
+├── image-handlers.ts       # ~400 LOC — image read, export, upload
+└── index.ts                # barrel export + IPC channel mapping JSDoc
+
+tests/unit/graviscan/
+├── scanner-handlers.test.ts
+├── session-handlers.test.ts
+└── image-handlers.test.ts
+```
+
+Cherry-picked dependencies (already exist in Ben's branch, need to land on our branch):
+- `src/main/lsusb-detection.ts`
+- `src/main/graviscan-path-utils.ts`
+- `src/main/box-backup.ts`
+
+---
+
+### Task 0: Cherry-Pick Dependencies
+
+**Files:**
+- Create: `src/main/lsusb-detection.ts` (from Ben's branch)
+- Create: `src/main/graviscan-path-utils.ts` (from Ben's branch)
+- Create: `src/main/box-backup.ts` (from Ben's branch)
+
+- [ ] **Step 1: Extract lsusb-detection.ts from Ben's branch**
+
+```bash
+git show origin/graviscan/4-main-process:src/main/lsusb-detection.ts > src/main/lsusb-detection.ts
+```
+
+- [ ] **Step 2: Extract graviscan-path-utils.ts from Ben's branch**
+
+```bash
+git show origin/graviscan/4-main-process:src/main/graviscan-path-utils.ts > src/main/graviscan-path-utils.ts
+```
+
+- [ ] **Step 3: Extract box-backup.ts from Ben's branch**
+
+```bash
+git show origin/graviscan/4-main-process:src/main/box-backup.ts > src/main/box-backup.ts
+```
+
+- [ ] **Step 4: Verify all three files compile**
+
+Run: `npx tsc --noEmit`
+Expected: No errors (these files only depend on Node builtins, `@prisma/client`, and `../types/graviscan` which already exist on `main`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/lsusb-detection.ts src/main/graviscan-path-utils.ts src/main/box-backup.ts
+git commit -m "chore: cherry-pick graviscan utility files from PR #138
+
+Extract lsusb-detection, graviscan-path-utils, and box-backup from
+origin/graviscan/4-main-process. Required as imports for handler modules."
+```
+
+---
+
+### Task 1: Scanner Handlers — Tests
+
+**Files:**
+- Create: `tests/unit/graviscan/scanner-handlers.test.ts`
+
+- [ ] **Step 1: Write scanner-handlers test file with mocks and detectScanners tests**
+
+```typescript
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Module-mock detectEpsonScanners before importing the module under test
+vi.mock('../../../src/main/lsusb-detection', () => ({
+  detectEpsonScanners: vi.fn(),
+}));
+
+import { detectEpsonScanners } from '../../../src/main/lsusb-detection';
+import type { DetectedScanner } from '../../../src/types/graviscan';
+
+// Import will be added after implementation exists — for now these are the test specs
+
+const mockDetect = vi.mocked(detectEpsonScanners);
+
+// Helper: create a mock PrismaClient
+function createMockDb() {
+  return {
+    graviScanner: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    graviConfig: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  } as any;
+}
+
+const MOCK_SCANNER: DetectedScanner = {
+  name: 'Perfection V600 Photo',
+  scanner_id: 'scanner-1',
+  usb_bus: 1,
+  usb_device: 2,
+  usb_port: '1-2',
+  is_available: true,
+  vendor_id: '04b8',
+  product_id: '013a',
+  sane_name: 'epkowa:interpreter:001:002',
+};
+
+describe('scanner-handlers', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    vi.stubEnv('GRAVISCAN_MOCK', '');
+    mockDetect.mockReset();
+  });
+
+  describe('detectScanners', () => {
+    it('should return detected scanners from lsusb', async () => {
+      mockDetect.mockReturnValue({
+        success: true,
+        scanners: [MOCK_SCANNER],
+        count: 1,
+      });
+
+      const { detectScanners } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await detectScanners(db);
+
+      expect(result.success).toBe(true);
+      expect(result.scanners).toHaveLength(1);
+      expect(result.scanners[0].vendor_id).toBe('04b8');
+    });
+
+    it('should return mock scanners when GRAVISCAN_MOCK is true', async () => {
+      vi.stubEnv('GRAVISCAN_MOCK', 'true');
+      db.graviScanner.findMany.mockResolvedValue([
+        { id: 'db-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a', usb_bus: 1, usb_device: 1, usb_port: '1-1', enabled: true },
+      ]);
+
+      const { detectScanners } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await detectScanners(db);
+
+      expect(result.success).toBe(true);
+      expect(result.mock).toBe(true);
+      expect(mockDetect).not.toHaveBeenCalled();
+    });
+
+    it('should propagate detection failure', async () => {
+      mockDetect.mockReturnValue({
+        success: false,
+        error: 'lsusb not found',
+        scanners: [],
+        count: 0,
+      });
+
+      const { detectScanners } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await detectScanners(db);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('lsusb not found');
+    });
+  });
+
+  describe('saveScannersToDB', () => {
+    it('should create new scanner records', async () => {
+      db.graviScanner.findFirst.mockResolvedValue(null);
+      db.graviScanner.create.mockResolvedValue({
+        id: 'new-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
+        usb_bus: 1, usb_device: 2, usb_port: '1-2', enabled: true,
+      });
+
+      const { saveScannersToDB } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await saveScannersToDB(db, [{
+        name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
+        usb_bus: 1, usb_device: 2, usb_port: '1-2',
+      }]);
+
+      expect(result.success).toBe(true);
+      expect(result.scanners).toHaveLength(1);
+      expect(db.graviScanner.create).toHaveBeenCalled();
+    });
+
+    it('should update existing scanner matched by USB port', async () => {
+      db.graviScanner.findFirst
+        .mockResolvedValueOnce(null) // bus+device match
+        .mockResolvedValueOnce({ id: 'existing-1', name: 'Old Name', usb_port: '1-2' }); // port match
+      db.graviScanner.update.mockResolvedValue({
+        id: 'existing-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
+        usb_bus: 1, usb_device: 2, usb_port: '1-2', enabled: true,
+      });
+
+      const { saveScannersToDB } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await saveScannersToDB(db, [{
+        name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
+        usb_bus: 1, usb_device: 2, usb_port: '1-2',
+      }]);
+
+      expect(result.success).toBe(true);
+      expect(db.graviScanner.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('getConfig', () => {
+    it('should return config from database', async () => {
+      db.graviConfig.findFirst.mockResolvedValue({
+        id: '1', grid_mode: '2grid', resolution: 600, format: 'tiff',
+      });
+
+      const { getConfig } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await getConfig(db);
+
+      expect(result.success).toBe(true);
+      expect(result.config?.grid_mode).toBe('2grid');
+    });
+
+    it('should return null when no config exists', async () => {
+      db.graviConfig.findFirst.mockResolvedValue(null);
+
+      const { getConfig } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await getConfig(db);
+
+      expect(result.success).toBe(true);
+      expect(result.config).toBeNull();
+    });
+  });
+
+  describe('saveConfig', () => {
+    it('should create config when none exists', async () => {
+      db.graviConfig.findFirst.mockResolvedValue(null);
+      db.graviConfig.create.mockResolvedValue({
+        id: '1', grid_mode: '4grid', resolution: 1200, format: 'tiff',
+      });
+
+      const { saveConfig } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await saveConfig(db, { grid_mode: '4grid', resolution: 1200 });
+
+      expect(result.success).toBe(true);
+      expect(db.graviConfig.create).toHaveBeenCalled();
+    });
+
+    it('should update existing config', async () => {
+      db.graviConfig.findFirst.mockResolvedValue({ id: '1' });
+      db.graviConfig.update.mockResolvedValue({
+        id: '1', grid_mode: '2grid', resolution: 600, format: 'tiff',
+      });
+
+      const { saveConfig } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await saveConfig(db, { grid_mode: '2grid', resolution: 600 });
+
+      expect(result.success).toBe(true);
+      expect(db.graviConfig.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('getPlatformInfo', () => {
+    it('should return sane backend on linux', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+      const { getPlatformInfo } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await getPlatformInfo();
+
+      expect(result.success).toBe(true);
+      expect(result.backend).toBe('sane');
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    });
+
+    it('should return unsupported on darwin', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+
+      const { getPlatformInfo } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await getPlatformInfo();
+
+      expect(result.supported).toBe(false);
+      expect(result.backend).toBe('unsupported');
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    });
+
+    it('should return mock platform info when GRAVISCAN_MOCK is true', async () => {
+      vi.stubEnv('GRAVISCAN_MOCK', 'true');
+
+      const { getPlatformInfo } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await getPlatformInfo();
+
+      expect(result.success).toBe(true);
+      expect(result.supported).toBe(true);
+      expect(result.mock_enabled).toBe(true);
+    });
+  });
+
+  describe('validateConfig', () => {
+    it('should return no-config when no saved scanners', async () => {
+      db.graviScanner.findMany.mockResolvedValue([]);
+
+      const { validateConfig } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await validateConfig(db);
+
+      expect(result.success).toBe(true);
+      expect(result.status).toBe('no-config');
+    });
+
+    it('should match saved scanners by USB port', async () => {
+      db.graviScanner.findMany.mockResolvedValue([
+        { id: 's1', name: 'Scanner 1', usb_port: '1-2', vendor_id: '04b8', product_id: '013a', enabled: true },
+      ]);
+      mockDetect.mockReturnValue({
+        success: true,
+        scanners: [{ ...MOCK_SCANNER, usb_port: '1-2' }],
+        count: 1,
+      });
+
+      const { validateConfig } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await validateConfig(db);
+
+      expect(result.success).toBe(true);
+      expect(result.status).toBe('valid');
+      expect(result.matched).toHaveLength(1);
+      expect(result.missing).toHaveLength(0);
+    });
+
+    it('should report missing scanners', async () => {
+      db.graviScanner.findMany.mockResolvedValue([
+        { id: 's1', name: 'Scanner 1', usb_port: '1-2', vendor_id: '04b8', product_id: '013a', enabled: true },
+      ]);
+      mockDetect.mockReturnValue({ success: true, scanners: [], count: 0 });
+
+      const { validateConfig } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      const result = await validateConfig(db);
+
+      expect(result.status).toBe('mismatch');
+      expect(result.missing).toHaveLength(1);
+    });
+  });
+
+  describe('runStartupScannerValidation', () => {
+    it('should skip validation when no cached scanners', async () => {
+      const { runStartupScannerValidation, resetSessionValidation } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      resetSessionValidation();
+
+      const result = await runStartupScannerValidation(db, []);
+
+      expect(result.isValidated).toBe(false);
+      expect(result.isValidating).toBe(false);
+    });
+
+    it('should validate cached scanners against detected hardware', async () => {
+      db.graviScanner.findMany.mockResolvedValue([
+        { id: 's1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a', enabled: true },
+      ]);
+      mockDetect.mockReturnValue({
+        success: true,
+        scanners: [{ ...MOCK_SCANNER, scanner_id: 's1' }],
+        count: 1,
+      });
+
+      const { runStartupScannerValidation, resetSessionValidation } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      resetSessionValidation();
+
+      const result = await runStartupScannerValidation(db, ['s1']);
+
+      expect(result.isValidated).toBe(true);
+      expect(result.allScannersAvailable).toBe(true);
+    });
+  });
+
+  describe('getSessionValidationState / resetSessionValidation', () => {
+    it('should return current state and reset', async () => {
+      const { getSessionValidationState, resetSessionValidation } = await import(
+        '../../../src/main/graviscan/scanner-handlers'
+      );
+      resetSessionValidation();
+      const state = getSessionValidationState();
+      expect(state.isValidating).toBe(false);
+      expect(state.isValidated).toBe(false);
+      expect(state.detectedScanners).toEqual([]);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/graviscan/scanner-handlers.test.ts --reporter=verbose`
+Expected: FAIL — `Cannot find module '../../../src/main/graviscan/scanner-handlers'`
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/unit/graviscan/scanner-handlers.test.ts
+git commit -m "test: add scanner-handlers unit tests (red)
+
+Tests for detectScanners, saveScannersToDB, getConfig, saveConfig,
+getPlatformInfo, validateConfig, runStartupScannerValidation, and
+validation state accessors. All tests fail — implementation next."
+```
+
+---
+
+### Task 2: Scanner Handlers — Implementation
+
+**Files:**
+- Create: `src/main/graviscan/scanner-handlers.ts`
+
+- [ ] **Step 1: Implement scanner-handlers.ts**
+
+Extract and adapt the following handlers from `origin/graviscan/4-main-process:src/main/graviscan-handlers.ts`:
+- `graviscan:detect-scanners` (lines 236-352)
+- `graviscan:get-config` (lines 362-380)
+- `graviscan:save-config` (lines 383-424)
+- `graviscan:save-scanners-db` (lines 434-557)
+- `graviscan:platform-info` (lines 568-613)
+- `graviscan:validate-scanners` (lines 621-636) — delegates to `runStartupScannerValidation`
+- `graviscan:validate-config` (lines 638-772)
+- Plus: `runStartupScannerValidation` (lines 56-190), `getSessionValidationState` (lines 191-196), `resetSessionValidation` (lines 198-206)
+
+Key adaptations from Ben's code:
+- Remove `ipcMain.handle()` wrappers — export naked async functions
+- Replace module-level `db` with `db: PrismaClient` parameter on every function
+- Keep module-level `sessionValidation` state + exported `resetSessionValidation()`
+- Scanner model: Epson Perfection V600 (USB `04b8:013a`)
+
+```bash
+git show origin/graviscan/4-main-process:src/main/graviscan-handlers.ts > /tmp/graviscan-handlers-full.ts
+```
+
+Then create `src/main/graviscan/scanner-handlers.ts` by extracting and refactoring the relevant sections. The file should:
+
+1. Import `PrismaClient`, `detectEpsonScanners`, and types from `../types/graviscan`
+2. Define and export `SessionValidationState` interface
+3. Keep module-level `sessionValidation` const + `resetSessionValidation()` + `getSessionValidationState()`
+4. Export `runStartupScannerValidation(db, cachedScannerIds)` — adapted from lines 56-190, with `db` as first param
+5. Export `detectScanners(db)` — adapted from lines 236-352
+6. Export `getConfig(db)` — adapted from lines 362-380
+7. Export `saveConfig(db, configInput)` — adapted from lines 383-424
+8. Export `saveScannersToDB(db, scanners)` — adapted from lines 434-557
+9. Export `getPlatformInfo()` — adapted from lines 568-613 (no `db` needed)
+10. Export `validateConfig(db)` — adapted from lines 638-772
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/graviscan/scanner-handlers.test.ts --reporter=verbose`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run TypeScript compilation**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/graviscan/scanner-handlers.ts
+git commit -m "feat: add scanner-handlers module (green)
+
+Extracts 7 handlers + 3 validation state functions from Ben's
+graviscan-handlers.ts. Pure exports with db injection, no ipcMain."
+```
+
+---
+
+### Task 3: Session Handlers — Tests
+
+**Files:**
+- Create: `tests/unit/graviscan/session-handlers.test.ts`
+
+- [ ] **Step 1: Write session-handlers test file**
+
+```typescript
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Types matching Ben's ScanCoordinator + PlateConfig
+interface ScanCoordinatorLike {
+  readonly isScanning: boolean;
+  initialize(scanners: any[]): Promise<void>;
+  scanOnce(platesPerScanner: Map<string, any[]>): Promise<void>;
+  scanInterval(platesPerScanner: Map<string, any[]>, intervalMs: number, durationMs: number): Promise<void>;
+  cancelAll(): void;
+  shutdown(): Promise<void>;
+  on(event: string, listener: (...args: any[]) => void): this;
+}
+
+function createMockCoordinator(overrides: Partial<ScanCoordinatorLike> = {}): ScanCoordinatorLike {
+  return {
+    isScanning: false,
+    initialize: vi.fn().mockResolvedValue(undefined),
+    scanOnce: vi.fn().mockResolvedValue(undefined),
+    scanInterval: vi.fn().mockResolvedValue(undefined),
+    cancelAll: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn().mockReturnThis(),
+    ...overrides,
+  };
+}
+
+function createMockSessionFns() {
+  return {
+    getScanSession: vi.fn().mockReturnValue(null),
+    setScanSession: vi.fn(),
+    markScanJobRecorded: vi.fn(),
+  };
+}
+
+describe('session-handlers', () => {
+  let coordinator: ReturnType<typeof createMockCoordinator>;
+  let sessionFns: ReturnType<typeof createMockSessionFns>;
+  let onError: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    coordinator = createMockCoordinator();
+    sessionFns = createMockSessionFns();
+    onError = vi.fn();
+  });
+
+  describe('startScan', () => {
+    const baseParams = {
+      scanners: [{
+        scannerId: 's1',
+        saneName: 'epkowa:interpreter:001:002',
+        plates: [{ plate_index: '00', grid_mode: '2grid', resolution: 600, output_path: '/tmp/scan' }],
+      }],
+      metadata: {
+        experimentId: 'exp-1',
+        phenotyperId: 'pheno-1',
+        resolution: 600,
+      },
+    };
+
+    it('should reject when coordinator is null', async () => {
+      const { startScan } = await import(
+        '../../../src/main/graviscan/session-handlers'
+      );
+      const result = await startScan(null as any, baseParams, sessionFns, onError);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not initialized');
+    });
+
+    it('should reject when scan already in progress', async () => {
+      coordinator = createMockCoordinator({ isScanning: true } as any);
+
+      const { startScan } = await import(
+        '../../../src/main/graviscan/session-handlers'
+      );
+      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('already in progress');
+    });
+
+    it('should initialize coordinator and call scanOnce for one-shot', async () => {
+      const { startScan } = await import(
+        '../../../src/main/graviscan/session-handlers'
+      );
+      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+
+      expect(result.success).toBe(true);
+      expect(coordinator.initialize).toHaveBeenCalled();
+      expect(coordinator.scanOnce).toHaveBeenCalled();
+      expect(sessionFns.setScanSession).toHaveBeenCalled();
+    });
+
+    it('should call scanInterval for continuous mode', async () => {
+      const continuousParams = {
+        ...baseParams,
+        interval: { intervalSeconds: 300, durationSeconds: 3600 },
+      };
+
+      const { startScan } = await import(
+        '../../../src/main/graviscan/session-handlers'
+      );
+      const result = await startScan(coordinator, continuousParams, sessionFns, onError);
+
+      expect(result.success).toBe(true);
+      expect(coordinator.scanInterval).toHaveBeenCalledWith(
+        expect.any(Map),
+        300000,
+        3600000,
+      );
+    });
+
+    it('should build correct session state with jobs map', async () => {
+      const { startScan } = await import(
+        '../../../src/main/graviscan/session-handlers'
+      );
+      await startScan(coordinator, baseParams, sessionFns, onError);
+
+      const sessionArg = sessionFns.setScanSession.mock.calls[0][0];
+      expect(sessionArg.isActive).toBe(true);
+      expect(sessionArg.experimentId).toBe('exp-1');
+      expect(sessionArg.jobs['s1:00']).toBeDefined();
+      expect(sessionArg.jobs['s1:00'].status).toBe('pending');
+    });
+
+    it('should calculate totalCycles for continuous mode', async () => {
+      const continuousParams = {
+        ...baseParams,
+        interval: { intervalSeconds: 60, durationSeconds: 300 },
+      };
+
+      const { startScan } = await import(
+        '../../../src/main/graviscan/session-handlers'
+      );
+      await startScan(coordinator, continuousParams, sessionFns, onError);
+
+      const sessionArg = sessionFns.setScanSession.mock.calls[0][0];
+      expect(sessionArg.totalCycles).toBe(5); // 300 / 60
+    });
+
+    it('should call onError and clear session when fire-and-forget rejects', async () => {
+      const deferred = { reject: (_e: Error) => {} };
+      const scanPromise = new Promise<void>((_resolve, reject) => {
+        deferred.reject = reject;
+      });
+      coordinator = createMockCoordinator({
+        scanOnce: vi.fn().mockReturnValue(scanPromise),
+      } as any);
+
+      const { startScan } = await import(
+        '../../../src/main/graviscan/session-handlers'
+      );
+      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+      expect(result.success).toBe(true);
+
+      // Now reject the detached promise
+      deferred.reject(new Error('Subprocess crashed'));
+      // Let microtasks flush
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(sessionFns.setScanSession).toHaveBeenCalledWith(null);
+      expect(onError).toHaveBeenCalled();
+    });
+  });
+
+  describe('getScanStatus', () => {
+    it('should return isActive false when no session', async () => {
+      const { getScanStatus } = await import(
+        '../../../src/main/graviscan/session-handlers'
+      );
+      const result = getScanStatus(sessionFns);
+
+      expect(result.isActive).toBe(false);
+    });
+
+    it('should return full session state when active', async () => {
+      sessionFns.getScanSession.mockReturnValue({
+        isActive: true,
+        experimentId: 'exp-1',
+        phenotyperId: 'pheno-1',
+        resolution: 600,
+        sessionId: null,
+        jobs: { 's1:00': { status: 'pending' } },
+        isContinuous: false,
+        currentCycle: 0,
+        totalCycles: 1,
+        intervalMs: 0,
+        scanStartedAt: Date.now(),
+        scanDurationMs: 0,
+        coordinatorState: 'scanning',
+        nextScanAt: null,
+        waveNumber: 0,
+      });
+
+      const { getScanStatus } = await import(
+        '../../../src/main/graviscan/session-handlers'
+      );
+      const result = getScanStatus(sessionFns);
+
+      expect(result.isActive).toBe(true);
+      expect(result.experimentId).toBe('exp-1');
+      expect(result.jobs).toBeDefined();
+    });
+  });
+
+  describe('markJobRecorded', () => {
+    it('should delegate to injected markScanJobRecorded', async () => {
+      const { markJobRecorded } = await import(
+        '../../../src/main/graviscan/session-handlers'
+      );
+      markJobRecorded(sessionFns, 's1:00');
+
+      expect(sessionFns.markScanJobRecorded).toHaveBeenCalledWith('s1:00');
+    });
+  });
+
+  describe('cancelScan', () => {
+    it('should call cancelAll and shutdown then clear session', async () => {
+      const { cancelScan } = await import(
+        '../../../src/main/graviscan/session-handlers'
+      );
+      const result = await cancelScan(coordinator, sessionFns);
+
+      expect(result.success).toBe(true);
+      expect(coordinator.cancelAll).toHaveBeenCalled();
+      expect(coordinator.shutdown).toHaveBeenCalled();
+      expect(sessionFns.setScanSession).toHaveBeenCalledWith(null);
+    });
+
+    it('should return error when coordinator is null', async () => {
+      const { cancelScan } = await import(
+        '../../../src/main/graviscan/session-handlers'
+      );
+      const result = await cancelScan(null as any, sessionFns);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not initialized');
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/graviscan/session-handlers.test.ts --reporter=verbose`
+Expected: FAIL — `Cannot find module '../../../src/main/graviscan/session-handlers'`
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/unit/graviscan/session-handlers.test.ts
+git commit -m "test: add session-handlers unit tests (red)
+
+Tests for startScan (one-shot, continuous, rejection, fire-and-forget
+error), getScanStatus, markJobRecorded, cancelScan. All fail."
+```
+
+---
+
+### Task 4: Session Handlers — Implementation
+
+**Files:**
+- Create: `src/main/graviscan/session-handlers.ts`
+
+- [ ] **Step 1: Implement session-handlers.ts**
+
+Extract and adapt from Ben's `graviscan-handlers.ts`:
+- `graviscan:start-scan` (lines 784-938)
+- `graviscan:get-scan-status` (lines 940-968)
+- `graviscan:mark-job-recorded` (lines 968-978)
+- `graviscan:cancel-scan` (lines 979-1010)
+
+Key adaptations:
+- Define locally: `ScanCoordinatorLike` interface (`cancelAll()` not `cancelScan()`), `ScannerConfig`, `PlateConfig` (with `resolution: number`)
+- Remove `ipcMain.handle()` wrappers
+- Replace `getCoordinator?.()` with injected `coordinator` parameter
+- Replace `getScanSession`/`setScanSession`/`markScanJobRecorded` imports from `./main` with injected `sessionFns` parameter
+- Replace `getMainWindow?.()?.webContents.send('graviscan:scan-error', ...)` with injected `onError` callback
+- Fire-and-forget `.catch()` calls `onError` and `sessionFns.setScanSession(null)`
+
+The module exports:
+- `startScan(coordinator, params, sessionFns, onError)`
+- `getScanStatus(sessionFns)`
+- `markJobRecorded(sessionFns, jobKey)`
+- `cancelScan(coordinator, sessionFns)`
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/graviscan/session-handlers.test.ts --reporter=verbose`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run TypeScript compilation**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/graviscan/session-handlers.ts
+git commit -m "feat: add session-handlers module (green)
+
+Extracts 4 scan lifecycle handlers from Ben's graviscan-handlers.ts.
+Coordinator and session fns injected as parameters. Local
+ScanCoordinatorLike interface based on Ben's ScanCoordinator."
+```
+
+---
+
+### Task 5: Image Handlers — Tests
+
+**Files:**
+- Create: `tests/unit/graviscan/image-handlers.test.ts`
+
+- [ ] **Step 1: Write image-handlers test file**
+
+```typescript
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Module mocks — must be before imports
+vi.mock('electron', () => ({
+  app: {
+    getAppPath: vi.fn().mockReturnValue('/mock/app'),
+    getPath: vi.fn().mockReturnValue('/mock/home'),
+  },
+}));
+
+vi.mock('sharp', () => ({
+  default: vi.fn(() => ({
+    resize: vi.fn().mockReturnThis(),
+    jpeg: vi.fn().mockReturnValue({
+      toBuffer: vi.fn().mockResolvedValue(Buffer.from('fake-jpeg-data')),
+    }),
+  })),
+}));
+
+vi.mock('../../../src/main/graviscan-path-utils', () => ({
+  resolveGraviScanPath: vi.fn(),
+}));
+
+vi.mock('../../../src/main/box-backup', () => ({
+  runBoxBackup: vi.fn(),
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(true),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    promises: {
+      copyFile: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+import { app } from 'electron';
+import { resolveGraviScanPath } from '../../../src/main/graviscan-path-utils';
+import { runBoxBackup } from '../../../src/main/box-backup';
+import * as fs from 'fs';
+
+const mockResolvePath = vi.mocked(resolveGraviScanPath);
+const mockRunBoxBackup = vi.mocked(runBoxBackup);
+
+function createMockDb() {
+  return {
+    graviScan: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  } as any;
+}
+
+describe('image-handlers', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(async () => {
+    db = createMockDb();
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+    mockResolvePath.mockReset();
+    mockRunBoxBackup.mockReset();
+    // Reset upload state
+    const { resetUploadState } = await import(
+      '../../../src/main/graviscan/image-handlers'
+    );
+    resetUploadState();
+  });
+
+  describe('getOutputDir', () => {
+    it('should return dev path when NODE_ENV is development', async () => {
+      vi.stubEnv('NODE_ENV', 'development');
+      vi.mocked(app.getAppPath).mockReturnValue('/project/root');
+
+      const { getOutputDir } = await import(
+        '../../../src/main/graviscan/image-handlers'
+      );
+      const result = getOutputDir();
+
+      expect(result.success).toBe(true);
+      expect(result.path).toContain('.graviscan');
+    });
+
+    it('should return production path when NODE_ENV is production', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.mocked(app.getPath).mockReturnValue('/home/user');
+
+      const { getOutputDir } = await import(
+        '../../../src/main/graviscan/image-handlers'
+      );
+      const result = getOutputDir();
+
+      expect(result.success).toBe(true);
+      expect(result.path).toContain('.bloom');
+    });
+
+    it('should create directory if missing', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const { getOutputDir } = await import(
+        '../../../src/main/graviscan/image-handlers'
+      );
+      getOutputDir();
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+    });
+
+    it('should return error when mkdirSync fails', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.mkdirSync).mockImplementation(() => { throw new Error('EACCES'); });
+
+      const { getOutputDir } = await import(
+        '../../../src/main/graviscan/image-handlers'
+      );
+      const result = getOutputDir();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('EACCES');
+    });
+  });
+
+  describe('readScanImage', () => {
+    it('should return base64 data URI for thumbnail', async () => {
+      mockResolvePath.mockReturnValue('/scan/image.tiff');
+
+      const { readScanImage } = await import(
+        '../../../src/main/graviscan/image-handlers'
+      );
+      const result = await readScanImage('/scan/image.tiff');
+
+      expect(result.success).toBe(true);
+      expect(result.dataUri).toMatch(/^data:image\/jpeg;base64,/);
+    });
+
+    it('should return error when file not found', async () => {
+      mockResolvePath.mockReturnValue(null);
+
+      const { readScanImage } = await import(
+        '../../../src/main/graviscan/image-handlers'
+      );
+      const result = await readScanImage('/missing/image.tiff');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+  });
+
+  describe('uploadAllScans', () => {
+    it('should trigger box backup and report results', async () => {
+      mockRunBoxBackup.mockResolvedValue({
+        success: true, experiments: 1, filesCopied: 5, errors: [],
+      } as any);
+
+      const { uploadAllScans } = await import(
+        '../../../src/main/graviscan/image-handlers'
+      );
+      const onProgress = vi.fn();
+      const result = await uploadAllScans(db, onProgress);
+
+      expect(result.success).toBe(true);
+      expect(result.uploaded).toBe(5);
+      expect(mockRunBoxBackup).toHaveBeenCalled();
+    });
+
+    it('should reject concurrent uploads', async () => {
+      // Make first upload hang
+      mockRunBoxBackup.mockReturnValue(new Promise(() => {}));
+
+      const { uploadAllScans } = await import(
+        '../../../src/main/graviscan/image-handlers'
+      );
+      // Start first upload (will hang)
+      const first = uploadAllScans(db);
+      // Try second immediately
+      const second = await uploadAllScans(db);
+
+      expect(second.success).toBe(false);
+      expect(second.errors).toContain('Upload already in progress');
+    });
+  });
+
+  describe('downloadImages', () => {
+    it('should return zero counts when no images found', async () => {
+      db.graviScan.findMany.mockResolvedValue([]);
+
+      const { downloadImages } = await import(
+        '../../../src/main/graviscan/image-handlers'
+      );
+      const result = await downloadImages(db, {
+        experimentId: 'exp-1',
+        experimentName: 'Test Exp',
+        targetDir: '/tmp/download',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.total).toBe(0);
+      expect(result.copied).toBe(0);
+    });
+
+    it('should copy images and write metadata CSV', async () => {
+      db.graviScan.findMany.mockResolvedValue([{
+        wave_number: 0,
+        plate_barcode: 'PLATE-001',
+        plate_index: '00',
+        grid_mode: '2grid',
+        capture_date: new Date('2026-04-01'),
+        experiment: { accession: { graviPlateAccessions: [] } },
+        images: [{ path: '/scan/image.tiff' }],
+      }]);
+      mockResolvePath.mockReturnValue('/scan/image.tiff');
+
+      const { downloadImages } = await import(
+        '../../../src/main/graviscan/image-handlers'
+      );
+      const onProgress = vi.fn();
+      const result = await downloadImages(db, {
+        experimentId: 'exp-1',
+        experimentName: 'Test Exp',
+        targetDir: '/tmp/download',
+      }, onProgress);
+
+      expect(result.total).toBe(1);
+      expect(result.copied).toBe(1);
+      expect(fs.writeFileSync).toHaveBeenCalled(); // metadata CSV
+      expect(fs.promises.copyFile).toHaveBeenCalled();
+      expect(onProgress).toHaveBeenCalled();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/graviscan/image-handlers.test.ts --reporter=verbose`
+Expected: FAIL — `Cannot find module '../../../src/main/graviscan/image-handlers'`
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/unit/graviscan/image-handlers.test.ts
+git commit -m "test: add image-handlers unit tests (red)
+
+Tests for getOutputDir, readScanImage, uploadAllScans (incl concurrent
+upload guard), downloadImages (incl metadata CSV). All fail."
+```
+
+---
+
+### Task 6: Image Handlers — Implementation
+
+**Files:**
+- Create: `src/main/graviscan/image-handlers.ts`
+
+- [ ] **Step 1: Implement image-handlers.ts**
+
+Extract and adapt from Ben's `graviscan-handlers.ts`:
+- `graviscan:get-output-dir` (lines 1014-1050)
+- `graviscan:read-scan-image` (lines 1055-1093)
+- `graviscan:upload-all-scans` (lines 1095-1155)
+- `graviscan:download-images` (lines 1159-1338)
+
+Key adaptations:
+- Remove `ipcMain.handle()` wrappers
+- `getOutputDir()` — keep Electron `app` import (module-mocked in tests)
+- `readScanImage(filePath, options?)` — same as Ben's but no `_event` param
+- `uploadAllScans(db, onProgress?)` — replace `getMainWindow?.()?.webContents.send('graviscan:box-backup-progress', progress)` with `onProgress?.(progress)`. Module-level `uploadInProgress` guard + exported `resetUploadState()`
+- `downloadImages(db, params, onProgress?)` — accept `targetDir: string` in params (no `dialog.showOpenDialog`). Replace `mainWindow.webContents.send('graviscan:download-progress', ...)` with `onProgress?.(...)`. Remove `mainWindow` null check (no longer relevant).
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/graviscan/image-handlers.test.ts --reporter=verbose`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run TypeScript compilation**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/graviscan/image-handlers.ts
+git commit -m "feat: add image-handlers module (green)
+
+Extracts 4 image operation handlers from Ben's graviscan-handlers.ts.
+Progress events via callback injection. Upload guard with
+resetUploadState() for testing. Dialog handling deferred to 3c."
+```
+
+---
+
+### Task 7: Barrel Export + Full Verification
+
+**Files:**
+- Create: `src/main/graviscan/index.ts`
+
+- [ ] **Step 1: Create index.ts barrel export**
+
+```typescript
+/**
+ * GraviScan Handler Modules
+ *
+ * Extracted from PR #138 (origin/graviscan/4-main-process) graviscan-handlers.ts.
+ * Each module exports testable functions — no ipcMain dependency.
+ * IPC wiring happens in Increment 3c (register-handlers.ts).
+ *
+ * IPC channel → function mapping (for 3c reference):
+ *
+ *   graviscan:detect-scanners    → scannerHandlers.detectScanners(db)
+ *   graviscan:get-config         → scannerHandlers.getConfig(db)
+ *   graviscan:save-config        → scannerHandlers.saveConfig(db, config)
+ *   graviscan:save-scanners-db   → scannerHandlers.saveScannersToDB(db, scanners)
+ *   graviscan:platform-info      → scannerHandlers.getPlatformInfo()
+ *   graviscan:validate-scanners  → scannerHandlers.runStartupScannerValidation(db, ids)
+ *   graviscan:validate-config    → scannerHandlers.validateConfig(db)
+ *   graviscan:start-scan         → sessionHandlers.startScan(coordinator, params, fns, onError)
+ *   graviscan:get-scan-status    → sessionHandlers.getScanStatus(fns)
+ *   graviscan:mark-job-recorded  → sessionHandlers.markJobRecorded(fns, key)
+ *   graviscan:cancel-scan        → sessionHandlers.cancelScan(coordinator, fns)
+ *   graviscan:get-output-dir     → imageHandlers.getOutputDir()
+ *   graviscan:read-scan-image    → imageHandlers.readScanImage(path, opts)
+ *   graviscan:upload-all-scans   → imageHandlers.uploadAllScans(db, onProgress)
+ *   graviscan:download-images    → imageHandlers.downloadImages(db, params, onProgress)
+ *
+ * webContents.send channels replaced by callbacks:
+ *   graviscan:scan-error          → onError callback in startScan
+ *   graviscan:box-backup-progress → onProgress callback in uploadAllScans
+ *   graviscan:download-progress   → onProgress callback in downloadImages
+ */
+
+export * from './scanner-handlers';
+export * from './session-handlers';
+export * from './image-handlers';
+```
+
+- [ ] **Step 2: Run ALL tests**
+
+Run: `npx vitest run tests/unit/graviscan/ --reporter=verbose`
+Expected: All tests PASS across all 3 test files
+
+- [ ] **Step 3: Run TypeScript compilation**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Run lint**
+
+Run: `npx eslint src/main/graviscan/`
+Expected: No errors (fix any that appear)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/graviscan/index.ts
+git commit -m "feat: add barrel export with IPC channel mapping JSDoc
+
+Re-exports all public functions from scanner-handlers, session-handlers,
+and image-handlers. JSDoc documents IPC channel → function mapping and
+webContents.send → callback replacements for Increment 3c."
+```
+
+- [ ] **Step 6: Final verification — run full test suite**
+
+Run: `npx vitest run --reporter=verbose`
+Expected: All existing tests still pass + new graviscan tests pass
+
+---
+
+## Summary
+
+| Task | Module | What | Commit message prefix |
+|------|--------|------|-----------------------|
+| 0 | deps | Cherry-pick lsusb-detection, path-utils, box-backup | `chore:` |
+| 1 | scanner-handlers | Tests (red) | `test:` |
+| 2 | scanner-handlers | Implementation (green) | `feat:` |
+| 3 | session-handlers | Tests (red) | `test:` |
+| 4 | session-handlers | Implementation (green) | `feat:` |
+| 5 | image-handlers | Tests (red) | `test:` |
+| 6 | image-handlers | Implementation (green) | `feat:` |
+| 7 | index.ts | Barrel export + full verification | `feat:` |

--- a/docs/superpowers/plans/2026-04-09-graviscan-handler-modules.md
+++ b/docs/superpowers/plans/2026-04-09-graviscan-handler-modules.md
@@ -64,7 +64,7 @@ git show origin/graviscan/4-main-process:src/main/box-backup.ts > src/main/box-b
 - [ ] **Step 4: Create the graviscan module directory**
 
 ```bash
-mkdir -p src/main/graviscan
+mkdir -p src/main/graviscan tests/unit/graviscan
 ```
 
 - [ ] **Step 5: Verify all three files compile**

--- a/openspec/changes/add-graviscan-handler-modules/design.md
+++ b/openspec/changes/add-graviscan-handler-modules/design.md
@@ -18,12 +18,14 @@ The key insight from the CylinderScan codebase: `camera-process.ts` and `scanner
 We follow the same principle: **business logic in separate modules, testable via direct import, with module-mocked external dependencies.** We are NOT claiming pure-function purity. These modules have module-level state (`sessionValidation`, `uploadInProgress`) and use module-level imports (`detectEpsonScanners`, `sharp`, `fs`) that are mocked in tests via `vi.mock()`.
 
 What IS dependency-injected (passed as parameters):
+
 - `db: PrismaClient` — enables mocking without singleton coupling
 - `coordinator: ScanCoordinator` — does not exist yet (Increment 3b), injected to avoid import coupling
 - Session state functions (`getScanSession`, `setScanSession`, `markScanJobRecorded`) — currently live in `main.ts`, injected to break circular dependency
 - Progress/error callbacks — replace `mainWindow.webContents.send()` for testability
 
 What is NOT dependency-injected (module-mocked in tests via `vi.mock()`):
+
 - `detectEpsonScanners` from `../lsusb-detection`
 - `resolveGraviScanPath` from `../graviscan-path-utils`
 - `sharp` (native image processing)
@@ -32,6 +34,7 @@ What is NOT dependency-injected (module-mocked in tests via `vi.mock()`):
 - `app` from `electron` (used by `getOutputDir` for path resolution — `app.getAppPath()`, `app.getPath('home')`)
 
 Alternatives considered:
+
 - **Handler files own `ipcMain.handle()`**: Rejected. This is the `database-handlers.ts` pattern that led to 942 untested lines. Requires mocking Electron's IPC runtime.
 - **Pure stateless functions with full DI**: Rejected. Overstates purity — we have real module-level state and it's simpler to let external deps be module imports rather than threading 6+ parameters through every call.
 
@@ -39,11 +42,11 @@ Alternatives considered:
 
 Grouped by workflow phase rather than strict domain object:
 
-| Module | Handlers | Rationale |
-|---|---|---|
+| Module                | Handlers                                                                                                                                           | Rationale                                             |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
 | `scanner-handlers.ts` | `detect-scanners`, `save-scanners-db`, `get-config`, `save-config`, `platform-info`, `validate-scanners`, `validate-config` + validation state fns | Everything about scanner hardware setup and readiness |
-| `session-handlers.ts` | `start-scan`, `get-scan-status`, `mark-job-recorded`, `cancel-scan` | Scan execution lifecycle via ScanCoordinator |
-| `image-handlers.ts` | `get-output-dir`, `read-scan-image`, `upload-all-scans`, `download-images` | Image output, export, and backup |
+| `session-handlers.ts` | `start-scan`, `get-scan-status`, `mark-job-recorded`, `cancel-scan`                                                                                | Scan execution lifecycle via ScanCoordinator          |
+| `image-handlers.ts`   | `get-output-dir`, `read-scan-image`, `upload-all-scans`, `download-images`                                                                         | Image output, export, and backup                      |
 
 ### Cherry-pick dependencies from Ben's branch
 
@@ -64,7 +67,11 @@ interface ScanCoordinatorLike {
   readonly isScanning: boolean;
   initialize(scanners: ScannerConfig[]): Promise<void>;
   scanOnce(platesPerScanner: Map<string, PlateConfig[]>): Promise<void>;
-  scanInterval(platesPerScanner: Map<string, PlateConfig[]>, intervalMs: number, durationMs: number): Promise<void>;
+  scanInterval(
+    platesPerScanner: Map<string, PlateConfig[]>,
+    intervalMs: number,
+    durationMs: number
+  ): Promise<void>;
   cancelAll(): void;
   shutdown(): Promise<void>;
   on(event: string, listener: (...args: any[]) => void): this;
@@ -111,7 +118,7 @@ export async function downloadImages(
   db: PrismaClient,
   params: DownloadParams,
   onProgress?: (progress: DownloadProgress) => void
-): Promise<DownloadResult>
+): Promise<DownloadResult>;
 ```
 
 The IPC wiring layer (3c) converts callbacks to `webContents.send()`.
@@ -123,6 +130,7 @@ Ben's `download-images` handler opens a native folder picker via `dialog.showOpe
 ### Module-level mutable state
 
 Two pieces of module-level state exist:
+
 - **`sessionValidation`** in `scanner-handlers.ts` — startup validation state. Exposed via `getSessionValidationState()` / `resetSessionValidation()`. Tests call `resetSessionValidation()` in `beforeEach`.
 - **`uploadInProgress`** in `image-handlers.ts` — upload guard boolean. Prevents concurrent Box uploads. Managed as module-level closure state with `resetUploadState()` exported for testing.
 

--- a/openspec/changes/add-graviscan-handler-modules/design.md
+++ b/openspec/changes/add-graviscan-handler-modules/design.md
@@ -2,33 +2,37 @@
 
 Increment 3a of the GraviScan integration. PR #138 (`origin/graviscan/4-main-process`) contains a monolithic `graviscan-handlers.ts` (1,338 lines, 15 IPC handlers) that needs restructuring before integration into `main.ts`.
 
-The CylinderScan codebase demonstrates two patterns:
-- **Testable pattern**: `camera-process.ts`, `scanner-process.ts` — pure classes with no `ipcMain` dependency, full unit test coverage
-- **Untestable pattern**: `database-handlers.ts` (942 lines) — business logic coupled to `ipcMain.handle()`, zero unit tests, coverage excluded via `src/main/**` in vitest.config.ts
-
-We follow the testable pattern.
+The design spec (`docs/superpowers/specs/2026-04-03-graviscan-integration-design.md`, line 304) lists 4 modules for Increment 3a. We are delivering 3 modules now because `scan-handlers.ts` (GraviScan DB CRUD) has no source handlers in Ben's file — those will be added in Increment 3c when `database-handlers.ts` is extended. This divergence is intentional and documented here.
 
 ## Goals / Non-Goals
 
-- Goals: Split Ben's monolithic file into 3 focused, independently testable service modules. Write comprehensive unit tests. No integration with `main.ts` yet.
+- Goals: Split Ben's monolithic file into 3 focused, independently testable modules in `src/main/graviscan/`. Write comprehensive unit tests. No integration with `main.ts` yet.
 - Non-Goals: IPC wiring (Increment 3c), `scan-handlers.ts` for DB CRUD (Increment 3c), renderer changes, preload changes, coverage threshold increases (tracked in issue #181).
 
 ## Decisions
 
-### 3 modules now, 4th in Increment 3c
+### Separate-module pattern (testable via direct import)
 
-`scan-handlers.ts` (GraviScan DB CRUD) is deferred because the CRUD handlers don't exist in Ben's file — they'll be added when `database-handlers.ts` is extended in Increment 3c. Shipping an empty placeholder adds no value.
+The key insight from the CylinderScan codebase: `camera-process.ts` and `scanner-process.ts` are testable because they live in **separate modules from `main.ts`**, not because they're pure. They are stateful EventEmitter classes — `ScannerProcess` even calls `getDatabase()` directly. But they can be imported and tested without booting Electron, which is what matters.
 
-### Service module pattern (no ipcMain dependency)
+We follow the same principle: **business logic in separate modules, testable via direct import, with module-mocked external dependencies.** We are NOT claiming pure-function purity. These modules have module-level state (`sessionValidation`, `uploadInProgress`) and use module-level imports (`detectEpsonScanners`, `sharp`, `fs`) that are mocked in tests via `vi.mock()`.
 
-Each module exports pure async functions. Dependencies (`PrismaClient`, `ScanCoordinator`, session state functions) are injected as parameters. This enables:
-- Unit testing with Vitest + mocked Prisma (no Electron mocking)
-- Reuse from CLI tools or background workers if needed later
-- Clean separation: service modules own business logic, `register-handlers.ts` (3c) owns IPC ceremony
+What IS dependency-injected (passed as parameters):
+- `db: PrismaClient` — enables mocking without singleton coupling
+- `coordinator: ScanCoordinator` — does not exist yet (Increment 3b), injected to avoid import coupling
+- Session state functions (`getScanSession`, `setScanSession`, `markScanJobRecorded`) — currently live in `main.ts`, injected to break circular dependency
+- Progress/error callbacks — replace `mainWindow.webContents.send()` for testability
+
+What is NOT dependency-injected (module-mocked in tests via `vi.mock()`):
+- `detectEpsonScanners` from `../lsusb-detection`
+- `resolveGraviScanPath` from `../graviscan-path-utils`
+- `sharp` (native image processing)
+- `fs` / `fs.promises` (filesystem operations)
+- `runBoxBackup` from `../box-backup`
 
 Alternatives considered:
-- **Handler files own `ipcMain.handle()`**: Rejected. This is the `database-handlers.ts` pattern that led to 942 untested lines. Couples business logic to Electron runtime.
-- **Hybrid (ipcMain + extracted helpers)**: Rejected. Confusing ownership — is the handler responsible for logic or just IPC?
+- **Handler files own `ipcMain.handle()`**: Rejected. This is the `database-handlers.ts` pattern that led to 942 untested lines. Requires mocking Electron's IPC runtime.
+- **Pure stateless functions with full DI**: Rejected. Overstates purity — we have real module-level state and it's simpler to let external deps be module imports rather than threading 6+ parameters through every call.
 
 ### Handler-to-module mapping (lifecycle split)
 
@@ -40,39 +44,69 @@ Grouped by workflow phase rather than strict domain object:
 | `session-handlers.ts` | `start-scan`, `get-scan-status`, `mark-job-recorded`, `cancel-scan` | Scan execution lifecycle via ScanCoordinator |
 | `image-handlers.ts` | `get-output-dir`, `read-scan-image`, `upload-all-scans`, `download-images` | Image output, export, and backup |
 
-### Progress events via callback injection
+### ScanCoordinator interface contract
 
-`uploadAllScans` and `downloadImages` in Ben's code send progress to the renderer via `mainWindow.webContents.send()`. Instead, service functions accept an `onProgress` callback. The IPC wiring layer (3c) converts this to `webContents.send()`:
+`ScanCoordinator` is implemented in Increment 3b, but `session-handlers.ts` depends on it now. We define the interface based on Ben's existing implementation (`origin/graviscan/4-main-process:src/main/scan-coordinator.ts`):
 
 ```typescript
-// Service (pure, testable)
+interface ScanCoordinatorLike {
+  readonly isScanning: boolean;
+  initialize(scanners: ScannerConfig[]): Promise<void>;
+  scanOnce(platesPerScanner: Map<string, PlateConfig[]>): Promise<void>;
+  scanInterval(platesPerScanner: Map<string, PlateConfig[]>, intervalMs: number, durationMs: number): Promise<void>;
+  cancelScan(): void;
+  shutdown(): Promise<void>;
+  on(event: string, listener: (...args: any[]) => void): this;
+}
+```
+
+We code against this interface. If 3b changes the coordinator API, we update the interface and the tests. The interface lives in `session-handlers.ts` as a local type (not exported to shared types) since it's an internal contract.
+
+### Event forwarding for long-running scans
+
+`startScan` triggers fire-and-forget operations (`coordinator.scanOnce()` / `coordinator.scanInterval()`) that run for minutes and emit streaming progress events. A single `onProgress` callback is insufficient for this.
+
+The service function accepts an `onError` callback for the detached promise's catch handler. Real-time progress event wiring (coordinator → renderer) is deferred to the IPC wiring layer in Increment 3c, where `main.ts` owns the coordinator instance and wires `coordinator.on('scan-complete', ...)` → `mainWindow.webContents.send()`. This is consistent with how CylinderScan's `ensureScannerProcess()` wires event forwarding in `main.ts` (lines 672-709).
+
+In 3a, `session-handlers.ts` functions handle the request/response portion (validate, build session state, call coordinator methods, return success/failure). The streaming event layer is 3c's responsibility.
+
+### Progress callbacks for batch operations
+
+`uploadAllScans` and `downloadImages` are batch operations with bounded progress (not streaming events). These accept `onProgress` callbacks:
+
+```typescript
 export async function downloadImages(
   db: PrismaClient,
   params: DownloadParams,
   onProgress?: (progress: DownloadProgress) => void
 ): Promise<DownloadResult>
-
-// IPC wiring (Increment 3c)
-ipcMain.handle('graviscan:download-images', (_e, params) =>
-  downloadImages(db, params, (p) =>
-    mainWindow?.webContents.send('graviscan:download-progress', p)
-  )
-);
 ```
+
+The IPC wiring layer (3c) converts callbacks to `webContents.send()`.
 
 ### Dialog handling for downloadImages
 
-Ben's `download-images` handler opens a native folder picker via `dialog.showOpenDialog()`. This is an Electron API that can't be called from a pure service function. The service function accepts `targetDir: string` as a parameter. The IPC wiring layer (3c) handles the dialog and passes the result.
+Ben's `download-images` handler opens a native folder picker via `dialog.showOpenDialog()`. The service function accepts `targetDir: string` as a parameter. The IPC wiring layer (3c) handles the dialog and passes the result.
+
+### Module-level mutable state
+
+Two pieces of module-level state exist:
+- **`sessionValidation`** in `scanner-handlers.ts` — startup validation state. Exposed via `getSessionValidationState()` / `resetSessionValidation()`. Tests call `resetSessionValidation()` in `beforeEach`.
+- **`uploadInProgress`** in `image-handlers.ts` — upload guard boolean. Prevents concurrent Box uploads. Managed as module-level closure state with `resetUploadState()` exported for testing.
+
+This is the same pattern as CylinderScan's module-level state in `main.ts` (`scannerIdentity`, `currentCameraSettings`). We own it honestly rather than claiming purity.
 
 ## Risks / Trade-offs
 
-- **Risk**: Service function signatures diverge from Ben's handler signatures, making 3c wiring non-trivial.
-  - Mitigation: Document the mapping in `index.ts` JSDoc. Keep parameter types close to Ben's originals.
-- **Risk**: Shared state (`sessionValidation` object) in `scanner-handlers.ts` is module-level mutable state.
-  - Mitigation: Expose only via `getSessionValidationState()` / `resetSessionValidation()`. Tests reset between runs.
-- **Risk**: `sharp` dependency for image conversion may behave differently across platforms.
-  - Mitigation: Mock `sharp` in unit tests. Real sharp behavior tested in E2E (Increment 5).
+- **Risk**: 3c wiring layer will be heavier than typical "thin dispatch." It must own coordinator lifecycle, event forwarding, and dialog handling — approximately 50-100 lines of stateful orchestration, not one-liner wrappers.
+  - Mitigation: Accepted. This complexity exists regardless of module organization; keeping it out of 3a makes each increment reviewable.
+- **Risk**: `ScanCoordinatorLike` interface may diverge from actual 3b implementation.
+  - Mitigation: Interface is derived from Ben's existing code. If 3b changes the API, update the interface — tests are the canary.
+- **Risk**: Module-level state (`sessionValidation`, `uploadInProgress`) shared across test files in Vitest's parallel execution.
+  - Mitigation: Export `reset*()` functions. All test files call them in `beforeEach`. Vitest isolates module instances per worker thread by default.
+- **Risk**: `sharp` chain mock is brittle (tied to builder API call order).
+  - Mitigation: Unit tests verify behavior (correct data URI returned, thumbnail vs full), not implementation details (call order). Add a small real TIFF fixture for a focused sharp integration test.
 
 ## Open Questions
 
-None — all resolved during design discussion.
+None — all resolved during design discussion and review.

--- a/openspec/changes/add-graviscan-handler-modules/design.md
+++ b/openspec/changes/add-graviscan-handler-modules/design.md
@@ -1,0 +1,78 @@
+## Context
+
+Increment 3a of the GraviScan integration. PR #138 (`origin/graviscan/4-main-process`) contains a monolithic `graviscan-handlers.ts` (1,338 lines, 15 IPC handlers) that needs restructuring before integration into `main.ts`.
+
+The CylinderScan codebase demonstrates two patterns:
+- **Testable pattern**: `camera-process.ts`, `scanner-process.ts` — pure classes with no `ipcMain` dependency, full unit test coverage
+- **Untestable pattern**: `database-handlers.ts` (942 lines) — business logic coupled to `ipcMain.handle()`, zero unit tests, coverage excluded via `src/main/**` in vitest.config.ts
+
+We follow the testable pattern.
+
+## Goals / Non-Goals
+
+- Goals: Split Ben's monolithic file into 3 focused, independently testable service modules. Write comprehensive unit tests. No integration with `main.ts` yet.
+- Non-Goals: IPC wiring (Increment 3c), `scan-handlers.ts` for DB CRUD (Increment 3c), renderer changes, preload changes, coverage threshold increases (tracked in issue #181).
+
+## Decisions
+
+### 3 modules now, 4th in Increment 3c
+
+`scan-handlers.ts` (GraviScan DB CRUD) is deferred because the CRUD handlers don't exist in Ben's file — they'll be added when `database-handlers.ts` is extended in Increment 3c. Shipping an empty placeholder adds no value.
+
+### Service module pattern (no ipcMain dependency)
+
+Each module exports pure async functions. Dependencies (`PrismaClient`, `ScanCoordinator`, session state functions) are injected as parameters. This enables:
+- Unit testing with Vitest + mocked Prisma (no Electron mocking)
+- Reuse from CLI tools or background workers if needed later
+- Clean separation: service modules own business logic, `register-handlers.ts` (3c) owns IPC ceremony
+
+Alternatives considered:
+- **Handler files own `ipcMain.handle()`**: Rejected. This is the `database-handlers.ts` pattern that led to 942 untested lines. Couples business logic to Electron runtime.
+- **Hybrid (ipcMain + extracted helpers)**: Rejected. Confusing ownership — is the handler responsible for logic or just IPC?
+
+### Handler-to-module mapping (lifecycle split)
+
+Grouped by workflow phase rather than strict domain object:
+
+| Module | Handlers | Rationale |
+|---|---|---|
+| `scanner-handlers.ts` | `detect-scanners`, `save-scanners-db`, `get-config`, `save-config`, `platform-info`, `validate-scanners`, `validate-config` + validation state fns | Everything about scanner hardware setup and readiness |
+| `session-handlers.ts` | `start-scan`, `get-scan-status`, `mark-job-recorded`, `cancel-scan` | Scan execution lifecycle via ScanCoordinator |
+| `image-handlers.ts` | `get-output-dir`, `read-scan-image`, `upload-all-scans`, `download-images` | Image output, export, and backup |
+
+### Progress events via callback injection
+
+`uploadAllScans` and `downloadImages` in Ben's code send progress to the renderer via `mainWindow.webContents.send()`. Instead, service functions accept an `onProgress` callback. The IPC wiring layer (3c) converts this to `webContents.send()`:
+
+```typescript
+// Service (pure, testable)
+export async function downloadImages(
+  db: PrismaClient,
+  params: DownloadParams,
+  onProgress?: (progress: DownloadProgress) => void
+): Promise<DownloadResult>
+
+// IPC wiring (Increment 3c)
+ipcMain.handle('graviscan:download-images', (_e, params) =>
+  downloadImages(db, params, (p) =>
+    mainWindow?.webContents.send('graviscan:download-progress', p)
+  )
+);
+```
+
+### Dialog handling for downloadImages
+
+Ben's `download-images` handler opens a native folder picker via `dialog.showOpenDialog()`. This is an Electron API that can't be called from a pure service function. The service function accepts `targetDir: string` as a parameter. The IPC wiring layer (3c) handles the dialog and passes the result.
+
+## Risks / Trade-offs
+
+- **Risk**: Service function signatures diverge from Ben's handler signatures, making 3c wiring non-trivial.
+  - Mitigation: Document the mapping in `index.ts` JSDoc. Keep parameter types close to Ben's originals.
+- **Risk**: Shared state (`sessionValidation` object) in `scanner-handlers.ts` is module-level mutable state.
+  - Mitigation: Expose only via `getSessionValidationState()` / `resetSessionValidation()`. Tests reset between runs.
+- **Risk**: `sharp` dependency for image conversion may behave differently across platforms.
+  - Mitigation: Mock `sharp` in unit tests. Real sharp behavior tested in E2E (Increment 5).
+
+## Open Questions
+
+None — all resolved during design discussion.

--- a/openspec/changes/add-graviscan-handler-modules/design.md
+++ b/openspec/changes/add-graviscan-handler-modules/design.md
@@ -29,6 +29,7 @@ What is NOT dependency-injected (module-mocked in tests via `vi.mock()`):
 - `sharp` (native image processing)
 - `fs` / `fs.promises` (filesystem operations)
 - `runBoxBackup` from `../box-backup`
+- `app` from `electron` (used by `getOutputDir` for path resolution — `app.getAppPath()`, `app.getPath('home')`)
 
 Alternatives considered:
 - **Handler files own `ipcMain.handle()`**: Rejected. This is the `database-handlers.ts` pattern that led to 942 untested lines. Requires mocking Electron's IPC runtime.
@@ -44,6 +45,16 @@ Grouped by workflow phase rather than strict domain object:
 | `session-handlers.ts` | `start-scan`, `get-scan-status`, `mark-job-recorded`, `cancel-scan` | Scan execution lifecycle via ScanCoordinator |
 | `image-handlers.ts` | `get-output-dir`, `read-scan-image`, `upload-all-scans`, `download-images` | Image output, export, and backup |
 
+### Cherry-pick dependencies from Ben's branch
+
+These utility files must be cherry-picked from `origin/graviscan/4-main-process` as they are imported by the handler modules but don't exist on `main` yet:
+
+- `src/main/graviscan-path-utils.ts` — `resolveGraviScanPath()` used by `image-handlers.ts`
+- `src/main/lsusb-detection.ts` — `detectEpsonScanners()` used by `scanner-handlers.ts`
+- `src/main/box-backup.ts` — `runBoxBackup()` used by `image-handlers.ts`
+
+Without these, `tsc --noEmit` will fail on unresolved imports.
+
 ### ScanCoordinator interface contract
 
 `ScanCoordinator` is implemented in Increment 3b, but `session-handlers.ts` depends on it now. We define the interface based on Ben's existing implementation (`origin/graviscan/4-main-process:src/main/scan-coordinator.ts`):
@@ -54,13 +65,31 @@ interface ScanCoordinatorLike {
   initialize(scanners: ScannerConfig[]): Promise<void>;
   scanOnce(platesPerScanner: Map<string, PlateConfig[]>): Promise<void>;
   scanInterval(platesPerScanner: Map<string, PlateConfig[]>, intervalMs: number, durationMs: number): Promise<void>;
-  cancelScan(): void;
+  cancelAll(): void;
   shutdown(): Promise<void>;
   on(event: string, listener: (...args: any[]) => void): this;
 }
 ```
 
 We code against this interface. If 3b changes the coordinator API, we update the interface and the tests. The interface lives in `session-handlers.ts` as a local type (not exported to shared types) since it's an internal contract.
+
+`ScannerConfig` and `PlateConfig` are also defined locally in `session-handlers.ts` (not imported from 3b's `scan-coordinator.ts` / `scanner-subprocess.ts`, which don't exist yet):
+
+```typescript
+interface ScannerConfig {
+  scannerId: string;
+  saneName: string;
+  plates: PlateConfig[];
+}
+
+interface PlateConfig {
+  plate_index: string;
+  grid_mode: string;
+  output_path: string;
+}
+```
+
+Known coordinator event types (for test mock fidelity): `scan-event`, `grid-complete`, `interval-start`, `cycle-complete`, `interval-waiting`, `overtime`, `interval-complete`. These are documented here for 3c reference but not typed in the interface (kept as `string` via the EventEmitter `on` signature).
 
 ### Event forwarding for long-running scans
 
@@ -69,6 +98,8 @@ We code against this interface. If 3b changes the coordinator API, we update the
 The service function accepts an `onError` callback for the detached promise's catch handler. Real-time progress event wiring (coordinator → renderer) is deferred to the IPC wiring layer in Increment 3c, where `main.ts` owns the coordinator instance and wires `coordinator.on('scan-complete', ...)` → `mainWindow.webContents.send()`. This is consistent with how CylinderScan's `ensureScannerProcess()` wires event forwarding in `main.ts` (lines 672-709).
 
 In 3a, `session-handlers.ts` functions handle the request/response portion (validate, build session state, call coordinator methods, return success/failure). The streaming event layer is 3c's responsibility.
+
+**Session state ownership split**: `startScan` (3a) builds the initial `ScanSession` state object. However, coordinator events in 3c mutate that same state (updating `jobs[key].status`, `coordinatorState`, `currentCycle`, `nextScanAt`, writing `completed_at` to DB). This means session state is built in 3a but mutated in 3c. We accept this split — 3a owns construction and request/response queries, 3c owns event-driven mutation. The `ScanSession` shape is the contract between them.
 
 ### Progress callbacks for batch operations
 
@@ -98,8 +129,8 @@ This is the same pattern as CylinderScan's module-level state in `main.ts` (`sca
 
 ## Risks / Trade-offs
 
-- **Risk**: 3c wiring layer will be heavier than typical "thin dispatch." It must own coordinator lifecycle, event forwarding, and dialog handling — approximately 50-100 lines of stateful orchestration, not one-liner wrappers.
-  - Mitigation: Accepted. This complexity exists regardless of module organization; keeping it out of 3a makes each increment reviewable.
+- **Risk**: 3c wiring layer will be substantial. It must own coordinator lifecycle (construction, shutdown), event forwarding (7 event types with session state mutation and DB writes), dialog handling, and IPC registration — estimated 200+ lines of stateful orchestration, not one-liner wrappers.
+  - Mitigation: Accepted. This complexity exists regardless of module organization; keeping it out of 3a makes each increment reviewable. The session state shape and `ScanCoordinatorLike` interface are the contracts that make the split manageable.
 - **Risk**: `ScanCoordinatorLike` interface may diverge from actual 3b implementation.
   - Mitigation: Interface is derived from Ben's existing code. If 3b changes the API, update the interface — tests are the canary.
 - **Risk**: Module-level state (`sessionValidation`, `uploadInProgress`) shared across test files in Vitest's parallel execution.

--- a/openspec/changes/add-graviscan-handler-modules/design.md
+++ b/openspec/changes/add-graviscan-handler-modules/design.md
@@ -85,6 +85,7 @@ interface ScannerConfig {
 interface PlateConfig {
   plate_index: string;
   grid_mode: string;
+  resolution: number;
   output_path: string;
 }
 ```

--- a/openspec/changes/add-graviscan-handler-modules/proposal.md
+++ b/openspec/changes/add-graviscan-handler-modules/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+PR #138 contains a monolithic `graviscan-handlers.ts` (1,338 lines) that mixes scanner detection, config management, scan execution, and image operations in a single file. This makes it untestable (the existing CylinderScan `database-handlers.ts` at 942 lines has zero unit tests for the same reason — business logic coupled to `ipcMain`). Splitting into focused service modules enables unit testing without Electron mocking and follows the proven CylinderScan pattern where `camera-process.ts` and `scanner-process.ts` are pure classes with full test coverage.
+
+## What Changes
+
+- Cherry-pick and restructure 15 IPC handlers from `origin/graviscan/4-main-process:src/main/graviscan-handlers.ts` into 3 focused service modules in `src/main/graviscan/`:
+  - `scanner-handlers.ts` (~500 LOC) — scanner detection, config, validation, platform info
+  - `session-handlers.ts` (~400 LOC) — scan execution lifecycle: start, status, cancel
+  - `image-handlers.ts` (~400 LOC) — image read/convert, export with metadata CSV, Box upload
+- Each module exports pure async functions (no `ipcMain` dependency) — dependencies injected as parameters
+- Add comprehensive unit tests for all 3 modules using Vitest + mocked Prisma
+- `scan-handlers.ts` (GraviScan DB CRUD) deferred to Increment 3c when `database-handlers.ts` is extended
+- `register-handlers.ts` (IPC wiring) deferred to Increment 3c — no main.ts integration yet
+- Add `index.ts` barrel export for clean imports
+
+## Impact
+
+- Affected specs: `scanning`
+- Affected code: `src/main/graviscan/` (new directory, 3 new modules + tests + index)
+- Source: `origin/graviscan/4-main-process:src/main/graviscan-handlers.ts` (PR #138)
+- Scanner model: Epson Perfection V600 (USB `04b8:013a`)
+- No changes to `main.ts`, `preload.ts`, or `database-handlers.ts` in this increment
+- Reference: `docs/superpowers/specs/2026-04-03-graviscan-integration-design.md` (Increment 3a)

--- a/openspec/changes/add-graviscan-handler-modules/proposal.md
+++ b/openspec/changes/add-graviscan-handler-modules/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-PR #138 contains a monolithic `graviscan-handlers.ts` (1,338 lines) that mixes scanner detection, config management, scan execution, and image operations in a single file. This makes it untestable (the existing CylinderScan `database-handlers.ts` at 942 lines has zero unit tests for the same reason — business logic coupled to `ipcMain`). Splitting into focused service modules enables unit testing without Electron mocking and follows the proven CylinderScan pattern where `camera-process.ts` and `scanner-process.ts` are pure classes with full test coverage.
+PR #138 contains a monolithic `graviscan-handlers.ts` (1,338 lines) that mixes scanner detection, config management, scan execution, and image operations in a single file. This makes it untestable (the existing CylinderScan `database-handlers.ts` at 942 lines has zero unit tests for the same reason — business logic coupled to `ipcMain`). Splitting into focused modules enables unit testing via direct import without Electron runtime, following the same principle that makes CylinderScan's `camera-process.ts` and `scanner-process.ts` testable — separate modules, not purity.
 
 ## What Changes
 
@@ -8,7 +8,7 @@ PR #138 contains a monolithic `graviscan-handlers.ts` (1,338 lines) that mixes s
   - `scanner-handlers.ts` (~500 LOC) — scanner detection, config, validation, platform info
   - `session-handlers.ts` (~400 LOC) — scan execution lifecycle: start, status, cancel
   - `image-handlers.ts` (~400 LOC) — image read/convert, export with metadata CSV, Box upload
-- Each module exports pure async functions (no `ipcMain` dependency) — dependencies injected as parameters
+- Each module is testable via direct import (no `ipcMain` dependency). Key deps (`PrismaClient`, `ScanCoordinator`, session fns) injected as parameters; external deps (`detectEpsonScanners`, `sharp`, `fs`) module-mocked in tests
 - Add comprehensive unit tests for all 3 modules using Vitest + mocked Prisma
 - `scan-handlers.ts` (GraviScan DB CRUD) deferred to Increment 3c when `database-handlers.ts` is extended
 - `register-handlers.ts` (IPC wiring) deferred to Increment 3c — no main.ts integration yet

--- a/openspec/changes/add-graviscan-handler-modules/specs/scanning/spec.md
+++ b/openspec/changes/add-graviscan-handler-modules/specs/scanning/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: GraviScan Scanner Detection and Configuration
 
-The system SHALL provide scanner detection, configuration persistence, and startup validation as pure service functions in `src/main/graviscan/scanner-handlers.ts`, independent of Electron IPC.
+The system SHALL provide scanner detection, configuration persistence, and startup validation as testable functions in `src/main/graviscan/scanner-handlers.ts`, importable without Electron runtime.
 
 #### Scenario: Detect connected USB scanners
 
@@ -15,7 +15,20 @@ The system SHALL provide scanner detection, configuration persistence, and start
 
 - **GIVEN** the environment variable `GRAVISCAN_MOCK` is set to `'true'`
 - **WHEN** `detectScanners(db)` is called
-- **THEN** the system SHALL return simulated scanner data without requiring USB hardware
+- **THEN** the system SHALL return simulated scanner data from database records without requiring USB hardware
+
+#### Scenario: Handle scanner detection failure
+
+- **GIVEN** `detectEpsonScanners()` returns `{ success: false, error: '...' }`
+- **WHEN** `detectScanners(db)` is called
+- **THEN** the system SHALL return `{ success: false, error: '...' }` with the upstream error message
+
+#### Scenario: Save scanner records to database
+
+- **GIVEN** an array of detected scanners with USB port information
+- **WHEN** `saveScannersToDB(db, scanners)` is called
+- **THEN** the system SHALL upsert `GraviScanner` records matching by USB port
+- **AND** update bus/device numbers for existing scanners whose port matches
 
 #### Scenario: Save scanner configuration
 
@@ -23,6 +36,19 @@ The system SHALL provide scanner detection, configuration persistence, and start
 - **WHEN** `saveConfig(db, config)` is called
 - **THEN** the system SHALL persist the configuration to the `GraviConfig` table
 - **AND** create or update the singleton config record
+
+#### Scenario: Read scanner configuration when none exists
+
+- **GIVEN** no `GraviConfig` record exists in the database
+- **WHEN** `getConfig(db)` is called
+- **THEN** the system SHALL return `null`
+
+#### Scenario: Platform info reports correct backend
+
+- **GIVEN** the system is running on a specific platform
+- **WHEN** `getPlatformInfo()` is called
+- **THEN** the system SHALL return `'sane'` on Linux, `'twain'` on Windows, and `'unsupported'` on macOS
+- **AND** report mock mode status from the environment variable
 
 #### Scenario: Validate scanner config against connected hardware
 
@@ -32,30 +58,49 @@ The system SHALL provide scanner detection, configuration persistence, and start
 - **AND** categorize each saved scanner as matched, missing, or new
 - **AND** return a validation status of `'valid'`, `'mismatch'`, or `'no-config'`
 
-#### Scenario: Platform info reports correct backend
+#### Scenario: Validate config with no saved scanners
 
-- **GIVEN** the system is running on a specific platform
-- **WHEN** `getPlatformInfo()` is called
-- **THEN** the system SHALL return `'sane'` on Linux, `'twain'` on Windows, and `'unsupported'` on macOS
-- **AND** report mock mode status from the environment variable
+- **GIVEN** no enabled `GraviScanner` records exist in the database
+- **WHEN** `validateConfig(db)` is called
+- **THEN** the system SHALL return status `'no-config'` without attempting USB detection
+
+#### Scenario: Run startup scanner validation
+
+- **GIVEN** cached scanner IDs from the renderer
+- **WHEN** `runStartupScannerValidation(cachedScannerIds)` is called
+- **THEN** the system SHALL compare cached IDs with detected USB devices
+- **AND** update module-level `sessionValidation` state with results
+
+#### Scenario: Skip startup validation when no cached scanners
+
+- **GIVEN** an empty array of cached scanner IDs
+- **WHEN** `runStartupScannerValidation([])` is called
+- **THEN** the system SHALL set `isValidated: false` and `allScannersAvailable: false` without running detection
+
+#### Scenario: Read and reset validation state
+
+- **GIVEN** startup validation has completed
+- **WHEN** `getSessionValidationState()` is called
+- **THEN** the system SHALL return the current `SessionValidationState`
+- **AND** `resetSessionValidation()` SHALL restore validation state to initial defaults
 
 ### Requirement: GraviScan Session Lifecycle Management
 
-The system SHALL provide scan session start, status, cancel, and job-recording as pure service functions in `src/main/graviscan/session-handlers.ts`, with dependencies injected for testability.
+The system SHALL provide scan session start, status, cancel, and job-recording as testable functions in `src/main/graviscan/session-handlers.ts`, with `ScanCoordinator` and session state functions injected as parameters.
 
 #### Scenario: Start one-shot scan
 
 - **GIVEN** a `ScanCoordinator` instance is provided and no scan is in progress
 - **WHEN** `startScan(coordinator, params, sessionFns)` is called without interval parameters
 - **THEN** the system SHALL initialize scanner subprocesses via the coordinator
-- **AND** trigger a one-shot scan via `coordinator.scanOnce()`
+- **AND** trigger a one-shot scan via `coordinator.scanOnce()` (fire-and-forget)
 - **AND** build and persist scan session state via the injected `setScanSession`
 
 #### Scenario: Start continuous scan
 
 - **GIVEN** a `ScanCoordinator` instance is provided and no scan is in progress
 - **WHEN** `startScan(coordinator, params, sessionFns)` is called with interval parameters
-- **THEN** the system SHALL trigger continuous scanning via `coordinator.scanInterval()`
+- **THEN** the system SHALL trigger continuous scanning via `coordinator.scanInterval()` (fire-and-forget)
 - **AND** calculate total cycles from interval and duration
 
 #### Scenario: Reject scan when already in progress
@@ -64,6 +109,19 @@ The system SHALL provide scan session start, status, cancel, and job-recording a
 - **WHEN** `startScan()` is called
 - **THEN** the system SHALL return `{ success: false, error: 'Scan already in progress' }`
 
+#### Scenario: Reject scan when coordinator not provided
+
+- **GIVEN** no `ScanCoordinator` instance is available (null/undefined)
+- **WHEN** `startScan(null, params, sessionFns)` is called
+- **THEN** the system SHALL return `{ success: false, error: 'ScanCoordinator not initialized' }`
+
+#### Scenario: Handle error in fire-and-forget scan
+
+- **GIVEN** a scan has been started and the function has returned `{ success: true }`
+- **WHEN** the coordinator's detached promise rejects
+- **THEN** the system SHALL call `setScanSession(null)` to clear session state
+- **AND** call the injected `onError` callback with the error
+
 #### Scenario: Cancel active scan
 
 - **GIVEN** a scan session is active
@@ -71,15 +129,33 @@ The system SHALL provide scan session start, status, cancel, and job-recording a
 - **THEN** the system SHALL cancel the scan via the coordinator
 - **AND** clear session state via the injected `setScanSession(null)`
 
+#### Scenario: Cancel when no scan is active
+
+- **GIVEN** no scan session is active
+- **WHEN** `cancelScan(coordinator, sessionFns)` is called
+- **THEN** the system SHALL return gracefully without error
+
 #### Scenario: Get scan status after navigation
 
 - **GIVEN** a scan session was started and the user navigated away
 - **WHEN** `getScanStatus(sessionFns)` is called
 - **THEN** the system SHALL return the persisted session state including `isActive`, `experimentId`, `jobs`, and progress
 
+#### Scenario: Get scan status when no session exists
+
+- **GIVEN** no scan session is active
+- **WHEN** `getScanStatus(sessionFns)` is called
+- **THEN** the system SHALL return `{ isActive: false }`
+
+#### Scenario: Mark scan job as recorded
+
+- **GIVEN** an active scan session with completed jobs
+- **WHEN** `markJobRecorded(sessionFns, scannerId, plateIndex)` is called
+- **THEN** the system SHALL mark the specified job as DB-recorded in session state
+
 ### Requirement: GraviScan Image Operations
 
-The system SHALL provide image reading, export, and cloud backup as pure service functions in `src/main/graviscan/image-handlers.ts`, using callback injection for progress reporting.
+The system SHALL provide image reading, export, and cloud backup as testable functions in `src/main/graviscan/image-handlers.ts`, using callback injection for progress reporting.
 
 #### Scenario: Read scan image as JPEG thumbnail
 
@@ -103,14 +179,32 @@ The system SHALL provide image reading, export, and cloud backup as pure service
 - **THEN** the system SHALL attempt path resolution via `resolveGraviScanPath()` (extension fallback, `_et_` fallback)
 - **AND** return `{ success: false, error: 'File not found' }` if resolution fails
 
+#### Scenario: Get scan output directory
+
+- **GIVEN** a scan output path is configured
+- **WHEN** `getOutputDir()` is called
+- **THEN** the system SHALL return the resolved output directory path
+
+#### Scenario: Get output directory when not configured
+
+- **GIVEN** no scan output path is configured
+- **WHEN** `getOutputDir()` is called
+- **THEN** the system SHALL return a sensible default or `{ success: false }` error
+
 #### Scenario: Download experiment images with metadata CSV
 
 - **GIVEN** an experiment has GraviScan images across multiple waves
 - **WHEN** `downloadImages(db, { experimentId, experimentName, targetDir })` is called with an already-resolved target directory (dialog handling deferred to IPC wiring in Increment 3c)
 - **THEN** the system SHALL group images by wave number into subdirectories
 - **AND** write a `metadata.csv` per wave with experiment, plate, accession, and image columns
-- **AND** copy image files with 4-concurrent file copy operations
+- **AND** copy image files with concurrent file copy operations
 - **AND** report progress via the injected `onProgress` callback
+
+#### Scenario: Download with no images found
+
+- **GIVEN** an experiment has no GraviScan images
+- **WHEN** `downloadImages(db, params)` is called
+- **THEN** the system SHALL return `{ success: true, total: 0, copied: 0, errors: [] }`
 
 #### Scenario: Upload pending scans to Box backup
 
@@ -118,4 +212,9 @@ The system SHALL provide image reading, export, and cloud backup as pure service
 - **WHEN** `uploadAllScans(db, onProgress)` is called
 - **THEN** the system SHALL trigger Box backup via `runBoxBackup()`
 - **AND** report progress via the injected `onProgress` callback
-- **AND** guard against concurrent uploads
+
+#### Scenario: Reject concurrent upload
+
+- **GIVEN** an upload is already in progress (module-level `uploadInProgress` guard)
+- **WHEN** `uploadAllScans(db, onProgress)` is called
+- **THEN** the system SHALL return `{ success: false, error: 'Upload already in progress' }`

--- a/openspec/changes/add-graviscan-handler-modules/specs/scanning/spec.md
+++ b/openspec/changes/add-graviscan-handler-modules/specs/scanning/spec.md
@@ -153,8 +153,8 @@ The system SHALL provide scan session start, status, cancel, and job-recording a
 #### Scenario: Mark scan job as recorded
 
 - **GIVEN** an active scan session with completed jobs
-- **WHEN** `markJobRecorded(sessionFns, scannerId, plateIndex)` is called
-- **THEN** the system SHALL mark the specified job as DB-recorded in session state
+- **WHEN** `markJobRecorded(sessionFns, jobKey)` is called with `jobKey` in the format `${scannerId}:${plate_index}`
+- **THEN** the system SHALL mark the specified job as DB-recorded in session state using that job key
 
 ### Requirement: GraviScan Image Operations
 
@@ -222,4 +222,4 @@ The system SHALL provide image reading, export, and cloud backup as testable fun
 
 - **GIVEN** an upload is already in progress (module-level `uploadInProgress` guard)
 - **WHEN** `uploadAllScans(db, onProgress)` is called
-- **THEN** the system SHALL return `{ success: false, error: 'Upload already in progress' }`
+- **THEN** the system SHALL return `{ success: false, errors: ['Upload already in progress'], uploaded: 0, skipped: 0, failed: 0 }`

--- a/openspec/changes/add-graviscan-handler-modules/specs/scanning/spec.md
+++ b/openspec/changes/add-graviscan-handler-modules/specs/scanning/spec.md
@@ -67,14 +67,15 @@ The system SHALL provide scanner detection, configuration persistence, and start
 #### Scenario: Run startup scanner validation
 
 - **GIVEN** cached scanner IDs from the renderer
-- **WHEN** `runStartupScannerValidation(cachedScannerIds)` is called
-- **THEN** the system SHALL compare cached IDs with detected USB devices
+- **WHEN** `runStartupScannerValidation(db, cachedScannerIds)` is called
+- **THEN** the system SHALL query `GraviScanner` records from the database
+- **AND** compare cached IDs with detected USB devices
 - **AND** update module-level `sessionValidation` state with results
 
 #### Scenario: Skip startup validation when no cached scanners
 
 - **GIVEN** an empty array of cached scanner IDs
-- **WHEN** `runStartupScannerValidation([])` is called
+- **WHEN** `runStartupScannerValidation(db, [])` is called
 - **THEN** the system SHALL set `isValidated: false` and `allScannersAvailable: false` without running detection
 
 #### Scenario: Read and reset validation state
@@ -126,7 +127,7 @@ The system SHALL provide scan session start, status, cancel, and job-recording a
 
 - **GIVEN** a scan session is active
 - **WHEN** `cancelScan(coordinator, sessionFns)` is called
-- **THEN** the system SHALL cancel the scan via the coordinator
+- **THEN** the system SHALL cancel the scan via `coordinator.cancelAll()`
 - **AND** clear session state via the injected `setScanSession(null)`
 
 #### Scenario: Cancel when no scan is active
@@ -181,15 +182,17 @@ The system SHALL provide image reading, export, and cloud backup as testable fun
 
 #### Scenario: Get scan output directory
 
-- **GIVEN** a scan output path is configured
+- **GIVEN** the application is running
 - **WHEN** `getOutputDir()` is called
-- **THEN** the system SHALL return the resolved output directory path
+- **THEN** the system SHALL compute the output path from `app.getAppPath()` (development) or `app.getPath('home')` (production) based on `NODE_ENV`
+- **AND** create the directory if it does not exist
+- **AND** return the resolved output directory path
 
-#### Scenario: Get output directory when not configured
+#### Scenario: Get output directory when directory creation fails
 
-- **GIVEN** no scan output path is configured
+- **GIVEN** the computed output path cannot be created (e.g., permissions error)
 - **WHEN** `getOutputDir()` is called
-- **THEN** the system SHALL return a sensible default or `{ success: false }` error
+- **THEN** the system SHALL return `{ success: false, error: '...' }` with the filesystem error
 
 #### Scenario: Download experiment images with metadata CSV
 

--- a/openspec/changes/add-graviscan-handler-modules/specs/scanning/spec.md
+++ b/openspec/changes/add-graviscan-handler-modules/specs/scanning/spec.md
@@ -93,7 +93,7 @@ The system SHALL provide scan session start, status, cancel, and job-recording a
 
 - **GIVEN** a `ScanCoordinator` instance is provided and no scan is in progress
 - **WHEN** `startScan(coordinator, params, sessionFns)` is called without interval parameters
-- **THEN** the system SHALL initialize scanner subprocesses via the coordinator
+- **THEN** the system SHALL initialize scanner subprocesses via `coordinator.initialize(scannerConfigs)`
 - **AND** trigger a one-shot scan via `coordinator.scanOnce()` (fire-and-forget)
 - **AND** build and persist scan session state via the injected `setScanSession`
 
@@ -101,7 +101,8 @@ The system SHALL provide scan session start, status, cancel, and job-recording a
 
 - **GIVEN** a `ScanCoordinator` instance is provided and no scan is in progress
 - **WHEN** `startScan(coordinator, params, sessionFns)` is called with interval parameters
-- **THEN** the system SHALL trigger continuous scanning via `coordinator.scanInterval()` (fire-and-forget)
+- **THEN** the system SHALL initialize subprocesses via `coordinator.initialize(scannerConfigs)`
+- **AND** trigger continuous scanning via `coordinator.scanInterval()` (fire-and-forget)
 - **AND** calculate total cycles from interval and duration
 
 #### Scenario: Reject scan when already in progress
@@ -128,6 +129,7 @@ The system SHALL provide scan session start, status, cancel, and job-recording a
 - **GIVEN** a scan session is active
 - **WHEN** `cancelScan(coordinator, sessionFns)` is called
 - **THEN** the system SHALL cancel the scan via `coordinator.cancelAll()`
+- **AND** shut down coordinator subprocesses via `coordinator.shutdown()`
 - **AND** clear session state via the injected `setScanSession(null)`
 
 #### Scenario: Cancel when no scan is active

--- a/openspec/changes/add-graviscan-handler-modules/specs/scanning/spec.md
+++ b/openspec/changes/add-graviscan-handler-modules/specs/scanning/spec.md
@@ -1,0 +1,121 @@
+## ADDED Requirements
+
+### Requirement: GraviScan Scanner Detection and Configuration
+
+The system SHALL provide scanner detection, configuration persistence, and startup validation as pure service functions in `src/main/graviscan/scanner-handlers.ts`, independent of Electron IPC.
+
+#### Scenario: Detect connected USB scanners
+
+- **GIVEN** the GraviScan scanner detection service is available
+- **WHEN** `detectScanners(db)` is called
+- **THEN** the system SHALL detect Epson Perfection V600 scanners (USB `04b8:013a`) via `detectEpsonScanners()`
+- **AND** return an array of `DetectedScanner` objects with USB bus, device, and port information
+
+#### Scenario: Detect scanners in mock mode
+
+- **GIVEN** the environment variable `GRAVISCAN_MOCK` is set to `'true'`
+- **WHEN** `detectScanners(db)` is called
+- **THEN** the system SHALL return simulated scanner data without requiring USB hardware
+
+#### Scenario: Save scanner configuration
+
+- **GIVEN** a valid `GraviConfigInput` with grid mode and resolution
+- **WHEN** `saveConfig(db, config)` is called
+- **THEN** the system SHALL persist the configuration to the `GraviConfig` table
+- **AND** create or update the singleton config record
+
+#### Scenario: Validate scanner config against connected hardware
+
+- **GIVEN** saved scanners exist in the database with USB port information
+- **WHEN** `validateConfig(db)` is called
+- **THEN** the system SHALL detect currently connected scanners
+- **AND** categorize each saved scanner as matched, missing, or new
+- **AND** return a validation status of `'valid'`, `'mismatch'`, or `'no-config'`
+
+#### Scenario: Platform info reports correct backend
+
+- **GIVEN** the system is running on a specific platform
+- **WHEN** `getPlatformInfo()` is called
+- **THEN** the system SHALL return `'sane'` on Linux, `'twain'` on Windows, and `'unsupported'` on macOS
+- **AND** report mock mode status from the environment variable
+
+### Requirement: GraviScan Session Lifecycle Management
+
+The system SHALL provide scan session start, status, cancel, and job-recording as pure service functions in `src/main/graviscan/session-handlers.ts`, with dependencies injected for testability.
+
+#### Scenario: Start one-shot scan
+
+- **GIVEN** a `ScanCoordinator` instance is provided and no scan is in progress
+- **WHEN** `startScan(coordinator, params, sessionFns)` is called without interval parameters
+- **THEN** the system SHALL initialize scanner subprocesses via the coordinator
+- **AND** trigger a one-shot scan via `coordinator.scanOnce()`
+- **AND** build and persist scan session state via the injected `setScanSession`
+
+#### Scenario: Start continuous scan
+
+- **GIVEN** a `ScanCoordinator` instance is provided and no scan is in progress
+- **WHEN** `startScan(coordinator, params, sessionFns)` is called with interval parameters
+- **THEN** the system SHALL trigger continuous scanning via `coordinator.scanInterval()`
+- **AND** calculate total cycles from interval and duration
+
+#### Scenario: Reject scan when already in progress
+
+- **GIVEN** the coordinator reports `isScanning` is true
+- **WHEN** `startScan()` is called
+- **THEN** the system SHALL return `{ success: false, error: 'Scan already in progress' }`
+
+#### Scenario: Cancel active scan
+
+- **GIVEN** a scan session is active
+- **WHEN** `cancelScan(coordinator, sessionFns)` is called
+- **THEN** the system SHALL cancel the scan via the coordinator
+- **AND** clear session state via the injected `setScanSession(null)`
+
+#### Scenario: Get scan status after navigation
+
+- **GIVEN** a scan session was started and the user navigated away
+- **WHEN** `getScanStatus(sessionFns)` is called
+- **THEN** the system SHALL return the persisted session state including `isActive`, `experimentId`, `jobs`, and progress
+
+### Requirement: GraviScan Image Operations
+
+The system SHALL provide image reading, export, and cloud backup as pure service functions in `src/main/graviscan/image-handlers.ts`, using callback injection for progress reporting.
+
+#### Scenario: Read scan image as JPEG thumbnail
+
+- **GIVEN** a TIFF scan image exists on disk
+- **WHEN** `readScanImage(filePath)` is called without `full` option
+- **THEN** the system SHALL convert the TIFF to JPEG at quality 85
+- **AND** resize to 400px width (without enlargement)
+- **AND** return a base64 data URI
+
+#### Scenario: Read scan image at full resolution
+
+- **GIVEN** a TIFF scan image exists on disk
+- **WHEN** `readScanImage(filePath, { full: true })` is called
+- **THEN** the system SHALL convert the TIFF to JPEG at quality 95
+- **AND** return the full-resolution image as a base64 data URI
+
+#### Scenario: Handle missing scan image with path fallback
+
+- **GIVEN** the requested file path does not exist
+- **WHEN** `readScanImage(filePath)` is called
+- **THEN** the system SHALL attempt path resolution via `resolveGraviScanPath()` (extension fallback, `_et_` fallback)
+- **AND** return `{ success: false, error: 'File not found' }` if resolution fails
+
+#### Scenario: Download experiment images with metadata CSV
+
+- **GIVEN** an experiment has GraviScan images across multiple waves
+- **WHEN** `downloadImages(db, { experimentId, experimentName, targetDir })` is called
+- **THEN** the system SHALL group images by wave number into subdirectories
+- **AND** write a `metadata.csv` per wave with experiment, plate, accession, and image columns
+- **AND** copy image files with 4-concurrent file copy operations
+- **AND** report progress via the injected `onProgress` callback
+
+#### Scenario: Upload pending scans to Box backup
+
+- **GIVEN** scans exist with pending upload status
+- **WHEN** `uploadAllScans(db, onProgress)` is called
+- **THEN** the system SHALL trigger Box backup via `runBoxBackup()`
+- **AND** report progress via the injected `onProgress` callback
+- **AND** guard against concurrent uploads

--- a/openspec/changes/add-graviscan-handler-modules/specs/scanning/spec.md
+++ b/openspec/changes/add-graviscan-handler-modules/specs/scanning/spec.md
@@ -106,7 +106,7 @@ The system SHALL provide image reading, export, and cloud backup as pure service
 #### Scenario: Download experiment images with metadata CSV
 
 - **GIVEN** an experiment has GraviScan images across multiple waves
-- **WHEN** `downloadImages(db, { experimentId, experimentName, targetDir })` is called
+- **WHEN** `downloadImages(db, { experimentId, experimentName, targetDir })` is called with an already-resolved target directory (dialog handling deferred to IPC wiring in Increment 3c)
 - **THEN** the system SHALL group images by wave number into subdirectories
 - **AND** write a `metadata.csv` per wave with experiment, plate, accession, and image columns
 - **AND** copy image files with 4-concurrent file copy operations

--- a/openspec/changes/add-graviscan-handler-modules/tasks.md
+++ b/openspec/changes/add-graviscan-handler-modules/tasks.md
@@ -24,7 +24,7 @@
 
 - [x] 2.1 Write `session-handlers.test.ts` tests first (use `// @vitest-environment node` directive):
   - `startScan`: calls `coordinator.initialize(scannerConfigs)` before scanning, one-shot mode calls `coordinator.scanOnce()`, continuous mode calls `coordinator.scanInterval()` with correct interval/duration, rejects when coordinator is null, rejects when `coordinator.isScanning` is true, builds session state correctly (verify `jobs` shape, `totalCycles` calculation)
-  - Fire-and-forget error path: mock `coordinator.scanOnce()` to return a promise that rejects *after* the function returns; verify `setScanSession(null)` and `onError` callback are called
+  - Fire-and-forget error path: mock `coordinator.scanOnce()` to return a promise that rejects _after_ the function returns; verify `setScanSession(null)` and `onError` callback are called
   - `getScanStatus`: returns session state when active, returns `{ isActive: false }` when no session
   - `markJobRecorded`: marks specified job key as DB-recorded in session state
   - `cancelScan`: calls `coordinator.cancelAll()` then `coordinator.shutdown()` (note: method is `cancelAll`, not `cancelScan`), clears session state, handles no active scan gracefully

--- a/openspec/changes/add-graviscan-handler-modules/tasks.md
+++ b/openspec/changes/add-graviscan-handler-modules/tasks.md
@@ -1,38 +1,43 @@
 ## 1. Scanner Handlers Module
 
-- [ ] 1.1 Write `scanner-handlers.test.ts` tests first:
-  - `detectScanners`: returns detected scanners, mock mode returns simulated scanners, handles detection failure
-  - `saveScannersToDB`: persists scanner records with USB port matching, updates existing scanners
+- [ ] 1.1 Write `scanner-handlers.test.ts` tests first (use `// @vitest-environment node` directive):
+  - `detectScanners`: returns detected scanners, mock mode returns simulated scanners from DB records, handles detection failure (upstream error propagation)
+  - `saveScannersToDB`: persists scanner records with USB port matching, upserts existing scanners
   - `getConfig`: reads GraviConfig from DB, returns null when no config exists
   - `saveConfig`: persists grid mode + resolution, creates or updates singleton
-  - `getPlatformInfo`: returns correct backend per platform (linux=sane, win32=twain, darwin=unsupported), mock mode override
+  - `getPlatformInfo`: returns correct backend per platform (linux=sane, win32=twain, darwin=unsupported), mock mode override. Use `vi.stubEnv` for `GRAVISCAN_MOCK` and `vi.stubGlobal` / `Object.defineProperty` for `process.platform`.
   - `validateScanners`: compares cached IDs with connected hardware, returns validation state
-  - `validateConfig`: matches saved USB ports with detected scanners, categorizes matched/missing/new
-  - `runStartupScannerValidation`: skips validation when no cached scanners, sets validation state
-  - `getSessionValidationState` / `resetSessionValidation`: state accessors
-- [ ] 1.2 Implement `scanner-handlers.ts` — extract and adapt 7 handlers + 3 validation state functions from Ben's `graviscan-handlers.ts`. Export pure async functions with `db: PrismaClient` injected. Scanner model: Epson Perfection V600 (USB `04b8:013a`).
+  - `validateConfig`: matches saved USB ports with detected scanners, categorizes matched/missing/new, returns 'no-config' when no saved scanners
+  - `runStartupScannerValidation`: skips validation when no cached scanners, sets module-level validation state
+  - `getSessionValidationState` / `resetSessionValidation`: state accessors, reset in `beforeEach`
+  - Module-mock `detectEpsonScanners` via `vi.mock('../lsusb-detection')`
+- [ ] 1.2 Implement `scanner-handlers.ts` — extract and adapt 7 handlers + 3 validation state functions from Ben's `graviscan-handlers.ts`. Inject `db: PrismaClient` as parameter. Module-level `sessionValidation` state with exported reset function. Scanner model: Epson Perfection V600 (USB `04b8:013a`). Types from `src/types/graviscan.ts`: `DetectedScanner`, `GraviConfig`, `GraviConfigInput`, `GraviScanner`, `GraviScanPlatformInfo`.
 
 ## 2. Session Handlers Module
 
-- [ ] 2.1 Write `session-handlers.test.ts` tests first:
-  - `startScan`: one-shot mode calls `coordinator.scanOnce()`, continuous mode calls `coordinator.scanInterval()`, rejects when coordinator not initialized, rejects when scan already in progress, builds session state correctly
+- [ ] 2.1 Write `session-handlers.test.ts` tests first (use `// @vitest-environment node` directive):
+  - `startScan`: one-shot mode calls `coordinator.scanOnce()`, continuous mode calls `coordinator.scanInterval()` with correct interval/duration, rejects when coordinator is null, rejects when `coordinator.isScanning` is true, builds session state correctly (verify `jobs` shape, `totalCycles` calculation)
+  - Fire-and-forget error path: mock `coordinator.scanOnce()` to return a promise that rejects *after* the function returns; verify `setScanSession(null)` and `onError` callback are called
   - `getScanStatus`: returns session state when active, returns `{ isActive: false }` when no session
-  - `markJobRecorded`: marks specified job as DB-recorded in session state
-  - `cancelScan`: calls `coordinator.cancelScan()`, clears session state, handles no active scan gracefully
-- [ ] 2.2 Implement `session-handlers.ts` — extract and adapt 4 handlers from Ben's file. Dependencies (`ScanCoordinator`, `getScanSession`/`setScanSession`/`markScanJobRecorded`) injected as parameters for testability.
+  - `markJobRecorded`: marks specified job key as DB-recorded in session state
+  - `cancelScan`: calls coordinator cancel, clears session state, handles no active scan gracefully
+  - Mock coordinator via object literal implementing `ScanCoordinatorLike` interface
+  - Mock session functions (`getScanSession`, `setScanSession`, `markScanJobRecorded`) as `vi.fn()` parameters
+- [ ] 2.2 Implement `session-handlers.ts` — extract and adapt 4 handlers from Ben's file. Define `ScanCoordinatorLike` interface locally (based on Ben's `ScanCoordinator` from `origin/graviscan/4-main-process:src/main/scan-coordinator.ts`). Inject coordinator, session fns, and `onError` callback as parameters. Types from Ben's file: `ScannerConfig`, `PlateConfig`.
 
 ## 3. Image Handlers Module
 
-- [ ] 3.1 Write `image-handlers.test.ts` tests first:
-  - `getOutputDir`: returns configured output path, handles missing config
-  - `readScanImage`: converts TIFF to JPEG via sharp, thumbnail mode resizes to 400px, full mode uses quality 95, handles missing file with `resolveGraviScanPath` fallback, returns base64 data URI
-  - `uploadAllScans`: triggers Box backup, reports progress via callback, handles upload-already-in-progress guard
-  - `downloadImages`: queries scans by experiment, groups by wave number, writes metadata CSV per wave, copies files with 4-concurrency, reports progress via callback, handles cancelled dialog
-- [ ] 3.2 Implement `image-handlers.ts` — extract and adapt 4 handlers from Ben's file. Progress events use callback injection (`onProgress?: (p) => void`) instead of direct `mainWindow.webContents.send()`.
+- [ ] 3.1 Write `image-handlers.test.ts` tests first (use `// @vitest-environment node` directive):
+  - `getOutputDir`: returns configured output path, returns error/default when not configured
+  - `readScanImage`: thumbnail mode returns base64 data URI (quality 85, 400px resize), full mode returns quality 95 data URI, handles missing file with `resolveGraviScanPath` fallback, returns error when file not found after resolution. Module-mock `sharp` and `resolveGraviScanPath`. Test behavior (correct URI returned), not implementation details (sharp call order).
+  - `uploadAllScans`: triggers Box backup, reports progress via callback, guards against concurrent uploads (`uploadInProgress`), returns error when upload already in progress. Module-mock `runBoxBackup`.
+  - `downloadImages`: queries scans by experiment, groups by wave into subdirectories, writes metadata CSV per wave, copies files concurrently, reports progress via callback, returns `{ total: 0, copied: 0 }` when no images found. Module-mock `fs` and `resolveGraviScanPath`. Test file copy results, NOT concurrency mechanics (defer to E2E).
+  - Reset `uploadInProgress` state in `beforeEach` via exported `resetUploadState()`
+- [ ] 3.2 Implement `image-handlers.ts` — extract and adapt 4 handlers from Ben's file. Module-level `uploadInProgress` guard with exported `resetUploadState()` for testing. Progress events use callback injection (`onProgress?: (p) => void`). `downloadImages` accepts `targetDir: string` parameter (dialog handling deferred to 3c). `resolveGraviScanPath` imported from `../graviscan-path-utils` (existing utility in Ben's branch, cherry-picked as dependency).
 
 ## 4. Barrel Export + Verification
 
-- [ ] 4.1 Create `index.ts` barrel export re-exporting all public functions from the 3 modules
+- [ ] 4.1 Create `index.ts` barrel export re-exporting all public functions from the 3 modules. Add JSDoc mapping IPC channel names → exported functions for 3c wiring reference.
 - [ ] 4.2 Run all tests, verify passing: `npx vitest run --reporter=verbose tests/unit/graviscan/`
 - [ ] 4.3 Run TypeScript compilation: `npx tsc --noEmit`
 - [ ] 4.4 Run lint: `npx eslint src/main/graviscan/`

--- a/openspec/changes/add-graviscan-handler-modules/tasks.md
+++ b/openspec/changes/add-graviscan-handler-modules/tasks.md
@@ -1,17 +1,25 @@
+## 0. Cherry-Pick Dependencies
+
+- [ ] 0.1 Cherry-pick or extract these utility files from `origin/graviscan/4-main-process` (required for imports to resolve):
+  - `src/main/lsusb-detection.ts` — `detectEpsonScanners()`, used by scanner-handlers
+  - `src/main/graviscan-path-utils.ts` — `resolveGraviScanPath()`, used by image-handlers
+  - `src/main/box-backup.ts` — `runBoxBackup()`, used by image-handlers
+  - Verify each file compiles independently: `npx tsc --noEmit`
+
 ## 1. Scanner Handlers Module
 
-- [ ] 1.1 Write `scanner-handlers.test.ts` tests first (use `// @vitest-environment node` directive):
-  - `detectScanners`: returns detected scanners, mock mode returns simulated scanners from DB records, handles detection failure (upstream error propagation)
-  - `saveScannersToDB`: persists scanner records with USB port matching, upserts existing scanners
-  - `getConfig`: reads GraviConfig from DB, returns null when no config exists
-  - `saveConfig`: persists grid mode + resolution, creates or updates singleton
-  - `getPlatformInfo`: returns correct backend per platform (linux=sane, win32=twain, darwin=unsupported), mock mode override. Use `vi.stubEnv` for `GRAVISCAN_MOCK` and `vi.stubGlobal` / `Object.defineProperty` for `process.platform`.
-  - `validateScanners`: compares cached IDs with connected hardware, returns validation state
-  - `validateConfig`: matches saved USB ports with detected scanners, categorizes matched/missing/new, returns 'no-config' when no saved scanners
-  - `runStartupScannerValidation`: skips validation when no cached scanners, sets module-level validation state
-  - `getSessionValidationState` / `resetSessionValidation`: state accessors, reset in `beforeEach`
+- [ ] 1.1 Write `scanner-handlers.test.ts` tests first (use `// @vitest-environment node` directive, call `resetSessionValidation()` in `beforeEach`):
+  - `detectScanners(db)`: returns detected scanners, mock mode returns simulated scanners from DB records, handles detection failure (upstream error propagation)
+  - `saveScannersToDB(db, scanners)`: persists scanner records with USB port matching, upserts existing scanners
+  - `getConfig(db)`: reads GraviConfig from DB, returns null when no config exists
+  - `saveConfig(db, config)`: persists grid mode + resolution, creates or updates singleton
+  - `getPlatformInfo()`: returns correct backend per platform (linux=sane, win32=twain, darwin=unsupported), mock mode override. Use `vi.stubEnv` for `GRAVISCAN_MOCK` and `vi.stubGlobal` / `Object.defineProperty` for `process.platform`.
+  - `validateScanners(db, cachedIds)`: compares cached IDs with connected hardware, returns validation state
+  - `validateConfig(db)`: matches saved USB ports with detected scanners, categorizes matched/missing/new, returns 'no-config' when no saved scanners
+  - `runStartupScannerValidation(db, cachedIds)`: happy path — queries DB, detects USB, compares scanners, sets validation state. Early-return path — skips validation when no cached scanners.
+  - `getSessionValidationState()` / `resetSessionValidation()`: state accessors
   - Module-mock `detectEpsonScanners` via `vi.mock('../lsusb-detection')`
-- [ ] 1.2 Implement `scanner-handlers.ts` — extract and adapt 7 handlers + 3 validation state functions from Ben's `graviscan-handlers.ts`. Inject `db: PrismaClient` as parameter. Module-level `sessionValidation` state with exported reset function. Scanner model: Epson Perfection V600 (USB `04b8:013a`). Types from `src/types/graviscan.ts`: `DetectedScanner`, `GraviConfig`, `GraviConfigInput`, `GraviScanner`, `GraviScanPlatformInfo`.
+- [ ] 1.2 Implement `scanner-handlers.ts` — extract and adapt 7 handlers + 3 validation state functions from Ben's `graviscan-handlers.ts`. Inject `db: PrismaClient` as parameter (including to `runStartupScannerValidation`). Module-level `sessionValidation` state with exported reset function. Scanner model: Epson Perfection V600 (USB `04b8:013a`). Types from `src/types/graviscan.ts`: `DetectedScanner`, `GraviConfig`, `GraviConfigInput`, `GraviScanner`, `GraviScanPlatformInfo`.
 
 ## 2. Session Handlers Module
 
@@ -20,24 +28,23 @@
   - Fire-and-forget error path: mock `coordinator.scanOnce()` to return a promise that rejects *after* the function returns; verify `setScanSession(null)` and `onError` callback are called
   - `getScanStatus`: returns session state when active, returns `{ isActive: false }` when no session
   - `markJobRecorded`: marks specified job key as DB-recorded in session state
-  - `cancelScan`: calls coordinator cancel, clears session state, handles no active scan gracefully
+  - `cancelScan`: calls `coordinator.cancelAll()` (note: method is `cancelAll`, not `cancelScan`), clears session state, handles no active scan gracefully
   - Mock coordinator via object literal implementing `ScanCoordinatorLike` interface
   - Mock session functions (`getScanSession`, `setScanSession`, `markScanJobRecorded`) as `vi.fn()` parameters
-- [ ] 2.2 Implement `session-handlers.ts` — extract and adapt 4 handlers from Ben's file. Define `ScanCoordinatorLike` interface locally (based on Ben's `ScanCoordinator` from `origin/graviscan/4-main-process:src/main/scan-coordinator.ts`). Inject coordinator, session fns, and `onError` callback as parameters. Types from Ben's file: `ScannerConfig`, `PlateConfig`.
+- [ ] 2.2 Implement `session-handlers.ts` — extract and adapt 4 handlers from Ben's file. Define locally: `ScanCoordinatorLike` interface (method `cancelAll()`, not `cancelScan()`), `ScannerConfig`, `PlateConfig` types. These are local to this module — not imported from 3b files that don't exist yet. Inject coordinator, session fns, and `onError` callback as parameters.
 
 ## 3. Image Handlers Module
 
-- [ ] 3.1 Write `image-handlers.test.ts` tests first (use `// @vitest-environment node` directive):
-  - `getOutputDir`: returns configured output path, returns error/default when not configured
+- [ ] 3.1 Write `image-handlers.test.ts` tests first (use `// @vitest-environment node` directive, call `resetUploadState()` in `beforeEach`):
+  - `getOutputDir()`: returns computed output path based on `app.getAppPath()` / `app.getPath('home')` + NODE_ENV. Module-mock `electron` (`vi.mock('electron', () => ({ app: { getAppPath: vi.fn(), getPath: vi.fn() } }))`). Test that directory is created if missing.
   - `readScanImage`: thumbnail mode returns base64 data URI (quality 85, 400px resize), full mode returns quality 95 data URI, handles missing file with `resolveGraviScanPath` fallback, returns error when file not found after resolution. Module-mock `sharp` and `resolveGraviScanPath`. Test behavior (correct URI returned), not implementation details (sharp call order).
   - `uploadAllScans`: triggers Box backup, reports progress via callback, guards against concurrent uploads (`uploadInProgress`), returns error when upload already in progress. Module-mock `runBoxBackup`.
   - `downloadImages`: queries scans by experiment, groups by wave into subdirectories, writes metadata CSV per wave, copies files concurrently, reports progress via callback, returns `{ total: 0, copied: 0 }` when no images found. Module-mock `fs` and `resolveGraviScanPath`. Test file copy results, NOT concurrency mechanics (defer to E2E).
-  - Reset `uploadInProgress` state in `beforeEach` via exported `resetUploadState()`
-- [ ] 3.2 Implement `image-handlers.ts` — extract and adapt 4 handlers from Ben's file. Module-level `uploadInProgress` guard with exported `resetUploadState()` for testing. Progress events use callback injection (`onProgress?: (p) => void`). `downloadImages` accepts `targetDir: string` parameter (dialog handling deferred to 3c). `resolveGraviScanPath` imported from `../graviscan-path-utils` (existing utility in Ben's branch, cherry-picked as dependency).
+- [ ] 3.2 Implement `image-handlers.ts` — extract and adapt 4 handlers from Ben's file. Module-level `uploadInProgress` guard with exported `resetUploadState()` for testing. `getOutputDir` uses Electron `app` API for path resolution (module-mocked in tests). Progress events use callback injection (`onProgress?: (p) => void`). `downloadImages` accepts `targetDir: string` parameter (dialog handling deferred to 3c).
 
 ## 4. Barrel Export + Verification
 
-- [ ] 4.1 Create `index.ts` barrel export re-exporting all public functions from the 3 modules. Add JSDoc mapping IPC channel names → exported functions for 3c wiring reference.
+- [ ] 4.1 Create `index.ts` barrel export re-exporting all public functions from the 3 modules. Add JSDoc mapping IPC channel names → exported functions for 3c wiring reference. Include note on `webContents.send` event channels replaced by callbacks: `graviscan:scan-error` → `onError`, `graviscan:box-backup-progress` → `onProgress`, `graviscan:download-progress` → `onProgress`.
 - [ ] 4.2 Run all tests, verify passing: `npx vitest run --reporter=verbose tests/unit/graviscan/`
 - [ ] 4.3 Run TypeScript compilation: `npx tsc --noEmit`
 - [ ] 4.4 Run lint: `npx eslint src/main/graviscan/`

--- a/openspec/changes/add-graviscan-handler-modules/tasks.md
+++ b/openspec/changes/add-graviscan-handler-modules/tasks.md
@@ -1,0 +1,38 @@
+## 1. Scanner Handlers Module
+
+- [ ] 1.1 Write `scanner-handlers.test.ts` tests first:
+  - `detectScanners`: returns detected scanners, mock mode returns simulated scanners, handles detection failure
+  - `saveScannersToDB`: persists scanner records with USB port matching, updates existing scanners
+  - `getConfig`: reads GraviConfig from DB, returns null when no config exists
+  - `saveConfig`: persists grid mode + resolution, creates or updates singleton
+  - `getPlatformInfo`: returns correct backend per platform (linux=sane, win32=twain, darwin=unsupported), mock mode override
+  - `validateScanners`: compares cached IDs with connected hardware, returns validation state
+  - `validateConfig`: matches saved USB ports with detected scanners, categorizes matched/missing/new
+  - `runStartupScannerValidation`: skips validation when no cached scanners, sets validation state
+  - `getSessionValidationState` / `resetSessionValidation`: state accessors
+- [ ] 1.2 Implement `scanner-handlers.ts` — extract and adapt 7 handlers + 3 validation state functions from Ben's `graviscan-handlers.ts`. Export pure async functions with `db: PrismaClient` injected. Scanner model: Epson Perfection V600 (USB `04b8:013a`).
+
+## 2. Session Handlers Module
+
+- [ ] 2.1 Write `session-handlers.test.ts` tests first:
+  - `startScan`: one-shot mode calls `coordinator.scanOnce()`, continuous mode calls `coordinator.scanInterval()`, rejects when coordinator not initialized, rejects when scan already in progress, builds session state correctly
+  - `getScanStatus`: returns session state when active, returns `{ isActive: false }` when no session
+  - `markJobRecorded`: marks specified job as DB-recorded in session state
+  - `cancelScan`: calls `coordinator.cancelScan()`, clears session state, handles no active scan gracefully
+- [ ] 2.2 Implement `session-handlers.ts` — extract and adapt 4 handlers from Ben's file. Dependencies (`ScanCoordinator`, `getScanSession`/`setScanSession`/`markScanJobRecorded`) injected as parameters for testability.
+
+## 3. Image Handlers Module
+
+- [ ] 3.1 Write `image-handlers.test.ts` tests first:
+  - `getOutputDir`: returns configured output path, handles missing config
+  - `readScanImage`: converts TIFF to JPEG via sharp, thumbnail mode resizes to 400px, full mode uses quality 95, handles missing file with `resolveGraviScanPath` fallback, returns base64 data URI
+  - `uploadAllScans`: triggers Box backup, reports progress via callback, handles upload-already-in-progress guard
+  - `downloadImages`: queries scans by experiment, groups by wave number, writes metadata CSV per wave, copies files with 4-concurrency, reports progress via callback, handles cancelled dialog
+- [ ] 3.2 Implement `image-handlers.ts` — extract and adapt 4 handlers from Ben's file. Progress events use callback injection (`onProgress?: (p) => void`) instead of direct `mainWindow.webContents.send()`.
+
+## 4. Barrel Export + Verification
+
+- [ ] 4.1 Create `index.ts` barrel export re-exporting all public functions from the 3 modules
+- [ ] 4.2 Run all tests, verify passing: `npx vitest run --reporter=verbose tests/unit/graviscan/`
+- [ ] 4.3 Run TypeScript compilation: `npx tsc --noEmit`
+- [ ] 4.4 Run lint: `npx eslint src/main/graviscan/`

--- a/openspec/changes/add-graviscan-handler-modules/tasks.md
+++ b/openspec/changes/add-graviscan-handler-modules/tasks.md
@@ -14,9 +14,8 @@
   - `getConfig(db)`: reads GraviConfig from DB, returns null when no config exists
   - `saveConfig(db, config)`: persists grid mode + resolution, creates or updates singleton
   - `getPlatformInfo()`: returns correct backend per platform (linux=sane, win32=twain, darwin=unsupported), mock mode override. Use `vi.stubEnv` for `GRAVISCAN_MOCK` and `vi.stubGlobal` / `Object.defineProperty` for `process.platform`.
-  - `validateScanners(db, cachedIds)`: compares cached IDs with connected hardware, returns validation state
   - `validateConfig(db)`: matches saved USB ports with detected scanners, categorizes matched/missing/new, returns 'no-config' when no saved scanners
-  - `runStartupScannerValidation(db, cachedIds)`: happy path — queries DB, detects USB, compares scanners, sets validation state. Early-return path — skips validation when no cached scanners.
+  - `runStartupScannerValidation(db, cachedIds)`: happy path — queries DB, detects USB, compares scanners, sets validation state. Early-return path — skips validation when no cached scanners. (Note: the `graviscan:validate-scanners` IPC handler is a thin wrapper that delegates to this function — no separate `validateScanners` export needed.)
   - `getSessionValidationState()` / `resetSessionValidation()`: state accessors
   - Module-mock `detectEpsonScanners` via `vi.mock('../lsusb-detection')`
 - [ ] 1.2 Implement `scanner-handlers.ts` — extract and adapt 7 handlers + 3 validation state functions from Ben's `graviscan-handlers.ts`. Inject `db: PrismaClient` as parameter (including to `runStartupScannerValidation`). Module-level `sessionValidation` state with exported reset function. Scanner model: Epson Perfection V600 (USB `04b8:013a`). Types from `src/types/graviscan.ts`: `DetectedScanner`, `GraviConfig`, `GraviConfigInput`, `GraviScanner`, `GraviScanPlatformInfo`.
@@ -24,11 +23,11 @@
 ## 2. Session Handlers Module
 
 - [ ] 2.1 Write `session-handlers.test.ts` tests first (use `// @vitest-environment node` directive):
-  - `startScan`: one-shot mode calls `coordinator.scanOnce()`, continuous mode calls `coordinator.scanInterval()` with correct interval/duration, rejects when coordinator is null, rejects when `coordinator.isScanning` is true, builds session state correctly (verify `jobs` shape, `totalCycles` calculation)
+  - `startScan`: calls `coordinator.initialize(scannerConfigs)` before scanning, one-shot mode calls `coordinator.scanOnce()`, continuous mode calls `coordinator.scanInterval()` with correct interval/duration, rejects when coordinator is null, rejects when `coordinator.isScanning` is true, builds session state correctly (verify `jobs` shape, `totalCycles` calculation)
   - Fire-and-forget error path: mock `coordinator.scanOnce()` to return a promise that rejects *after* the function returns; verify `setScanSession(null)` and `onError` callback are called
   - `getScanStatus`: returns session state when active, returns `{ isActive: false }` when no session
   - `markJobRecorded`: marks specified job key as DB-recorded in session state
-  - `cancelScan`: calls `coordinator.cancelAll()` (note: method is `cancelAll`, not `cancelScan`), clears session state, handles no active scan gracefully
+  - `cancelScan`: calls `coordinator.cancelAll()` then `coordinator.shutdown()` (note: method is `cancelAll`, not `cancelScan`), clears session state, handles no active scan gracefully
   - Mock coordinator via object literal implementing `ScanCoordinatorLike` interface
   - Mock session functions (`getScanSession`, `setScanSession`, `markScanJobRecorded`) as `vi.fn()` parameters
 - [ ] 2.2 Implement `session-handlers.ts` — extract and adapt 4 handlers from Ben's file. Define locally: `ScanCoordinatorLike` interface (method `cancelAll()`, not `cancelScan()`), `ScannerConfig`, `PlateConfig` types. These are local to this module — not imported from 3b files that don't exist yet. Inject coordinator, session fns, and `onError` callback as parameters.
@@ -36,7 +35,7 @@
 ## 3. Image Handlers Module
 
 - [ ] 3.1 Write `image-handlers.test.ts` tests first (use `// @vitest-environment node` directive, call `resetUploadState()` in `beforeEach`):
-  - `getOutputDir()`: returns computed output path based on `app.getAppPath()` / `app.getPath('home')` + NODE_ENV. Module-mock `electron` (`vi.mock('electron', () => ({ app: { getAppPath: vi.fn(), getPath: vi.fn() } }))`). Test that directory is created if missing.
+  - `getOutputDir()`: returns computed output path based on `app.getAppPath()` / `app.getPath('home')` + NODE_ENV. Module-mock `electron` (`vi.mock('electron', () => ({ app: { getAppPath: vi.fn(), getPath: vi.fn() } }))`). Test that directory is created if missing. Test failure when `mkdirSync` throws (permissions error) returns `{ success: false, error }`.
   - `readScanImage`: thumbnail mode returns base64 data URI (quality 85, 400px resize), full mode returns quality 95 data URI, handles missing file with `resolveGraviScanPath` fallback, returns error when file not found after resolution. Module-mock `sharp` and `resolveGraviScanPath`. Test behavior (correct URI returned), not implementation details (sharp call order).
   - `uploadAllScans`: triggers Box backup, reports progress via callback, guards against concurrent uploads (`uploadInProgress`), returns error when upload already in progress. Module-mock `runBoxBackup`.
   - `downloadImages`: queries scans by experiment, groups by wave into subdirectories, writes metadata CSV per wave, copies files concurrently, reports progress via callback, returns `{ total: 0, copied: 0 }` when no images found. Module-mock `fs` and `resolveGraviScanPath`. Test file copy results, NOT concurrency mechanics (defer to E2E).

--- a/openspec/changes/add-graviscan-handler-modules/tasks.md
+++ b/openspec/changes/add-graviscan-handler-modules/tasks.md
@@ -1,6 +1,6 @@
 ## 0. Cherry-Pick Dependencies
 
-- [ ] 0.1 Cherry-pick or extract these utility files from `origin/graviscan/4-main-process` (required for imports to resolve):
+- [x] 0.1 Cherry-pick or extract these utility files from `origin/graviscan/4-main-process` (required for imports to resolve):
   - `src/main/lsusb-detection.ts` — `detectEpsonScanners()`, used by scanner-handlers
   - `src/main/graviscan-path-utils.ts` — `resolveGraviScanPath()`, used by image-handlers
   - `src/main/box-backup.ts` — `runBoxBackup()`, used by image-handlers
@@ -8,7 +8,7 @@
 
 ## 1. Scanner Handlers Module
 
-- [ ] 1.1 Write `scanner-handlers.test.ts` tests first (use `// @vitest-environment node` directive, call `resetSessionValidation()` in `beforeEach`):
+- [x] 1.1 Write `scanner-handlers.test.ts` tests first (use `// @vitest-environment node` directive, call `resetSessionValidation()` in `beforeEach`):
   - `detectScanners(db)`: returns detected scanners, mock mode returns simulated scanners from DB records, handles detection failure (upstream error propagation)
   - `saveScannersToDB(db, scanners)`: persists scanner records with USB port matching, upserts existing scanners
   - `getConfig(db)`: reads GraviConfig from DB, returns null when no config exists
@@ -18,11 +18,11 @@
   - `runStartupScannerValidation(db, cachedIds)`: happy path — queries DB, detects USB, compares scanners, sets validation state. Early-return path — skips validation when no cached scanners. (Note: the `graviscan:validate-scanners` IPC handler is a thin wrapper that delegates to this function — no separate `validateScanners` export needed.)
   - `getSessionValidationState()` / `resetSessionValidation()`: state accessors
   - Module-mock `detectEpsonScanners` via `vi.mock('../lsusb-detection')`
-- [ ] 1.2 Implement `scanner-handlers.ts` — extract and adapt 7 handlers + 3 validation state functions from Ben's `graviscan-handlers.ts`. Inject `db: PrismaClient` as parameter (including to `runStartupScannerValidation`). Module-level `sessionValidation` state with exported reset function. Scanner model: Epson Perfection V600 (USB `04b8:013a`). Types from `src/types/graviscan.ts`: `DetectedScanner`, `GraviConfig`, `GraviConfigInput`, `GraviScanner`, `GraviScanPlatformInfo`.
+- [x] 1.2 Implement `scanner-handlers.ts` — extract and adapt 7 handlers + 3 validation state functions from Ben's `graviscan-handlers.ts`. Inject `db: PrismaClient` as parameter (including to `runStartupScannerValidation`). Module-level `sessionValidation` state with exported reset function. Scanner model: Epson Perfection V600 (USB `04b8:013a`). Types from `src/types/graviscan.ts`: `DetectedScanner`, `GraviConfig`, `GraviConfigInput`, `GraviScanner`, `GraviScanPlatformInfo`.
 
 ## 2. Session Handlers Module
 
-- [ ] 2.1 Write `session-handlers.test.ts` tests first (use `// @vitest-environment node` directive):
+- [x] 2.1 Write `session-handlers.test.ts` tests first (use `// @vitest-environment node` directive):
   - `startScan`: calls `coordinator.initialize(scannerConfigs)` before scanning, one-shot mode calls `coordinator.scanOnce()`, continuous mode calls `coordinator.scanInterval()` with correct interval/duration, rejects when coordinator is null, rejects when `coordinator.isScanning` is true, builds session state correctly (verify `jobs` shape, `totalCycles` calculation)
   - Fire-and-forget error path: mock `coordinator.scanOnce()` to return a promise that rejects *after* the function returns; verify `setScanSession(null)` and `onError` callback are called
   - `getScanStatus`: returns session state when active, returns `{ isActive: false }` when no session
@@ -30,20 +30,20 @@
   - `cancelScan`: calls `coordinator.cancelAll()` then `coordinator.shutdown()` (note: method is `cancelAll`, not `cancelScan`), clears session state, handles no active scan gracefully
   - Mock coordinator via object literal implementing `ScanCoordinatorLike` interface
   - Mock session functions (`getScanSession`, `setScanSession`, `markScanJobRecorded`) as `vi.fn()` parameters
-- [ ] 2.2 Implement `session-handlers.ts` — extract and adapt 4 handlers from Ben's file. Define locally: `ScanCoordinatorLike` interface (method `cancelAll()`, not `cancelScan()`), `ScannerConfig`, `PlateConfig` types. These are local to this module — not imported from 3b files that don't exist yet. Inject coordinator, session fns, and `onError` callback as parameters.
+- [x] 2.2 Implement `session-handlers.ts` — extract and adapt 4 handlers from Ben's file. Define locally: `ScanCoordinatorLike` interface (method `cancelAll()`, not `cancelScan()`), `ScannerConfig`, `PlateConfig` types. These are local to this module — not imported from 3b files that don't exist yet. Inject coordinator, session fns, and `onError` callback as parameters.
 
 ## 3. Image Handlers Module
 
-- [ ] 3.1 Write `image-handlers.test.ts` tests first (use `// @vitest-environment node` directive, call `resetUploadState()` in `beforeEach`):
+- [x] 3.1 Write `image-handlers.test.ts` tests first (use `// @vitest-environment node` directive, call `resetUploadState()` in `beforeEach`):
   - `getOutputDir()`: returns computed output path based on `app.getAppPath()` / `app.getPath('home')` + NODE_ENV. Module-mock `electron` (`vi.mock('electron', () => ({ app: { getAppPath: vi.fn(), getPath: vi.fn() } }))`). Test that directory is created if missing. Test failure when `mkdirSync` throws (permissions error) returns `{ success: false, error }`.
   - `readScanImage`: thumbnail mode returns base64 data URI (quality 85, 400px resize), full mode returns quality 95 data URI, handles missing file with `resolveGraviScanPath` fallback, returns error when file not found after resolution. Module-mock `sharp` and `resolveGraviScanPath`. Test behavior (correct URI returned), not implementation details (sharp call order).
   - `uploadAllScans`: triggers Box backup, reports progress via callback, guards against concurrent uploads (`uploadInProgress`), returns error when upload already in progress. Module-mock `runBoxBackup`.
   - `downloadImages`: queries scans by experiment, groups by wave into subdirectories, writes metadata CSV per wave, copies files concurrently, reports progress via callback, returns `{ total: 0, copied: 0 }` when no images found. Module-mock `fs` and `resolveGraviScanPath`. Test file copy results, NOT concurrency mechanics (defer to E2E).
-- [ ] 3.2 Implement `image-handlers.ts` — extract and adapt 4 handlers from Ben's file. Module-level `uploadInProgress` guard with exported `resetUploadState()` for testing. `getOutputDir` uses Electron `app` API for path resolution (module-mocked in tests). Progress events use callback injection (`onProgress?: (p) => void`). `downloadImages` accepts `targetDir: string` parameter (dialog handling deferred to 3c).
+- [x] 3.2 Implement `image-handlers.ts` — extract and adapt 4 handlers from Ben's file. Module-level `uploadInProgress` guard with exported `resetUploadState()` for testing. `getOutputDir` uses Electron `app` API for path resolution (module-mocked in tests). Progress events use callback injection (`onProgress?: (p) => void`). `downloadImages` accepts `targetDir: string` parameter (dialog handling deferred to 3c).
 
 ## 4. Barrel Export + Verification
 
-- [ ] 4.1 Create `index.ts` barrel export re-exporting all public functions from the 3 modules. Add JSDoc mapping IPC channel names → exported functions for 3c wiring reference. Include note on `webContents.send` event channels replaced by callbacks: `graviscan:scan-error` → `onError`, `graviscan:box-backup-progress` → `onProgress`, `graviscan:download-progress` → `onProgress`.
-- [ ] 4.2 Run all tests, verify passing: `npx vitest run --reporter=verbose tests/unit/graviscan/`
-- [ ] 4.3 Run TypeScript compilation: `npx tsc --noEmit`
-- [ ] 4.4 Run lint: `npx eslint src/main/graviscan/`
+- [x] 4.1 Create `index.ts` barrel export re-exporting all public functions from the 3 modules. Add JSDoc mapping IPC channel names → exported functions for 3c wiring reference. Include note on `webContents.send` event channels replaced by callbacks: `graviscan:scan-error` → `onError`, `graviscan:box-backup-progress` → `onProgress`, `graviscan:download-progress` → `onProgress`.
+- [x] 4.2 Run all tests, verify passing: `npx vitest run --reporter=verbose tests/unit/graviscan/`
+- [x] 4.3 Run TypeScript compilation: `npx tsc --noEmit`
+- [x] 4.4 Run lint: `npx eslint src/main/graviscan/`

--- a/openspec/specs/scanning/spec.md
+++ b/openspec/specs/scanning/spec.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 TBD - created by archiving change fix-scanner-event-listener-leak. Update Purpose after archive.
+
 ## Requirements
+
 ### Requirement: Scanner Event Listener Lifecycle
 
 Scanner event listeners SHALL be properly cleaned up when component unmounts or dependencies change to prevent memory leaks and duplicate event handling.
@@ -1167,4 +1169,3 @@ The system SHALL declare GraviScan-specific Python dependencies as optional depe
 - **WHEN** the lockfile includes `python-sane` and `pytwain`
 - **THEN** `python-sane` SHALL install successfully on Linux CI runners (requires `libsane-dev` system package)
 - **AND** `pytwain` (Windows-only) SHALL be excluded from Linux CI via environment markers or CI configuration to prevent cross-platform install failures
-

--- a/src/main/box-backup.ts
+++ b/src/main/box-backup.ts
@@ -1,0 +1,562 @@
+/**
+ * Box Backup via rclone
+ *
+ * After scans are uploaded to Bloom (Supabase), backs up raw TIF files
+ * to Box via `rclone copy`. Files are organized per experiment:
+ *
+ *   Box:GraviScan-Backups/
+ *     ExperimentName/
+ *       wave_0/
+ *         ExperimentName_st_..._cy1_S1_00.tif
+ *         metadata.csv
+ *       wave_1/
+ *         ...
+ *
+ * rclone copy automatically skips files that already exist at the destination.
+ * If rclone is not installed, logs a warning and skips.
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { execFile, spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { resolveGraviScanPath } from './graviscan-path-utils';
+
+const RCLONE_REMOTE = 'Box';
+const BOX_BASE_PATH = 'Graviscan-Backups';
+
+export interface BoxBackupProgress {
+  totalImages: number;
+  completedImages: number;
+  failedImages: number;
+  currentExperiment: string;
+}
+
+export interface BoxBackupResult {
+  success: boolean;
+  experiments: number;
+  filesCopied: number;
+  errors: string[];
+}
+
+/**
+ * Check if rclone is available on PATH.
+ */
+function isRcloneInstalled(): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile('which', ['rclone'], (error) => {
+      resolve(!error);
+    });
+  });
+}
+
+/**
+ * Run rclone copy for a list of source files to a Box destination folder.
+ * Uses a temp directory with symlinks to copy only the specific files.
+ */
+function rcloneCopyFiles(
+  filePaths: string[],
+  boxDestination: string,
+  onFileComplete?: (filename: string) => void
+): Promise<{ success: boolean; erroredFiles: Set<string>; error?: string }> {
+  return new Promise((resolve) => {
+    // Create a temp directory with symlinks to the files we want to copy
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'graviscan-backup-'));
+
+    try {
+      let symlinksCreated = 0;
+      const missingFiles: string[] = [];
+      const missingFileNames = new Set<string>();
+      for (const filePath of filePaths) {
+        const resolvedPath = resolveGraviScanPath(filePath);
+        if (resolvedPath) {
+          const fileName = path.basename(resolvedPath);
+          const linkPath = path.join(tmpDir, fileName);
+          fs.symlinkSync(resolvedPath, linkPath);
+          symlinksCreated++;
+        } else {
+          missingFiles.push(filePath);
+          missingFileNames.add(path.basename(filePath));
+        }
+      }
+
+      console.log(
+        `[BoxBackup] rcloneCopyFiles: ${symlinksCreated}/${filePaths.length} files found on disk`
+      );
+      if (missingFiles.length > 0) {
+        console.warn(
+          `[BoxBackup] Missing files (first 5):`,
+          missingFiles.slice(0, 5)
+        );
+      }
+
+      // If no files exist on disk, fail immediately — don't run rclone on empty dir
+      if (symlinksCreated === 0 && filePaths.length > 0) {
+        try {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+          // ignore
+        }
+        resolve({
+          success: false,
+          erroredFiles: missingFileNames,
+          error: `None of the ${filePaths.length} image files exist on disk`,
+        });
+        return;
+      }
+
+      const proc = spawn('rclone', [
+        'copy',
+        tmpDir,
+        `${RCLONE_REMOTE}:${boxDestination}`,
+        '--copy-links', // follow symlinks
+        '--use-json-log',
+        '--log-level',
+        'INFO',
+      ]);
+
+      const erroredFiles = new Set<string>(missingFileNames);
+      let stderrBuffer = '';
+      proc.stderr.on('data', (data: Buffer) => {
+        stderrBuffer += data.toString();
+        // Parse complete lines as they stream in
+        const lines = stderrBuffer.split('\n');
+        stderrBuffer = lines.pop() || ''; // keep incomplete last line in buffer
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const entry = JSON.parse(line);
+            if (entry.level === 'error' && entry.msg) {
+              const filename = entry.msg.split(':')[0].trim();
+              if (filename) erroredFiles.add(filename);
+            } else if (
+              entry.level === 'info' &&
+              entry.msg &&
+              /: Copied \(/.test(entry.msg)
+            ) {
+              const filename = entry.msg.split(':')[0].trim();
+              if (filename) onFileComplete?.(filename);
+            }
+          } catch {
+            // skip non-JSON lines
+          }
+        }
+      });
+
+      proc.on('close', (code) => {
+        // Parse any remaining buffered line
+        if (stderrBuffer.trim()) {
+          try {
+            const entry = JSON.parse(stderrBuffer);
+            if (entry.level === 'error' && entry.msg) {
+              const filename = entry.msg.split(':')[0].trim();
+              if (filename) erroredFiles.add(filename);
+            } else if (
+              entry.level === 'info' &&
+              entry.msg &&
+              /: Copied \(/.test(entry.msg)
+            ) {
+              const filename = entry.msg.split(':')[0].trim();
+              if (filename) onFileComplete?.(filename);
+            }
+          } catch {
+            // skip
+          }
+        }
+
+        // Clean up temp dir
+        try {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+          // ignore cleanup errors
+        }
+
+        if (code === 0 && erroredFiles.size === 0) {
+          resolve({ success: true, erroredFiles });
+        } else {
+          resolve({
+            success: false,
+            erroredFiles,
+            error: code !== 0 ? `rclone exited with code ${code}` : undefined,
+          });
+        }
+      });
+
+      proc.on('error', (err) => {
+        try {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+          // ignore
+        }
+        resolve({
+          success: false,
+          erroredFiles: new Set(),
+          error: err.message,
+        });
+      });
+    } catch (err) {
+      try {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+      resolve({
+        success: false,
+        erroredFiles: new Set(),
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+}
+
+/**
+ * Copy a single file (e.g. metadata.csv) to a Box destination folder.
+ * Uses a temp directory with the file copied in, then rclone copy (same
+ * pattern as image uploads) to avoid rclone copyto source-directory issues.
+ */
+function rcloneCopyFile(
+  filePath: string,
+  destFileName: string,
+  boxDestination: string
+): Promise<{ success: boolean; error?: string }> {
+  return new Promise((resolve) => {
+    // Create a temp directory containing a copy/link of the file with the desired name
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'graviscan-csv-'));
+    const tmpFilePath = path.join(tmpDir, destFileName);
+
+    try {
+      fs.copyFileSync(filePath, tmpFilePath);
+    } catch (err) {
+      try {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+      resolve({
+        success: false,
+        error: `Failed to prepare file: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      return;
+    }
+
+    const proc = spawn('rclone', [
+      'copy',
+      tmpDir,
+      `${RCLONE_REMOTE}:${boxDestination}`,
+      '--copy-links',
+    ]);
+
+    let stderr = '';
+    proc.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', (code) => {
+      try {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+      if (code === 0) {
+        resolve({ success: true });
+      } else {
+        resolve({
+          success: false,
+          error: `rclone exited with code ${code}: ${stderr}`,
+        });
+      }
+    });
+
+    proc.on('error', (err) => {
+      try {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+      resolve({ success: false, error: err.message });
+    });
+  });
+}
+
+interface ScanRow {
+  wave_number: number;
+  plate_barcode: string | null;
+  plate_index: string;
+  grid_mode: string;
+  capture_date: Date;
+  accession: string;
+  transplant_date: Date | null;
+  custom_note: string | null;
+  image_filename: string;
+}
+
+/**
+ * Export metadata CSV with scan-level data (wave_number from GraviScan).
+ */
+function exportMetadataCSV(
+  experimentName: string,
+  scanRows: ScanRow[]
+): string {
+  const rows: string[] = [];
+  rows.push(
+    'experiment,wave_number,plate_barcode,plate_index,grid_mode,capture_date,accession,transplant_date,custom_note,image_filename'
+  );
+
+  for (const r of scanRows) {
+    rows.push(
+      [
+        experimentName,
+        r.wave_number,
+        r.plate_barcode ?? '',
+        r.plate_index,
+        r.grid_mode,
+        r.capture_date.toISOString(),
+        r.accession,
+        r.transplant_date ? r.transplant_date.toISOString().split('T')[0] : '',
+        r.custom_note ?? '',
+        r.image_filename,
+      ].join(',')
+    );
+  }
+
+  return rows.join('\n') + '\n';
+}
+
+/**
+ * Run Box backup for all uploaded images, organized by experiment.
+ *
+ * Queries the DB for uploaded images, groups by experiment name,
+ * copies TIF files + metadata CSV to Box:GraviScan-Backups/<experiment>/.
+ *
+ * This is non-blocking from the caller's perspective when awaited —
+ * it runs rclone as child processes sequentially per experiment.
+ */
+export async function runBoxBackup(
+  db: PrismaClient,
+  onProgress?: (progress: BoxBackupProgress) => void
+): Promise<BoxBackupResult> {
+  const systemName = process.env.GRAVISCAN_SYSTEM_NAME || '';
+
+  const result: BoxBackupResult = {
+    success: true,
+    experiments: 0,
+    filesCopied: 0,
+    errors: [],
+  };
+
+  // Check if rclone is installed
+  const hasRclone = await isRcloneInstalled();
+  if (!hasRclone) {
+    console.warn('[BoxBackup] rclone not installed — skipping Box backup');
+    return { ...result, success: false, errors: ['rclone not installed'] };
+  }
+
+  console.log('[BoxBackup] Starting Box backup...');
+
+  // Query for images pending Box backup
+  const scans = await db.graviScan.findMany({
+    where: {
+      deleted: false,
+      images: {
+        some: { box_status: { in: ['pending', 'failed'] } },
+      },
+    },
+    include: {
+      images: { where: { box_status: { in: ['pending', 'failed'] } } },
+      experiment: {
+        include: {
+          accession: {
+            include: {
+              graviPlateAccessions: {
+                include: { sections: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (scans.length === 0) {
+    console.log('[BoxBackup] No uploaded images to back up');
+    return result;
+  }
+
+  // Group scans by experiment name → wave number
+  const experimentWaveMap = new Map<
+    string,
+    Map<
+      number,
+      { imageIds: string[]; imagePaths: string[]; scanRows: ScanRow[] }
+    >
+  >();
+
+  for (const scan of scans) {
+    const expName = scan.experiment.name;
+    if (!experimentWaveMap.has(expName)) {
+      experimentWaveMap.set(expName, new Map());
+    }
+
+    const waveMap = experimentWaveMap.get(expName)!;
+    const waveNum = scan.wave_number;
+    if (!waveMap.has(waveNum)) {
+      waveMap.set(waveNum, { imageIds: [], imagePaths: [], scanRows: [] });
+    }
+
+    // Look up accession from plate accessions if available
+    const plateAccessions =
+      scan.experiment.accession?.graviPlateAccessions ?? [];
+    const matchedAccession = plateAccessions.find(
+      (pa) => pa.plate_id === scan.plate_barcode
+    );
+    const accession = matchedAccession?.accession ?? '';
+
+    const entry = waveMap.get(waveNum)!;
+    for (const img of scan.images) {
+      entry.imageIds.push(img.id);
+      entry.imagePaths.push(img.path);
+      entry.scanRows.push({
+        wave_number: scan.wave_number,
+        plate_barcode: scan.plate_barcode,
+        plate_index: scan.plate_index,
+        grid_mode: scan.grid_mode,
+        capture_date: scan.capture_date,
+        accession,
+        transplant_date: scan.transplant_date,
+        custom_note: scan.custom_note,
+        image_filename: path.basename(img.path),
+      });
+    }
+  }
+
+  // Count total images for progress tracking
+  let totalImages = 0;
+  let completedImages = 0;
+  let failedImages = 0;
+  for (const [, waveMap] of experimentWaveMap) {
+    for (const [, data] of waveMap) {
+      totalImages += data.imagePaths.length;
+    }
+  }
+
+  // Process each experiment → wave
+  for (const [expName, waveMap] of experimentWaveMap) {
+    const sortedWaves = [...waveMap.keys()].sort((a, b) => a - b);
+
+    for (const waveNum of sortedWaves) {
+      const data = waveMap.get(waveNum)!;
+      const boxDest = systemName
+        ? `${BOX_BASE_PATH}/${systemName}/${expName}/wave_${waveNum}`
+        : `${BOX_BASE_PATH}/${expName}/wave_${waveNum}`;
+      console.log(
+        `[BoxBackup] Backing up ${data.imagePaths.length} images for ${expName}/wave_${waveNum}`
+      );
+
+      // Copy image files with per-file progress
+      const copyResult = await rcloneCopyFiles(data.imagePaths, boxDest, () => {
+        completedImages++;
+        onProgress?.({
+          totalImages,
+          completedImages,
+          failedImages,
+          currentExperiment: expName,
+        });
+      });
+
+      // Per-file status: mark only files that didn't error as uploaded
+      const uploadedIds: string[] = [];
+      const failedIds: string[] = [];
+
+      if (!copyResult.success && copyResult.erroredFiles.size === 0) {
+        // Total rclone failure (no per-file info) — mark ALL as failed
+        console.error(
+          `[BoxBackup] rclone failed entirely for ${expName}/wave_${waveNum} — marking all files as failed`
+        );
+        failedIds.push(...data.imageIds);
+      } else {
+        for (let i = 0; i < data.imagePaths.length; i++) {
+          const filename = path.basename(data.imagePaths[i]);
+          if (copyResult.erroredFiles.has(filename)) {
+            failedIds.push(data.imageIds[i]);
+          } else {
+            uploadedIds.push(data.imageIds[i]);
+          }
+        }
+      }
+
+      if (uploadedIds.length > 0) {
+        await db.graviImage.updateMany({
+          where: { id: { in: uploadedIds } },
+          data: { box_status: 'uploaded' },
+        });
+        result.filesCopied += uploadedIds.length;
+      }
+
+      if (failedIds.length > 0) {
+        await db.graviImage.updateMany({
+          where: { id: { in: failedIds } },
+          data: { box_status: 'failed' },
+        });
+        failedImages += failedIds.length;
+        result.errors.push(
+          `${expName}/wave_${waveNum}: ${failedIds.length}/${data.imagePaths.length} files failed`
+        );
+        result.success = false;
+        console.error(
+          `[BoxBackup] ${failedIds.length} files failed for ${expName}/wave_${waveNum}:`,
+          copyResult.error
+        );
+        // Update progress with failed count
+        onProgress?.({
+          totalImages,
+          completedImages,
+          failedImages,
+          currentExperiment: expName,
+        });
+      }
+
+      // Export and copy metadata CSV per wave
+      if (data.scanRows.length > 0) {
+        const csvContent = exportMetadataCSV(expName, data.scanRows);
+        const tmpCsvPath = path.join(
+          os.tmpdir(),
+          `graviscan-metadata-${expName}-wave${waveNum}.csv`
+        );
+
+        try {
+          fs.writeFileSync(tmpCsvPath, csvContent, 'utf-8');
+          const csvResult = await rcloneCopyFile(
+            tmpCsvPath,
+            'metadata.csv',
+            boxDest
+          );
+          if (!csvResult.success) {
+            result.errors.push(
+              `${expName}/wave_${waveNum} metadata: ${csvResult.error}`
+            );
+            console.error(
+              `[BoxBackup] Failed to copy metadata for ${expName}/wave_${waveNum}:`,
+              csvResult.error
+            );
+          }
+        } finally {
+          try {
+            fs.unlinkSync(tmpCsvPath);
+          } catch {
+            // ignore
+          }
+        }
+      }
+    }
+
+    result.experiments++;
+  }
+
+  console.log(
+    `[BoxBackup] Complete: ${result.experiments} experiments, ${result.filesCopied} files` +
+      (result.errors.length > 0 ? `, ${result.errors.length} errors` : '')
+  );
+
+  return result;
+}

--- a/src/main/box-backup.ts
+++ b/src/main/box-backup.ts
@@ -334,7 +334,8 @@ function exportMetadataCSV(
     );
   }
 
-  return rows.join('\n') + '\n';
+  // BOM prefix for Excel UTF-8 auto-detection on Windows
+  return '\uFEFF' + rows.join('\n') + '\n';
 }
 
 /**

--- a/src/main/box-backup.ts
+++ b/src/main/box-backup.ts
@@ -457,9 +457,7 @@ export async function runBoxBackup(
 
   // Process each experiment → wave
   for (const [expName, waveMap] of experimentWaveMap) {
-    const safeName = expName
-      .replace(/[/\\:*?"<>|.]/g, '_')
-      .replace(/\.\./g, '_');
+    const safeName = expName.replace(/[/\\:*?"<>|.]/g, '_');
     const sortedWaves = [...waveMap.keys()].sort((a, b) => a - b);
 
     for (const waveNum of sortedWaves) {

--- a/src/main/box-backup.ts
+++ b/src/main/box-backup.ts
@@ -17,14 +17,26 @@
  */
 
 import { PrismaClient } from '@prisma/client';
-import { execFile, spawn } from 'child_process';
+import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { resolveGraviScanPath } from './graviscan-path-utils';
 
 const RCLONE_REMOTE = 'Box';
-const BOX_BASE_PATH = 'Graviscan-Backups';
+const BOX_BASE_PATH = 'GraviScan-Backups';
+
+/**
+ * Escape a value for inclusion in a CSV field.
+ * Wraps in double-quotes and escapes inner quotes when the value
+ * contains commas, double-quotes, or newlines.
+ */
+function csvEscape(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return '"' + value.replace(/"/g, '""') + '"';
+  }
+  return value;
+}
 
 export interface BoxBackupProgress {
   totalImages: number;
@@ -45,9 +57,9 @@ export interface BoxBackupResult {
  */
 function isRcloneInstalled(): Promise<boolean> {
   return new Promise((resolve) => {
-    execFile('which', ['rclone'], (error) => {
-      resolve(!error);
-    });
+    const child = spawn('rclone', ['version'], { stdio: 'ignore' });
+    child.once('error', () => resolve(false));
+    child.once('exit', (code) => resolve(code === 0));
   });
 }
 
@@ -306,16 +318,18 @@ function exportMetadataCSV(
   for (const r of scanRows) {
     rows.push(
       [
-        experimentName,
-        r.wave_number,
-        r.plate_barcode ?? '',
-        r.plate_index,
-        r.grid_mode,
-        r.capture_date.toISOString(),
-        r.accession,
-        r.transplant_date ? r.transplant_date.toISOString().split('T')[0] : '',
-        r.custom_note ?? '',
-        r.image_filename,
+        csvEscape(experimentName),
+        csvEscape(String(r.wave_number)),
+        csvEscape(r.plate_barcode ?? ''),
+        csvEscape(r.plate_index),
+        csvEscape(r.grid_mode),
+        csvEscape(r.capture_date.toISOString()),
+        csvEscape(r.accession),
+        csvEscape(
+          r.transplant_date ? r.transplant_date.toISOString().split('T')[0] : ''
+        ),
+        csvEscape(r.custom_note ?? ''),
+        csvEscape(r.image_filename),
       ].join(',')
     );
   }
@@ -442,13 +456,14 @@ export async function runBoxBackup(
 
   // Process each experiment → wave
   for (const [expName, waveMap] of experimentWaveMap) {
+    const safeName = expName.replace(/[/\\:*?"<>|.]/g, '_').replace(/\.\./g, '_');
     const sortedWaves = [...waveMap.keys()].sort((a, b) => a - b);
 
     for (const waveNum of sortedWaves) {
       const data = waveMap.get(waveNum)!;
       const boxDest = systemName
-        ? `${BOX_BASE_PATH}/${systemName}/${expName}/wave_${waveNum}`
-        : `${BOX_BASE_PATH}/${expName}/wave_${waveNum}`;
+        ? `${BOX_BASE_PATH}/${systemName}/${safeName}/wave_${waveNum}`
+        : `${BOX_BASE_PATH}/${safeName}/wave_${waveNum}`;
       console.log(
         `[BoxBackup] Backing up ${data.imagePaths.length} images for ${expName}/wave_${waveNum}`
       );
@@ -521,7 +536,7 @@ export async function runBoxBackup(
         const csvContent = exportMetadataCSV(expName, data.scanRows);
         const tmpCsvPath = path.join(
           os.tmpdir(),
-          `graviscan-metadata-${expName}-wave${waveNum}.csv`
+          `graviscan-metadata-${safeName}-wave${waveNum}.csv`
         );
 
         try {

--- a/src/main/box-backup.ts
+++ b/src/main/box-backup.ts
@@ -457,7 +457,9 @@ export async function runBoxBackup(
 
   // Process each experiment → wave
   for (const [expName, waveMap] of experimentWaveMap) {
-    const safeName = expName.replace(/[/\\:*?"<>|.]/g, '_').replace(/\.\./g, '_');
+    const safeName = expName
+      .replace(/[/\\:*?"<>|.]/g, '_')
+      .replace(/\.\./g, '_');
     const sortedWaves = [...waveMap.keys()].sort((a, b) => a - b);
 
     for (const waveNum of sortedWaves) {

--- a/src/main/graviscan-path-utils.ts
+++ b/src/main/graviscan-path-utils.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared path resolution utilities for GraviScan image files.
+ *
+ * Handles the case where the DB stores a path with only _st_ (start time)
+ * but the file on disk has been renamed to include _et_ (end time).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Resolve a GraviScan image path that may be stale (missing _et_ timestamp).
+ *
+ * Tries in order:
+ * 1. The path as-is
+ * 2. Alternate extensions (.tif, .tiff)
+ * 3. Files with _et_ inserted after _st_ timestamp
+ *
+ * Returns the resolved path, or null if the file cannot be found.
+ */
+export function resolveGraviScanPath(filePath: string): string | null {
+  if (fs.existsSync(filePath)) return filePath;
+
+  const ext = path.extname(filePath);
+  const base = ext ? filePath.slice(0, -ext.length) : filePath;
+
+  // Try alternate extensions
+  const altExts = ['.tif', '.tiff'].filter((e) => e !== ext);
+  for (const altExt of altExts) {
+    if (fs.existsSync(base + altExt)) return base + altExt;
+  }
+
+  // Try finding renamed file with _et_ inserted after _st_ timestamp
+  const dir = path.dirname(filePath);
+  const basename = path.basename(filePath);
+  const etMatch = basename.match(/^(.+_st_\d{8}T\d{6})(_cy.+)$/);
+  if (etMatch && fs.existsSync(dir)) {
+    const prefix = etMatch[1];
+    const suffix = etMatch[2];
+    const suffixNoExt = suffix.replace(/\.[^.]+$/, '');
+    const candidates = fs
+      .readdirSync(dir)
+      .filter(
+        (f) =>
+          f.startsWith(prefix + '_et_') &&
+          (f.endsWith(suffix) || f.includes(suffixNoExt))
+      );
+    if (candidates.length === 1) {
+      return path.join(dir, candidates[0]);
+    }
+  }
+
+  return null;
+}

--- a/src/main/graviscan/image-handlers.ts
+++ b/src/main/graviscan/image-handlers.ts
@@ -21,6 +21,17 @@ import { resolveGraviScanPath } from '../graviscan-path-utils';
 import { runBoxBackup } from '../box-backup';
 
 // ---------------------------------------------------------------------------
+// CSV escaping helper
+// ---------------------------------------------------------------------------
+
+function csvEscape(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return '"' + value.replace(/"/g, '""') + '"';
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
 // Upload concurrency guard
 // ---------------------------------------------------------------------------
 
@@ -239,7 +250,9 @@ export async function downloadImages(
       ],
     });
 
-    const expDir = path.join(params.targetDir, params.experimentName);
+    // Sanitize experiment name for safe use as directory name
+    const safeName = params.experimentName.replace(/[/\\:*?"<>|.]/g, '_').replace(/\.\./g, '_');
+    const expDir = path.join(params.targetDir, safeName);
 
     // Group scans by wave number for subfolder organization
     const waveGroups = new Map<number, typeof scans>();
@@ -279,18 +292,20 @@ export async function downloadImages(
 
           csvRows.push(
             [
-              params.experimentName,
-              scan.wave_number,
-              scan.plate_barcode ?? '',
-              scan.plate_index,
-              scan.grid_mode,
-              scan.capture_date.toISOString(),
-              accession,
-              (scan as any).transplant_date
-                ? (scan as any).transplant_date.toISOString().split('T')[0]
-                : '',
-              (scan as any).custom_note ?? '',
-              originalFilename,
+              csvEscape(params.experimentName),
+              csvEscape(String(scan.wave_number)),
+              csvEscape(scan.plate_barcode ?? ''),
+              csvEscape(String(scan.plate_index)),
+              csvEscape(scan.grid_mode),
+              csvEscape(scan.capture_date.toISOString()),
+              csvEscape(accession),
+              csvEscape(
+                (scan as any).transplant_date
+                  ? (scan as any).transplant_date.toISOString().split('T')[0]
+                  : '',
+              ),
+              csvEscape((scan as any).custom_note ?? ''),
+              csvEscape(originalFilename),
             ].join(','),
           );
         }

--- a/src/main/graviscan/image-handlers.ts
+++ b/src/main/graviscan/image-handlers.ts
@@ -10,6 +10,8 @@
  * decoupled from Electron IPC plumbing.
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { app } from 'electron';
 import { PrismaClient } from '@prisma/client';
 import * as path from 'path';

--- a/src/main/graviscan/image-handlers.ts
+++ b/src/main/graviscan/image-handlers.ts
@@ -21,6 +21,15 @@ import { resolveGraviScanPath } from '../graviscan-path-utils';
 import { runBoxBackup } from '../box-backup';
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const THUMBNAIL_QUALITY = 85;
+const FULL_QUALITY = 95;
+const THUMBNAIL_WIDTH = 400;
+const COPY_CONCURRENCY = 4;
+
+// ---------------------------------------------------------------------------
 // CSV escaping helper
 // ---------------------------------------------------------------------------
 
@@ -113,10 +122,10 @@ export async function readScanImage(
       filePath = resolvedPath;
     }
 
-    const quality = options?.full ? 95 : 85;
+    const quality = options?.full ? FULL_QUALITY : THUMBNAIL_QUALITY;
     const pipeline = sharp(filePath);
     if (!options?.full) {
-      pipeline.resize(400, null, { withoutEnlargement: true });
+      pipeline.resize(THUMBNAIL_WIDTH, null, { withoutEnlargement: true });
     }
     const jpegBuffer = await pipeline.jpeg({ quality }).toBuffer();
     const base64 = jpegBuffer.toString('base64');
@@ -324,7 +333,6 @@ export async function downloadImages(
     // Copy files with progress (async, 4 concurrent copies)
     let copied = 0;
     const errors: string[] = [];
-    const COPY_CONCURRENCY = 4;
     let nextIdx = 0;
 
     const copyNext = async (): Promise<void> => {

--- a/src/main/graviscan/image-handlers.ts
+++ b/src/main/graviscan/image-handlers.ts
@@ -260,9 +260,7 @@ export async function downloadImages(
     });
 
     // Sanitize experiment name for safe use as directory name
-    const safeName = params.experimentName
-      .replace(/[/\\:*?"<>|.]/g, '_')
-      .replace(/\.\./g, '_');
+    const safeName = params.experimentName.replace(/[/\\:*?"<>|.]/g, '_');
     const expDir = path.join(params.targetDir, safeName);
 
     // Group scans by wave number for subfolder organization

--- a/src/main/graviscan/image-handlers.ts
+++ b/src/main/graviscan/image-handlers.ts
@@ -1,0 +1,358 @@
+/**
+ * GraviScan Image Handlers
+ *
+ * Extracted from Ben's monolithic graviscan-handlers.ts.
+ * Handles image operations: output directory, reading scan images,
+ * cloud upload (Box backup), and downloading experiment images.
+ *
+ * Progress events are delivered via callback injection rather than
+ * direct mainWindow.webContents.send() calls, keeping this module
+ * decoupled from Electron IPC plumbing.
+ */
+
+import { app } from 'electron';
+import { PrismaClient } from '@prisma/client';
+import * as path from 'path';
+import * as fs from 'fs';
+import sharp from 'sharp';
+import { resolveGraviScanPath } from '../graviscan-path-utils';
+import { runBoxBackup } from '../box-backup';
+
+// ---------------------------------------------------------------------------
+// Upload concurrency guard
+// ---------------------------------------------------------------------------
+
+let uploadInProgress = false;
+
+/** Reset the upload-in-progress flag (for testing). */
+export function resetUploadState(): void {
+  uploadInProgress = false;
+}
+
+// ---------------------------------------------------------------------------
+// getOutputDir
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the scan output directory path.
+ * Development: .graviscan/ in project root
+ * Production: ~/.bloom/graviscan/
+ */
+export function getOutputDir(): {
+  success: boolean;
+  path?: string;
+  error?: string;
+} {
+  try {
+    const isDev = process.env.NODE_ENV === 'development';
+    let outputDir: string;
+
+    if (isDev) {
+      outputDir = path.join(app.getAppPath(), '.graviscan');
+    } else {
+      const homeDir = app.getPath('home');
+      outputDir = path.join(homeDir, '.bloom', 'graviscan');
+    }
+
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+      console.log('[GraviScan] Created output directory:', outputDir);
+    }
+
+    return { success: true, path: outputDir };
+  } catch (error) {
+    console.error('[GraviScan] Error getting output directory:', error);
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : 'Failed to get output directory',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// readScanImage
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a scan image file and return as base64 data URI.
+ * Converts TIFF to JPEG. Thumbnail: quality 85, 400px resize.
+ * Full: quality 95, no resize.
+ */
+export async function readScanImage(
+  filePath: string,
+  options?: { full?: boolean },
+): Promise<{ success: boolean; dataUri?: string; error?: string }> {
+  try {
+    const resolvedPath = resolveGraviScanPath(filePath);
+    if (!resolvedPath) {
+      console.log(
+        `[read-scan-image] File not found: ${filePath} (tried extensions + _et_ fallback)`,
+      );
+      return { success: false, error: 'File not found' };
+    }
+    if (resolvedPath !== filePath) {
+      console.log(
+        `[read-scan-image] Resolved: ${path.basename(filePath)} -> ${path.basename(resolvedPath)}`,
+      );
+      filePath = resolvedPath;
+    }
+
+    const quality = options?.full ? 95 : 85;
+    const pipeline = sharp(filePath);
+    if (!options?.full) {
+      pipeline.resize(400, null, { withoutEnlargement: true });
+    }
+    const jpegBuffer = await pipeline.jpeg({ quality }).toBuffer();
+    const base64 = jpegBuffer.toString('base64');
+
+    return {
+      success: true,
+      dataUri: `data:image/jpeg;base64,${base64}`,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to read image',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// uploadAllScans
+// ---------------------------------------------------------------------------
+
+/**
+ * Upload all pending/failed scans to Box backup.
+ * Bloom (Supabase) upload is temporarily disabled due to proxy size limit.
+ * Progress events delivered via onProgress callback.
+ */
+export async function uploadAllScans(
+  db: PrismaClient,
+  onProgress?: (progress: unknown) => void,
+): Promise<{
+  success: boolean;
+  uploaded: number;
+  skipped: number;
+  failed: number;
+  errors: string[];
+}> {
+  if (uploadInProgress) {
+    console.log('[GraviScan:UPLOAD] Upload already in progress — skipping');
+    return {
+      success: false,
+      uploaded: 0,
+      skipped: 0,
+      failed: 0,
+      errors: ['Upload already in progress'],
+    };
+  }
+  uploadInProgress = true;
+  try {
+    console.log(
+      '[GraviScan:UPLOAD] Bloom upload disabled (proxy size limit) — Box backup only',
+    );
+
+    const boxResult = await runBoxBackup(db, (progress) => {
+      onProgress?.(progress);
+    });
+
+    console.log('[GraviScan:UPLOAD] Box backup result:', boxResult);
+
+    return {
+      success: boxResult.success,
+      uploaded: boxResult.filesCopied,
+      skipped: 0,
+      failed: boxResult.errors.length,
+      errors: boxResult.errors,
+    };
+  } catch (error) {
+    console.error('[GraviScan:UPLOAD] Error:', error);
+    return {
+      success: false,
+      uploaded: 0,
+      skipped: 0,
+      failed: 0,
+      errors: [error instanceof Error ? error.message : 'Upload failed'],
+    };
+  } finally {
+    uploadInProgress = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// downloadImages
+// ---------------------------------------------------------------------------
+
+/**
+ * Download experiment images to a target directory.
+ * Dialog handling is deferred to the IPC registration layer (3c).
+ * Progress events delivered via onProgress callback.
+ * Copies files with 4-way concurrency.
+ */
+export async function downloadImages(
+  db: PrismaClient,
+  params: {
+    experimentId: string;
+    experimentName: string;
+    targetDir: string;
+    waveNumber?: number;
+  },
+  onProgress?: (progress: {
+    total: number;
+    completed: number;
+    currentFile: string;
+  }) => void,
+): Promise<{
+  success: boolean;
+  total: number;
+  copied: number;
+  errors: string[];
+}> {
+  try {
+    const scans = await (db as any).graviScan.findMany({
+      where: {
+        experiment_id: params.experimentId,
+        deleted: false,
+        ...(params.waveNumber !== undefined && {
+          wave_number: params.waveNumber,
+        }),
+      },
+      include: {
+        images: true,
+        experiment: {
+          include: {
+            accession: {
+              include: { graviPlateAccessions: true },
+            },
+          },
+        },
+      },
+      orderBy: [
+        { wave_number: 'asc' },
+        { capture_date: 'asc' },
+        { plate_index: 'asc' },
+      ],
+    });
+
+    const expDir = path.join(params.targetDir, params.experimentName);
+
+    // Group scans by wave number for subfolder organization
+    const waveGroups = new Map<number, typeof scans>();
+    for (const scan of scans) {
+      const wave = scan.wave_number;
+      if (!waveGroups.has(wave)) waveGroups.set(wave, []);
+      waveGroups.get(wave)!.push(scan);
+    }
+
+    const csvHeader =
+      'experiment,wave_number,plate_barcode,plate_index,grid_mode,capture_date,accession,transplant_date,custom_note,image_filename';
+    const filesToCopy: { src: string; dest: string }[] = [];
+
+    for (const [waveNum, waveScans] of waveGroups) {
+      const waveDir = path.join(expDir, `wave_${waveNum}`);
+      fs.mkdirSync(waveDir, { recursive: true });
+
+      const csvRows: string[] = [csvHeader];
+
+      for (const scan of waveScans) {
+        const plateAccessions =
+          scan.experiment.accession?.graviPlateAccessions ?? [];
+        const matchedPlate = plateAccessions.find(
+          (p: any) => p.plate_id === scan.plate_barcode,
+        );
+        const accession = matchedPlate?.accession ?? '';
+
+        for (const img of scan.images) {
+          const srcPath = resolveGraviScanPath(img.path);
+          if (!srcPath) continue;
+
+          const originalFilename = path.basename(srcPath);
+          filesToCopy.push({
+            src: srcPath,
+            dest: path.join(waveDir, originalFilename),
+          });
+
+          csvRows.push(
+            [
+              params.experimentName,
+              scan.wave_number,
+              scan.plate_barcode ?? '',
+              scan.plate_index,
+              scan.grid_mode,
+              scan.capture_date.toISOString(),
+              accession,
+              (scan as any).transplant_date
+                ? (scan as any).transplant_date.toISOString().split('T')[0]
+                : '',
+              (scan as any).custom_note ?? '',
+              originalFilename,
+            ].join(','),
+          );
+        }
+      }
+
+      // Write metadata.csv per wave subfolder
+      fs.writeFileSync(
+        path.join(waveDir, 'metadata.csv'),
+        csvRows.join('\n') + '\n',
+        'utf-8',
+      );
+    }
+
+    // Copy files with progress (async, 4 concurrent copies)
+    let copied = 0;
+    const errors: string[] = [];
+    const COPY_CONCURRENCY = 4;
+    let nextIdx = 0;
+
+    const copyNext = async (): Promise<void> => {
+      const idx = nextIdx++;
+      if (idx >= filesToCopy.length) return;
+      const file = filesToCopy[idx];
+      try {
+        await fs.promises.copyFile(file.src, file.dest);
+        copied++;
+        onProgress?.({
+          total: filesToCopy.length,
+          completed: copied,
+          currentFile: path.basename(file.dest),
+        });
+      } catch (err) {
+        errors.push(
+          `${path.basename(file.src)}: ${err instanceof Error ? err.message : 'Copy failed'}`,
+        );
+      }
+      return copyNext();
+    };
+
+    await Promise.all(
+      Array.from(
+        { length: Math.min(COPY_CONCURRENCY, filesToCopy.length) },
+        () => copyNext(),
+      ),
+    );
+
+    const waveLabel =
+      params.waveNumber !== undefined ? ` (wave ${params.waveNumber})` : '';
+    console.log(
+      `[GraviScan:DOWNLOAD] Copied ${copied}/${filesToCopy.length} images${waveLabel} to ${expDir}`,
+    );
+    return {
+      success: errors.length === 0,
+      total: filesToCopy.length,
+      copied,
+      errors,
+    };
+  } catch (error) {
+    console.error('[GraviScan:DOWNLOAD] Error:', error);
+    return {
+      success: false,
+      total: 0,
+      copied: 0,
+      errors: [error instanceof Error ? error.message : 'Download failed'],
+    };
+  }
+}

--- a/src/main/graviscan/image-handlers.ts
+++ b/src/main/graviscan/image-handlers.ts
@@ -96,19 +96,19 @@ export function getOutputDir(): {
  */
 export async function readScanImage(
   filePath: string,
-  options?: { full?: boolean },
+  options?: { full?: boolean }
 ): Promise<{ success: boolean; dataUri?: string; error?: string }> {
   try {
     const resolvedPath = resolveGraviScanPath(filePath);
     if (!resolvedPath) {
       console.log(
-        `[read-scan-image] File not found: ${filePath} (tried extensions + _et_ fallback)`,
+        `[read-scan-image] File not found: ${filePath} (tried extensions + _et_ fallback)`
       );
       return { success: false, error: 'File not found' };
     }
     if (resolvedPath !== filePath) {
       console.log(
-        `[read-scan-image] Resolved: ${path.basename(filePath)} -> ${path.basename(resolvedPath)}`,
+        `[read-scan-image] Resolved: ${path.basename(filePath)} -> ${path.basename(resolvedPath)}`
       );
       filePath = resolvedPath;
     }
@@ -144,7 +144,7 @@ export async function readScanImage(
  */
 export async function uploadAllScans(
   db: PrismaClient,
-  onProgress?: (progress: unknown) => void,
+  onProgress?: (progress: unknown) => void
 ): Promise<{
   success: boolean;
   uploaded: number;
@@ -165,7 +165,7 @@ export async function uploadAllScans(
   uploadInProgress = true;
   try {
     console.log(
-      '[GraviScan:UPLOAD] Bloom upload disabled (proxy size limit) — Box backup only',
+      '[GraviScan:UPLOAD] Bloom upload disabled (proxy size limit) — Box backup only'
     );
 
     const boxResult = await runBoxBackup(db, (progress) => {
@@ -217,7 +217,7 @@ export async function downloadImages(
     total: number;
     completed: number;
     currentFile: string;
-  }) => void,
+  }) => void
 ): Promise<{
   success: boolean;
   total: number;
@@ -251,7 +251,9 @@ export async function downloadImages(
     });
 
     // Sanitize experiment name for safe use as directory name
-    const safeName = params.experimentName.replace(/[/\\:*?"<>|.]/g, '_').replace(/\.\./g, '_');
+    const safeName = params.experimentName
+      .replace(/[/\\:*?"<>|.]/g, '_')
+      .replace(/\.\./g, '_');
     const expDir = path.join(params.targetDir, safeName);
 
     // Group scans by wave number for subfolder organization
@@ -276,7 +278,7 @@ export async function downloadImages(
         const plateAccessions =
           scan.experiment.accession?.graviPlateAccessions ?? [];
         const matchedPlate = plateAccessions.find(
-          (p: any) => p.plate_id === scan.plate_barcode,
+          (p: any) => p.plate_id === scan.plate_barcode
         );
         const accession = matchedPlate?.accession ?? '';
 
@@ -302,11 +304,11 @@ export async function downloadImages(
               csvEscape(
                 (scan as any).transplant_date
                   ? (scan as any).transplant_date.toISOString().split('T')[0]
-                  : '',
+                  : ''
               ),
               csvEscape((scan as any).custom_note ?? ''),
               csvEscape(originalFilename),
-            ].join(','),
+            ].join(',')
           );
         }
       }
@@ -315,7 +317,7 @@ export async function downloadImages(
       fs.writeFileSync(
         path.join(waveDir, 'metadata.csv'),
         csvRows.join('\n') + '\n',
-        'utf-8',
+        'utf-8'
       );
     }
 
@@ -339,7 +341,7 @@ export async function downloadImages(
         });
       } catch (err) {
         errors.push(
-          `${path.basename(file.src)}: ${err instanceof Error ? err.message : 'Copy failed'}`,
+          `${path.basename(file.src)}: ${err instanceof Error ? err.message : 'Copy failed'}`
         );
       }
       return copyNext();
@@ -348,14 +350,14 @@ export async function downloadImages(
     await Promise.all(
       Array.from(
         { length: Math.min(COPY_CONCURRENCY, filesToCopy.length) },
-        () => copyNext(),
-      ),
+        () => copyNext()
+      )
     );
 
     const waveLabel =
       params.waveNumber !== undefined ? ` (wave ${params.waveNumber})` : '';
     console.log(
-      `[GraviScan:DOWNLOAD] Copied ${copied}/${filesToCopy.length} images${waveLabel} to ${expDir}`,
+      `[GraviScan:DOWNLOAD] Copied ${copied}/${filesToCopy.length} images${waveLabel} to ${expDir}`
     );
     return {
       success: errors.length === 0,

--- a/src/main/graviscan/image-handlers.ts
+++ b/src/main/graviscan/image-handlers.ts
@@ -325,7 +325,7 @@ export async function downloadImages(
       // Write metadata.csv per wave subfolder
       fs.writeFileSync(
         path.join(waveDir, 'metadata.csv'),
-        csvRows.join('\n') + '\n',
+        '\uFEFF' + csvRows.join('\n') + '\n',
         'utf-8'
       );
     }

--- a/src/main/graviscan/index.ts
+++ b/src/main/graviscan/index.ts
@@ -1,0 +1,34 @@
+/**
+ * GraviScan Handler Modules
+ *
+ * Extracted from PR #138 (origin/graviscan/4-main-process) graviscan-handlers.ts.
+ * Each module exports testable functions — no ipcMain dependency.
+ * IPC wiring happens in Increment 3c (register-handlers.ts).
+ *
+ * IPC channel → function mapping (for 3c reference):
+ *
+ *   graviscan:detect-scanners    → scannerHandlers.detectScanners(db)
+ *   graviscan:get-config         → scannerHandlers.getConfig(db)
+ *   graviscan:save-config        → scannerHandlers.saveConfig(db, config)
+ *   graviscan:save-scanners-db   → scannerHandlers.saveScannersToDB(db, scanners)
+ *   graviscan:platform-info      → scannerHandlers.getPlatformInfo()
+ *   graviscan:validate-scanners  → scannerHandlers.runStartupScannerValidation(db, ids)
+ *   graviscan:validate-config    → scannerHandlers.validateConfig(db)
+ *   graviscan:start-scan         → sessionHandlers.startScan(coordinator, params, fns, onError)
+ *   graviscan:get-scan-status    → sessionHandlers.getScanStatus(fns)
+ *   graviscan:mark-job-recorded  → sessionHandlers.markJobRecorded(fns, key)
+ *   graviscan:cancel-scan        → sessionHandlers.cancelScan(coordinator, fns)
+ *   graviscan:get-output-dir     → imageHandlers.getOutputDir()
+ *   graviscan:read-scan-image    → imageHandlers.readScanImage(path, opts)
+ *   graviscan:upload-all-scans   → imageHandlers.uploadAllScans(db, onProgress)
+ *   graviscan:download-images    → imageHandlers.downloadImages(db, params, onProgress)
+ *
+ * webContents.send channels replaced by callbacks:
+ *   graviscan:scan-error          → onError callback in startScan
+ *   graviscan:box-backup-progress → onProgress callback in uploadAllScans
+ *   graviscan:download-progress   → onProgress callback in downloadImages
+ */
+
+export * from './scanner-handlers';
+export * from './session-handlers';
+export * from './image-handlers';

--- a/src/main/graviscan/scanner-handlers.ts
+++ b/src/main/graviscan/scanner-handlers.ts
@@ -123,7 +123,7 @@ export async function runStartupScannerValidation(
 ): Promise<SessionValidationState> {
   sessionValidation.isValidating = true;
   sessionValidation.validationError = null;
-  sessionValidation.cachedScannerIds = cachedScannerIds;
+  sessionValidation.cachedScannerIds = [...cachedScannerIds];
 
   // If no cached scanners, skip validation (first-time user)
   if (cachedScannerIds.length === 0) {
@@ -432,16 +432,6 @@ export async function getPlatformInfo() {
   try {
     const mockEnabled = process.env.GRAVISCAN_MOCK?.toLowerCase() === 'true';
 
-    if (mockEnabled) {
-      return {
-        success: true,
-        supported: true,
-        backend: 'sane' as const,
-        mock_enabled: true,
-        system_name: process.env.GRAVISCAN_SYSTEM_NAME || null,
-      };
-    }
-
     const platform = process.platform;
     const isSupported = platform === 'linux' || platform === 'win32';
     const backend =
@@ -450,6 +440,16 @@ export async function getPlatformInfo() {
         : platform === 'win32'
           ? 'twain'
           : 'unsupported';
+
+    if (mockEnabled) {
+      return {
+        success: true,
+        supported: true,
+        backend: backend,
+        mock_enabled: true,
+        system_name: process.env.GRAVISCAN_SYSTEM_NAME || null,
+      } as { success: boolean } & GraviScanPlatformInfo;
+    }
 
     return {
       success: true,
@@ -507,7 +507,7 @@ export async function validateConfig(db: PrismaClient) {
         is_available: true,
         vendor_id: s.vendor_id,
         product_id: s.product_id,
-        sane_name: `epkowa:interpreter:001:${String(s.usb_device || i + 1).padStart(3, '0')}`,
+        sane_name: `epkowa:interpreter:${String(s.usb_bus || 1).padStart(3, '0')}:${String(s.usb_device || i + 1).padStart(3, '0')}`,
       }));
     } else {
       const lsusbResult = detectEpsonScanners();

--- a/src/main/graviscan/scanner-handlers.ts
+++ b/src/main/graviscan/scanner-handlers.ts
@@ -45,7 +45,7 @@ const sessionValidation: SessionValidationState = {
  */
 export async function runStartupScannerValidation(
   db: PrismaClient,
-  cachedScannerIds: string[],
+  cachedScannerIds: string[]
 ): Promise<SessionValidationState> {
   sessionValidation.isValidating = true;
   sessionValidation.validationError = null;
@@ -116,14 +116,14 @@ export async function runStartupScannerValidation(
         const match = dbScanners.find(
           (s: any) =>
             s.usb_bus === detected.usb_bus &&
-            s.usb_device === detected.usb_device,
+            s.usb_device === detected.usb_device
         );
         if (match) {
           detected.scanner_id = match.id;
           detected.name = match.name;
         } else {
           const portMatch = dbScanners.find(
-            (s: any) => s.usb_port && s.usb_port === detected.usb_port,
+            (s: any) => s.usb_port && s.usb_port === detected.usb_port
           );
           if (portMatch) {
             detected.scanner_id = portMatch.id;
@@ -137,12 +137,12 @@ export async function runStartupScannerValidation(
 
     // Build set of currently available scanner IDs
     const currentIds = new Set(
-      detectedScanners.filter((s) => s.is_available).map((s) => s.scanner_id),
+      detectedScanners.filter((s) => s.is_available).map((s) => s.scanner_id)
     );
 
     // Check if all cached scanners are still available
     const allScannersAvailable = cachedScannerIds.every((id) =>
-      currentIds.has(id),
+      currentIds.has(id)
     );
 
     sessionValidation.allScannersAvailable = allScannersAvailable;
@@ -261,15 +261,14 @@ export async function detectScanners(db: PrismaClient) {
     for (const detected of detectedScanners) {
       const match = dbScanners.find(
         (s: any) =>
-          s.usb_bus === detected.usb_bus &&
-          s.usb_device === detected.usb_device,
+          s.usb_bus === detected.usb_bus && s.usb_device === detected.usb_device
       );
       if (match) {
         detected.scanner_id = match.id;
         detected.name = match.name;
       } else {
         const portMatch = dbScanners.find(
-          (s: any) => s.usb_port && s.usb_port === detected.usb_port,
+          (s: any) => s.usb_port && s.usb_port === detected.usb_port
         );
         if (portMatch) {
           detected.scanner_id = portMatch.id;
@@ -319,7 +318,10 @@ export async function getConfig(db: PrismaClient) {
 // saveConfig
 // ---------------------------------------------------------------------------
 
-export async function saveConfig(db: PrismaClient, configInput: GraviConfigInput) {
+export async function saveConfig(
+  db: PrismaClient,
+  configInput: GraviConfigInput
+) {
   try {
     const existing = await (db as any).graviConfig.findFirst();
 
@@ -368,7 +370,7 @@ export async function saveScannersToDB(
     usb_port?: string;
     usb_bus?: number;
     usb_device?: number;
-  }>,
+  }>
 ) {
   try {
     const savedScanners: GraviScanner[] = [];
@@ -529,7 +531,10 @@ export async function validateConfig(db: PrismaClient) {
           success: false,
           status: 'error' as const,
           error: lsusbResult.error || 'Scanner detection failed',
-          matched: [] as Array<{ saved: GraviScanner; detected: DetectedScanner }>,
+          matched: [] as Array<{
+            saved: GraviScanner;
+            detected: DetectedScanner;
+          }>,
           missing: [] as GraviScanner[],
           new: [] as DetectedScanner[],
           savedScanners: savedScanners as GraviScanner[],

--- a/src/main/graviscan/scanner-handlers.ts
+++ b/src/main/graviscan/scanner-handlers.ts
@@ -1,0 +1,591 @@
+/**
+ * Scanner handler functions for GraviScan.
+ *
+ * Extracted from Ben's monolithic graviscan-handlers.ts.
+ * Pure async exports with db injection — no ipcMain wrappers.
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { detectEpsonScanners } from '../lsusb-detection';
+import type {
+  DetectedScanner,
+  GraviConfig,
+  GraviConfigInput,
+  GraviScanner,
+  GraviScanPlatformInfo,
+} from '../../types/graviscan';
+
+// ---------------------------------------------------------------------------
+// Session validation state — module-level singleton
+// ---------------------------------------------------------------------------
+
+export interface SessionValidationState {
+  isValidating: boolean;
+  isValidated: boolean;
+  validationError: string | null;
+  detectedScanners: DetectedScanner[];
+  cachedScannerIds: string[];
+  allScannersAvailable: boolean;
+}
+
+const sessionValidation: SessionValidationState = {
+  isValidating: false,
+  isValidated: false,
+  validationError: null,
+  detectedScanners: [],
+  cachedScannerIds: [],
+  allScannersAvailable: false,
+};
+
+/**
+ * Run background scanner validation on app startup.
+ * Compares cached scanner IDs with currently connected scanners.
+ */
+export async function runStartupScannerValidation(
+  db: PrismaClient,
+  cachedScannerIds: string[],
+): Promise<SessionValidationState> {
+  sessionValidation.isValidating = true;
+  sessionValidation.validationError = null;
+  sessionValidation.cachedScannerIds = cachedScannerIds;
+
+  // If no cached scanners, skip validation (first-time user)
+  if (cachedScannerIds.length === 0) {
+    sessionValidation.isValidating = false;
+    sessionValidation.isValidated = false;
+    sessionValidation.allScannersAvailable = false;
+    return sessionValidation;
+  }
+
+  try {
+    const mockEnabled = process.env.GRAVISCAN_MOCK?.toLowerCase() === 'true';
+
+    // Get scanner records from database
+    const dbScanners = await (db as any).graviScanner.findMany({
+      where: { enabled: true },
+    });
+
+    let detectedScanners: DetectedScanner[] = [];
+
+    if (mockEnabled) {
+      const mockCount = 2;
+      for (let i = 0; i < mockCount; i++) {
+        if (i < dbScanners.length) {
+          detectedScanners.push({
+            name: dbScanners[i].name,
+            scanner_id: dbScanners[i].id,
+            usb_bus: 1,
+            usb_device: i + 1,
+            usb_port: `1-${i + 1}`,
+            is_available: true,
+            vendor_id: dbScanners[i].vendor_id,
+            product_id: dbScanners[i].product_id,
+            sane_name: `epkowa:interpreter:001:${String(i + 1).padStart(3, '0')}`,
+          });
+        } else {
+          detectedScanners.push({
+            name: `Mock Scanner ${i + 1}`,
+            scanner_id: `mock-scanner-${i + 1}`,
+            usb_bus: 1,
+            usb_device: i + 1,
+            usb_port: `1-${i + 1}`,
+            is_available: true,
+            vendor_id: '04b8',
+            product_id: '013a',
+            sane_name: `epkowa:interpreter:001:${String(i + 1).padStart(3, '0')}`,
+          });
+        }
+      }
+    } else {
+      const lsusbResult = detectEpsonScanners();
+
+      if (!lsusbResult.success) {
+        sessionValidation.isValidating = false;
+        sessionValidation.isValidated = false;
+        sessionValidation.validationError =
+          lsusbResult.error || 'Scanner detection failed';
+        return sessionValidation;
+      }
+
+      detectedScanners = lsusbResult.scanners;
+
+      // Match detected scanners against DB records
+      for (const detected of detectedScanners) {
+        const match = dbScanners.find(
+          (s: any) =>
+            s.usb_bus === detected.usb_bus &&
+            s.usb_device === detected.usb_device,
+        );
+        if (match) {
+          detected.scanner_id = match.id;
+          detected.name = match.name;
+        } else {
+          const portMatch = dbScanners.find(
+            (s: any) => s.usb_port && s.usb_port === detected.usb_port,
+          );
+          if (portMatch) {
+            detected.scanner_id = portMatch.id;
+            detected.name = portMatch.name;
+          }
+        }
+      }
+    }
+
+    sessionValidation.detectedScanners = detectedScanners;
+
+    // Build set of currently available scanner IDs
+    const currentIds = new Set(
+      detectedScanners.filter((s) => s.is_available).map((s) => s.scanner_id),
+    );
+
+    // Check if all cached scanners are still available
+    const allScannersAvailable = cachedScannerIds.every((id) =>
+      currentIds.has(id),
+    );
+
+    sessionValidation.allScannersAvailable = allScannersAvailable;
+    sessionValidation.isValidated =
+      allScannersAvailable && detectedScanners.length > 0;
+    sessionValidation.isValidating = false;
+
+    if (!allScannersAvailable) {
+      sessionValidation.validationError =
+        'Some previously configured scanners are no longer available';
+    }
+
+    return sessionValidation;
+  } catch (error) {
+    sessionValidation.isValidating = false;
+    sessionValidation.isValidated = false;
+    sessionValidation.validationError =
+      error instanceof Error ? error.message : 'Validation failed';
+    return sessionValidation;
+  }
+}
+
+/**
+ * Get current session validation state.
+ */
+export function getSessionValidationState(): SessionValidationState {
+  return { ...sessionValidation };
+}
+
+/**
+ * Reset session validation (called on app close via IPC from renderer).
+ */
+export function resetSessionValidation(): void {
+  sessionValidation.isValidating = false;
+  sessionValidation.isValidated = false;
+  sessionValidation.validationError = null;
+  sessionValidation.detectedScanners = [];
+  sessionValidation.cachedScannerIds = [];
+  sessionValidation.allScannersAvailable = false;
+}
+
+// ---------------------------------------------------------------------------
+// detectScanners
+// ---------------------------------------------------------------------------
+
+export async function detectScanners(db: PrismaClient) {
+  try {
+    const mockEnabled = process.env.GRAVISCAN_MOCK?.toLowerCase() === 'true';
+
+    // Get scanner records from database
+    const dbScanners = await (db as any).graviScanner.findMany({
+      where: { enabled: true },
+    });
+
+    let detectedScanners: DetectedScanner[];
+
+    if (mockEnabled) {
+      const mockCount = 2;
+      detectedScanners = [];
+
+      for (let i = 0; i < mockCount; i++) {
+        if (i < dbScanners.length) {
+          detectedScanners.push({
+            name: dbScanners[i].name,
+            scanner_id: dbScanners[i].id,
+            usb_bus: 1,
+            usb_device: i + 1,
+            usb_port: `1-${i + 1}`,
+            is_available: true,
+            vendor_id: dbScanners[i].vendor_id,
+            product_id: dbScanners[i].product_id,
+            sane_name: `epkowa:interpreter:001:${String(i + 1).padStart(3, '0')}`,
+          });
+        } else {
+          detectedScanners.push({
+            name: `Mock Scanner ${i + 1}`,
+            scanner_id: `mock-scanner-${i + 1}`,
+            usb_bus: 1,
+            usb_device: i + 1,
+            usb_port: `1-${i + 1}`,
+            is_available: true,
+            vendor_id: '04b8',
+            product_id: '013a',
+            sane_name: `epkowa:interpreter:001:${String(i + 1).padStart(3, '0')}`,
+          });
+        }
+      }
+
+      return {
+        success: true,
+        scanners: detectedScanners,
+        count: detectedScanners.length,
+        mock: true,
+      };
+    }
+
+    // Real mode: detect via lsusb
+    const lsusbResult = detectEpsonScanners();
+
+    if (!lsusbResult.success) {
+      return {
+        success: false,
+        error: lsusbResult.error,
+        scanners: [] as DetectedScanner[],
+        count: 0,
+      };
+    }
+
+    detectedScanners = lsusbResult.scanners;
+
+    // Match detected scanners against DB records by usb_bus + usb_device
+    for (const detected of detectedScanners) {
+      const match = dbScanners.find(
+        (s: any) =>
+          s.usb_bus === detected.usb_bus &&
+          s.usb_device === detected.usb_device,
+      );
+      if (match) {
+        detected.scanner_id = match.id;
+        detected.name = match.name;
+      } else {
+        const portMatch = dbScanners.find(
+          (s: any) => s.usb_port && s.usb_port === detected.usb_port,
+        );
+        if (portMatch) {
+          detected.scanner_id = portMatch.id;
+          detected.name = portMatch.name;
+        } else {
+          detected.scanner_id = `new:${detected.usb_bus}:${detected.usb_device}`;
+        }
+      }
+    }
+
+    return {
+      success: true,
+      scanners: detectedScanners,
+      count: detectedScanners.length,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Detection failed',
+      scanners: [] as DetectedScanner[],
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getConfig
+// ---------------------------------------------------------------------------
+
+export async function getConfig(db: PrismaClient) {
+  try {
+    const config = await (db as any).graviConfig.findFirst();
+    return {
+      success: true,
+      config: config as GraviConfig | null,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to get config',
+      config: null as GraviConfig | null,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// saveConfig
+// ---------------------------------------------------------------------------
+
+export async function saveConfig(db: PrismaClient, configInput: GraviConfigInput) {
+  try {
+    const existing = await (db as any).graviConfig.findFirst();
+
+    let config: GraviConfig;
+    if (existing) {
+      config = (await (db as any).graviConfig.update({
+        where: { id: existing.id },
+        data: {
+          grid_mode: configInput.grid_mode,
+          resolution: configInput.resolution,
+        },
+      })) as GraviConfig;
+    } else {
+      config = (await (db as any).graviConfig.create({
+        data: {
+          grid_mode: configInput.grid_mode,
+          resolution: configInput.resolution,
+          format: 'tiff',
+        },
+      })) as GraviConfig;
+    }
+
+    return {
+      success: true,
+      config,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to save config',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// saveScannersToDB
+// ---------------------------------------------------------------------------
+
+export async function saveScannersToDB(
+  db: PrismaClient,
+  scanners: Array<{
+    name: string;
+    display_name?: string | null;
+    vendor_id: string;
+    product_id: string;
+    usb_port?: string;
+    usb_bus?: number;
+    usb_device?: number;
+  }>,
+) {
+  try {
+    const savedScanners: GraviScanner[] = [];
+
+    for (const scanner of scanners) {
+      // Look up existing scanner by USB bus + device (unique physical identifier)
+      let existing: GraviScanner | null = null;
+      if (scanner.usb_bus != null && scanner.usb_device != null) {
+        existing = (await (db as any).graviScanner.findFirst({
+          where: {
+            usb_bus: scanner.usb_bus,
+            usb_device: scanner.usb_device,
+          },
+        })) as GraviScanner | null;
+      }
+      // Fallback: match by usb_port (stable across replug, unlike usb_device)
+      if (!existing && scanner.usb_port) {
+        existing = (await (db as any).graviScanner.findFirst({
+          where: { usb_port: scanner.usb_port },
+        })) as GraviScanner | null;
+      }
+
+      if (existing) {
+        const updated = await (db as any).graviScanner.update({
+          where: { id: existing.id },
+          data: {
+            name: scanner.name,
+            display_name: scanner.display_name ?? existing.display_name ?? null,
+            vendor_id: scanner.vendor_id,
+            product_id: scanner.product_id,
+            usb_port: scanner.usb_port || null,
+            usb_bus: scanner.usb_bus || null,
+            usb_device: scanner.usb_device || null,
+          },
+        });
+        savedScanners.push(updated as GraviScanner);
+      } else {
+        const created = await (db as any).graviScanner.create({
+          data: {
+            name: scanner.name,
+            display_name: scanner.display_name || null,
+            vendor_id: scanner.vendor_id,
+            product_id: scanner.product_id,
+            usb_port: scanner.usb_port || null,
+            usb_bus: scanner.usb_bus || null,
+            usb_device: scanner.usb_device || null,
+            enabled: true,
+          },
+        });
+        savedScanners.push(created as GraviScanner);
+      }
+    }
+
+    return {
+      success: true,
+      scanners: savedScanners,
+      count: savedScanners.length,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to save scanners',
+      scanners: [] as GraviScanner[],
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getPlatformInfo
+// ---------------------------------------------------------------------------
+
+export async function getPlatformInfo() {
+  try {
+    const mockEnabled = process.env.GRAVISCAN_MOCK?.toLowerCase() === 'true';
+
+    if (mockEnabled) {
+      return {
+        success: true,
+        supported: true,
+        backend: 'sane' as const,
+        mock_enabled: true,
+        system_name: process.env.GRAVISCAN_SYSTEM_NAME || null,
+      };
+    }
+
+    const platform = process.platform;
+    const isSupported = platform === 'linux' || platform === 'win32';
+    const backend =
+      platform === 'linux'
+        ? 'sane'
+        : platform === 'win32'
+          ? 'twain'
+          : 'unsupported';
+
+    return {
+      success: true,
+      supported: isSupported,
+      backend: backend,
+      mock_enabled: mockEnabled,
+      system_name: process.env.GRAVISCAN_SYSTEM_NAME || null,
+    } as { success: boolean } & GraviScanPlatformInfo;
+  } catch (error) {
+    return {
+      success: false,
+      supported: false,
+      backend: 'unsupported',
+      mock_enabled: false,
+    } as { success: boolean } & GraviScanPlatformInfo;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// validateConfig
+// ---------------------------------------------------------------------------
+
+export async function validateConfig(db: PrismaClient) {
+  try {
+    // 1. Load saved scanners from database
+    const savedScanners = await (db as any).graviScanner.findMany({
+      where: { enabled: true },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    // If no saved scanners, return no-config status
+    if (savedScanners.length === 0) {
+      return {
+        success: true,
+        status: 'no-config' as const,
+        matched: [],
+        missing: [],
+        new: [],
+        savedScanners: [],
+        detectedScanners: [],
+      };
+    }
+
+    // 2. Detect currently connected scanners via lsusb
+    const mockEnabled = process.env.GRAVISCAN_MOCK?.toLowerCase() === 'true';
+    let detectedScanners: DetectedScanner[] = [];
+
+    if (mockEnabled) {
+      detectedScanners = savedScanners.map((s: any, i: number) => ({
+        name: s.name,
+        scanner_id: s.id,
+        usb_bus: s.usb_bus || 1,
+        usb_device: s.usb_device || i + 1,
+        usb_port: s.usb_port || `1-${i + 1}`,
+        is_available: true,
+        vendor_id: s.vendor_id,
+        product_id: s.product_id,
+        sane_name: `epkowa:interpreter:001:${String(s.usb_device || i + 1).padStart(3, '0')}`,
+      }));
+    } else {
+      const lsusbResult = detectEpsonScanners();
+
+      if (!lsusbResult.success) {
+        return {
+          success: false,
+          status: 'error' as const,
+          error: lsusbResult.error || 'Scanner detection failed',
+          matched: [] as Array<{ saved: GraviScanner; detected: DetectedScanner }>,
+          missing: [] as GraviScanner[],
+          new: [] as DetectedScanner[],
+          savedScanners: savedScanners as GraviScanner[],
+          detectedScanners: [] as DetectedScanner[],
+        };
+      }
+
+      detectedScanners = lsusbResult.scanners;
+    }
+
+    // 3. Match by usb_port
+    const detectedByPort = new Map<string, DetectedScanner>();
+    for (const detected of detectedScanners) {
+      if (detected.usb_port) {
+        detectedByPort.set(detected.usb_port, detected);
+      }
+    }
+
+    const matched: Array<{ saved: GraviScanner; detected: DetectedScanner }> =
+      [];
+    const missing: GraviScanner[] = [];
+
+    for (const saved of savedScanners) {
+      if (saved.usb_port && detectedByPort.has(saved.usb_port)) {
+        const detected = detectedByPort.get(saved.usb_port)!;
+        matched.push({ saved: saved as GraviScanner, detected });
+        detectedByPort.delete(saved.usb_port);
+      } else {
+        missing.push(saved as GraviScanner);
+      }
+    }
+
+    // Remaining detected scanners are "new" (not in saved config)
+    const newScanners = Array.from(detectedByPort.values());
+
+    // Determine status
+    const isValid =
+      missing.length === 0 && newScanners.length === 0 && matched.length > 0;
+    const status = isValid
+      ? 'valid'
+      : missing.length > 0 || newScanners.length > 0
+        ? 'mismatch'
+        : 'no-config';
+
+    return {
+      success: true,
+      status: status as 'valid' | 'mismatch' | 'no-config',
+      matched,
+      missing,
+      new: newScanners,
+      savedScanners: savedScanners as GraviScanner[],
+      detectedScanners,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      status: 'error' as const,
+      error: error instanceof Error ? error.message : 'Validation failed',
+      matched: [] as Array<{ saved: GraviScanner; detected: DetectedScanner }>,
+      missing: [] as GraviScanner[],
+      new: [] as DetectedScanner[],
+      savedScanners: [] as GraviScanner[],
+      detectedScanners: [] as DetectedScanner[],
+    };
+  }
+}

--- a/src/main/graviscan/scanner-handlers.ts
+++ b/src/main/graviscan/scanner-handlers.ts
@@ -169,7 +169,11 @@ export async function runStartupScannerValidation(
  * Get current session validation state.
  */
 export function getSessionValidationState(): SessionValidationState {
-  return { ...sessionValidation };
+  return {
+    ...sessionValidation,
+    detectedScanners: [...sessionValidation.detectedScanners],
+    cachedScannerIds: [...sessionValidation.cachedScannerIds],
+  };
 }
 
 /**
@@ -286,6 +290,7 @@ export async function detectScanners(db: PrismaClient) {
       success: false,
       error: error instanceof Error ? error.message : 'Detection failed',
       scanners: [] as DetectedScanner[],
+      count: 0,
     };
   }
 }

--- a/src/main/graviscan/scanner-handlers.ts
+++ b/src/main/graviscan/scanner-handlers.ts
@@ -18,6 +18,80 @@ import type {
 } from '../../types/graviscan';
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MOCK_SCANNER_COUNT = 2;
+
+// ---------------------------------------------------------------------------
+// Helpers — mock-scanner construction & DB matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Build mock DetectedScanner objects from DB records (or generate fakes when
+ * there are fewer DB records than MOCK_SCANNER_COUNT).
+ */
+function buildMockScanners(dbScanners: any[]): DetectedScanner[] {
+  const scanners: DetectedScanner[] = [];
+  for (let i = 0; i < MOCK_SCANNER_COUNT; i++) {
+    if (i < dbScanners.length) {
+      scanners.push({
+        name: dbScanners[i].name,
+        scanner_id: dbScanners[i].id,
+        usb_bus: 1,
+        usb_device: i + 1,
+        usb_port: `1-${i + 1}`,
+        is_available: true,
+        vendor_id: dbScanners[i].vendor_id,
+        product_id: dbScanners[i].product_id,
+        sane_name: `epkowa:interpreter:001:${String(i + 1).padStart(3, '0')}`,
+      });
+    } else {
+      scanners.push({
+        name: `Mock Scanner ${i + 1}`,
+        scanner_id: `mock-scanner-${i + 1}`,
+        usb_bus: 1,
+        usb_device: i + 1,
+        usb_port: `1-${i + 1}`,
+        is_available: true,
+        vendor_id: '04b8',
+        product_id: '013a',
+        sane_name: `epkowa:interpreter:001:${String(i + 1).padStart(3, '0')}`,
+      });
+    }
+  }
+  return scanners;
+}
+
+/**
+ * Match detected scanners to DB records by USB bus+device, falling back to
+ * usb_port. Mutates `detectedScanners` in-place (sets scanner_id and name).
+ */
+function matchDetectedToDb(
+  detectedScanners: DetectedScanner[],
+  dbScanners: any[]
+): void {
+  for (const detected of detectedScanners) {
+    const match = dbScanners.find(
+      (s: any) =>
+        s.usb_bus === detected.usb_bus && s.usb_device === detected.usb_device
+    );
+    if (match) {
+      detected.scanner_id = match.id;
+      detected.name = match.name;
+    } else {
+      const portMatch = dbScanners.find(
+        (s: any) => s.usb_port && s.usb_port === detected.usb_port
+      );
+      if (portMatch) {
+        detected.scanner_id = portMatch.id;
+        detected.name = portMatch.name;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Session validation state — module-level singleton
 // ---------------------------------------------------------------------------
 
@@ -70,34 +144,7 @@ export async function runStartupScannerValidation(
     let detectedScanners: DetectedScanner[] = [];
 
     if (mockEnabled) {
-      const mockCount = 2;
-      for (let i = 0; i < mockCount; i++) {
-        if (i < dbScanners.length) {
-          detectedScanners.push({
-            name: dbScanners[i].name,
-            scanner_id: dbScanners[i].id,
-            usb_bus: 1,
-            usb_device: i + 1,
-            usb_port: `1-${i + 1}`,
-            is_available: true,
-            vendor_id: dbScanners[i].vendor_id,
-            product_id: dbScanners[i].product_id,
-            sane_name: `epkowa:interpreter:001:${String(i + 1).padStart(3, '0')}`,
-          });
-        } else {
-          detectedScanners.push({
-            name: `Mock Scanner ${i + 1}`,
-            scanner_id: `mock-scanner-${i + 1}`,
-            usb_bus: 1,
-            usb_device: i + 1,
-            usb_port: `1-${i + 1}`,
-            is_available: true,
-            vendor_id: '04b8',
-            product_id: '013a',
-            sane_name: `epkowa:interpreter:001:${String(i + 1).padStart(3, '0')}`,
-          });
-        }
-      }
+      detectedScanners = buildMockScanners(dbScanners);
     } else {
       const lsusbResult = detectEpsonScanners();
 
@@ -110,27 +157,7 @@ export async function runStartupScannerValidation(
       }
 
       detectedScanners = lsusbResult.scanners;
-
-      // Match detected scanners against DB records
-      for (const detected of detectedScanners) {
-        const match = dbScanners.find(
-          (s: any) =>
-            s.usb_bus === detected.usb_bus &&
-            s.usb_device === detected.usb_device
-        );
-        if (match) {
-          detected.scanner_id = match.id;
-          detected.name = match.name;
-        } else {
-          const portMatch = dbScanners.find(
-            (s: any) => s.usb_port && s.usb_port === detected.usb_port
-          );
-          if (portMatch) {
-            detected.scanner_id = portMatch.id;
-            detected.name = portMatch.name;
-          }
-        }
-      }
+      matchDetectedToDb(detectedScanners, dbScanners);
     }
 
     sessionValidation.detectedScanners = detectedScanners;
@@ -204,36 +231,7 @@ export async function detectScanners(db: PrismaClient) {
     let detectedScanners: DetectedScanner[];
 
     if (mockEnabled) {
-      const mockCount = 2;
-      detectedScanners = [];
-
-      for (let i = 0; i < mockCount; i++) {
-        if (i < dbScanners.length) {
-          detectedScanners.push({
-            name: dbScanners[i].name,
-            scanner_id: dbScanners[i].id,
-            usb_bus: 1,
-            usb_device: i + 1,
-            usb_port: `1-${i + 1}`,
-            is_available: true,
-            vendor_id: dbScanners[i].vendor_id,
-            product_id: dbScanners[i].product_id,
-            sane_name: `epkowa:interpreter:001:${String(i + 1).padStart(3, '0')}`,
-          });
-        } else {
-          detectedScanners.push({
-            name: `Mock Scanner ${i + 1}`,
-            scanner_id: `mock-scanner-${i + 1}`,
-            usb_bus: 1,
-            usb_device: i + 1,
-            usb_port: `1-${i + 1}`,
-            is_available: true,
-            vendor_id: '04b8',
-            product_id: '013a',
-            sane_name: `epkowa:interpreter:001:${String(i + 1).padStart(3, '0')}`,
-          });
-        }
-      }
+      detectedScanners = buildMockScanners(dbScanners);
 
       return {
         success: true,
@@ -258,24 +256,12 @@ export async function detectScanners(db: PrismaClient) {
     detectedScanners = lsusbResult.scanners;
 
     // Match detected scanners against DB records by usb_bus + usb_device
+    matchDetectedToDb(detectedScanners, dbScanners);
+
+    // Tag any still-unmatched scanners as new
     for (const detected of detectedScanners) {
-      const match = dbScanners.find(
-        (s: any) =>
-          s.usb_bus === detected.usb_bus && s.usb_device === detected.usb_device
-      );
-      if (match) {
-        detected.scanner_id = match.id;
-        detected.name = match.name;
-      } else {
-        const portMatch = dbScanners.find(
-          (s: any) => s.usb_port && s.usb_port === detected.usb_port
-        );
-        if (portMatch) {
-          detected.scanner_id = portMatch.id;
-          detected.name = portMatch.name;
-        } else {
-          detected.scanner_id = `new:${detected.usb_bus}:${detected.usb_device}`;
-        }
+      if (!detected.scanner_id) {
+        detected.scanner_id = `new:${detected.usb_bus}:${detected.usb_device}`;
       }
     }
 

--- a/src/main/graviscan/scanner-handlers.ts
+++ b/src/main/graviscan/scanner-handlers.ts
@@ -463,7 +463,7 @@ export async function getPlatformInfo() {
       mock_enabled: mockEnabled,
       system_name: process.env.GRAVISCAN_SYSTEM_NAME || null,
     } as { success: boolean } & GraviScanPlatformInfo;
-  } catch (error) {
+  } catch (_error) {
     return {
       success: false,
       supported: false,

--- a/src/main/graviscan/scanner-handlers.ts
+++ b/src/main/graviscan/scanner-handlers.ts
@@ -5,6 +5,8 @@
  * Pure async exports with db injection — no ipcMain wrappers.
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { PrismaClient } from '@prisma/client';
 import { detectEpsonScanners } from '../lsusb-detection';
 import type {
@@ -463,7 +465,7 @@ export async function getPlatformInfo() {
       mock_enabled: mockEnabled,
       system_name: process.env.GRAVISCAN_SYSTEM_NAME || null,
     } as { success: boolean } & GraviScanPlatformInfo;
-  } catch (_error) {
+  } catch {
     return {
       success: false,
       supported: false,

--- a/src/main/graviscan/session-handlers.ts
+++ b/src/main/graviscan/session-handlers.ts
@@ -1,0 +1,250 @@
+/**
+ * GraviScan Session Handlers
+ *
+ * Extracted from Ben's monolithic graviscan-handlers.ts.
+ * Manages scan lifecycle: start, status, mark-recorded, cancel.
+ */
+
+// ---------------------------------------------------------------------------
+// Local interface types (will move to shared types in a later increment)
+// ---------------------------------------------------------------------------
+
+export interface ScanCoordinatorLike {
+  readonly isScanning: boolean;
+  initialize(scanners: ScannerConfig[]): Promise<void>;
+  scanOnce(platesPerScanner: Map<string, PlateConfig[]>): Promise<void>;
+  scanInterval(
+    platesPerScanner: Map<string, PlateConfig[]>,
+    intervalMs: number,
+    durationMs: number,
+  ): Promise<void>;
+  cancelAll(): void;
+  shutdown(): Promise<void>;
+  on(event: string, listener: (...args: any[]) => void): this;
+}
+
+export interface ScannerConfig {
+  scannerId: string;
+  saneName: string;
+  plates: PlateConfig[];
+}
+
+export interface PlateConfig {
+  plate_index: string;
+  grid_mode: string;
+  resolution: number;
+  output_path: string;
+}
+
+export interface SessionFns {
+  getScanSession: () => any;
+  setScanSession: (session: any) => void;
+  markScanJobRecorded: (jobKey: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Param types
+// ---------------------------------------------------------------------------
+
+interface StartScanParams {
+  scanners: Array<{
+    scannerId: string;
+    saneName: string;
+    plates: (PlateConfig & { plate_barcode?: string | null })[];
+  }>;
+  interval?: { intervalSeconds: number; durationSeconds: number };
+  metadata?: {
+    experimentId: string;
+    phenotyperId: string;
+    resolution: number;
+    sessionId?: string;
+    waveNumber?: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// startScan
+// ---------------------------------------------------------------------------
+
+export async function startScan(
+  coordinator: ScanCoordinatorLike | null,
+  params: StartScanParams,
+  sessionFns: SessionFns,
+  onError?: (error: string) => void,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    if (!coordinator) {
+      return { success: false, error: 'ScanCoordinator not initialized' };
+    }
+
+    if (coordinator.isScanning) {
+      return { success: false, error: 'Scan already in progress' };
+    }
+
+    // Build jobs map
+    const jobs: Record<
+      string,
+      {
+        scannerId: string;
+        plateIndex: string;
+        outputPath: string;
+        plantBarcode: string | null;
+        transplantDate: string | null;
+        customNote: string | null;
+        gridMode: string;
+        status: 'pending' | 'scanning' | 'complete' | 'error';
+        imagePath?: string;
+        error?: string;
+        durationMs?: number;
+      }
+    > = {};
+
+    for (const s of params.scanners) {
+      for (const plate of s.plates) {
+        const key = `${s.scannerId}:${plate.plate_index}`;
+        jobs[key] = {
+          scannerId: s.scannerId,
+          plateIndex: plate.plate_index,
+          outputPath: plate.output_path,
+          plantBarcode: plate.plate_barcode ?? null,
+          transplantDate: null,
+          customNote: null,
+          gridMode: plate.grid_mode,
+          status: 'pending',
+        };
+      }
+    }
+
+    const sessIntervalMs = params.interval
+      ? params.interval.intervalSeconds * 1000
+      : 0;
+    const sessDurationMs = params.interval
+      ? params.interval.durationSeconds * 1000
+      : 0;
+
+    sessionFns.setScanSession({
+      isActive: true,
+      isContinuous: !!params.interval,
+      experimentId: params.metadata?.experimentId || '',
+      phenotyperId: params.metadata?.phenotyperId || '',
+      resolution: params.metadata?.resolution || 300,
+      sessionId: params.metadata?.sessionId || null,
+      jobs,
+      currentCycle: 0,
+      totalCycles:
+        sessIntervalMs > 0 ? Math.ceil(sessDurationMs / sessIntervalMs) : 1,
+      intervalMs: sessIntervalMs,
+      scanStartedAt: Date.now(),
+      scanDurationMs: sessDurationMs,
+      coordinatorState: 'scanning',
+      nextScanAt: null,
+      waveNumber: params.metadata?.waveNumber || 0,
+    });
+
+    // Build scanner configs for coordinator initialization
+    const scannerConfigs: ScannerConfig[] = params.scanners.map((s) => ({
+      scannerId: s.scannerId,
+      saneName: s.saneName,
+      plates: s.plates,
+    }));
+
+    await coordinator.initialize(scannerConfigs);
+
+    // Build plates map for scanning
+    const platesPerScanner = new Map<string, PlateConfig[]>();
+    for (const s of params.scanners) {
+      platesPerScanner.set(s.scannerId, s.plates);
+    }
+
+    const handleError = (err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      sessionFns.setScanSession(null);
+      onError?.(message);
+    };
+
+    if (params.interval) {
+      const intervalMs = params.interval.intervalSeconds * 1000;
+      const durationMs = params.interval.durationSeconds * 1000;
+      coordinator
+        .scanInterval(platesPerScanner, intervalMs, durationMs)
+        .catch(handleError);
+    } else {
+      coordinator.scanOnce(platesPerScanner).catch(handleError);
+    }
+
+    return { success: true };
+  } catch (error) {
+    sessionFns.setScanSession(null);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Start scan failed',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getScanStatus
+// ---------------------------------------------------------------------------
+
+export function getScanStatus(
+  sessionFns: SessionFns,
+): Record<string, any> {
+  const session = sessionFns.getScanSession();
+  if (!session) {
+    return { isActive: false };
+  }
+  return {
+    isActive: session.isActive,
+    experimentId: session.experimentId,
+    phenotyperId: session.phenotyperId,
+    resolution: session.resolution,
+    sessionId: session.sessionId,
+    jobs: session.jobs,
+    isContinuous: session.isContinuous,
+    currentCycle: session.currentCycle,
+    totalCycles: session.totalCycles,
+    intervalMs: session.intervalMs,
+    scanStartedAt: session.scanStartedAt,
+    scanDurationMs: session.scanDurationMs,
+    coordinatorState: session.coordinatorState,
+    nextScanAt: session.nextScanAt,
+    waveNumber: session.waveNumber,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// markJobRecorded
+// ---------------------------------------------------------------------------
+
+export function markJobRecorded(
+  sessionFns: SessionFns,
+  jobKey: string,
+): void {
+  sessionFns.markScanJobRecorded(jobKey);
+}
+
+// ---------------------------------------------------------------------------
+// cancelScan
+// ---------------------------------------------------------------------------
+
+export async function cancelScan(
+  coordinator: ScanCoordinatorLike | null,
+  sessionFns: SessionFns,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    if (!coordinator) {
+      return { success: false, error: 'ScanCoordinator not initialized' };
+    }
+
+    coordinator.cancelAll();
+    await coordinator.shutdown();
+    sessionFns.setScanSession(null);
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Cancel failed',
+    };
+  }
+}

--- a/src/main/graviscan/session-handlers.ts
+++ b/src/main/graviscan/session-handlers.ts
@@ -18,7 +18,7 @@ export interface ScanCoordinatorLike {
   scanInterval(
     platesPerScanner: Map<string, PlateConfig[]>,
     intervalMs: number,
-    durationMs: number,
+    durationMs: number
   ): Promise<void>;
   cancelAll(): void;
   shutdown(): Promise<void>;
@@ -72,7 +72,7 @@ export async function startScan(
   coordinator: ScanCoordinatorLike | null,
   params: StartScanParams,
   sessionFns: SessionFns,
-  onError?: (error: string) => void,
+  onError?: (error: string) => void
 ): Promise<{ success: boolean; error?: string }> {
   try {
     if (!coordinator) {
@@ -188,9 +188,7 @@ export async function startScan(
 // getScanStatus
 // ---------------------------------------------------------------------------
 
-export function getScanStatus(
-  sessionFns: SessionFns,
-): Record<string, any> {
+export function getScanStatus(sessionFns: SessionFns): Record<string, any> {
   const session = sessionFns.getScanSession();
   if (!session) {
     return { isActive: false };
@@ -218,10 +216,7 @@ export function getScanStatus(
 // markJobRecorded
 // ---------------------------------------------------------------------------
 
-export function markJobRecorded(
-  sessionFns: SessionFns,
-  jobKey: string,
-): void {
+export function markJobRecorded(sessionFns: SessionFns, jobKey: string): void {
   sessionFns.markScanJobRecorded(jobKey);
 }
 
@@ -231,7 +226,7 @@ export function markJobRecorded(
 
 export async function cancelScan(
   coordinator: ScanCoordinatorLike | null,
-  sessionFns: SessionFns,
+  sessionFns: SessionFns
 ): Promise<{ success: boolean; error?: string }> {
   try {
     if (!coordinator) {

--- a/src/main/graviscan/session-handlers.ts
+++ b/src/main/graviscan/session-handlers.ts
@@ -239,6 +239,8 @@ export async function cancelScan(
 
     return { success: true };
   } catch (error) {
+    // Always clear session — even if shutdown fails, the scan is cancelled
+    sessionFns.setScanSession(null);
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Cancel failed',

--- a/src/main/graviscan/session-handlers.ts
+++ b/src/main/graviscan/session-handlers.ts
@@ -5,6 +5,8 @@
  * Manages scan lifecycle: start, status, mark-recorded, cancel.
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 // ---------------------------------------------------------------------------
 // Local interface types (will move to shared types in a later increment)
 // ---------------------------------------------------------------------------

--- a/src/main/graviscan/session-handlers.ts
+++ b/src/main/graviscan/session-handlers.ts
@@ -84,6 +84,18 @@ export async function startScan(
       return { success: false, error: 'Scan already in progress' };
     }
 
+    if (params.interval) {
+      if (
+        params.interval.intervalSeconds <= 0 ||
+        params.interval.durationSeconds <= 0
+      ) {
+        return {
+          success: false,
+          error: 'Interval and duration must be positive',
+        };
+      }
+    }
+
     // Build jobs map
     const jobs: Record<
       string,

--- a/src/main/graviscan/session-handlers.ts
+++ b/src/main/graviscan/session-handlers.ts
@@ -74,6 +74,7 @@ export async function startScan(
   sessionFns: SessionFns,
   onError?: (error: string) => void
 ): Promise<{ success: boolean; error?: string }> {
+  let sessionSet = false;
   try {
     if (!coordinator) {
       return { success: false, error: 'ScanCoordinator not initialized' };
@@ -124,6 +125,17 @@ export async function startScan(
       ? params.interval.durationSeconds * 1000
       : 0;
 
+    // Build scanner configs for coordinator initialization
+    const scannerConfigs: ScannerConfig[] = params.scanners.map((s) => ({
+      scannerId: s.scannerId,
+      saneName: s.saneName,
+      plates: s.plates,
+    }));
+
+    await coordinator.initialize(scannerConfigs);
+
+    // Only set session state AFTER initialize succeeds — avoids briefly
+    // reporting an active scan while the coordinator is still starting up.
     sessionFns.setScanSession({
       isActive: true,
       isContinuous: !!params.interval,
@@ -142,15 +154,7 @@ export async function startScan(
       nextScanAt: null,
       waveNumber: params.metadata?.waveNumber || 0,
     });
-
-    // Build scanner configs for coordinator initialization
-    const scannerConfigs: ScannerConfig[] = params.scanners.map((s) => ({
-      scannerId: s.scannerId,
-      saneName: s.saneName,
-      plates: s.plates,
-    }));
-
-    await coordinator.initialize(scannerConfigs);
+    sessionSet = true;
 
     // Build plates map for scanning
     const platesPerScanner = new Map<string, PlateConfig[]>();
@@ -176,7 +180,9 @@ export async function startScan(
 
     return { success: true };
   } catch (error) {
-    sessionFns.setScanSession(null);
+    if (sessionSet) {
+      sessionFns.setScanSession(null);
+    }
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Start scan failed',

--- a/src/main/lsusb-detection.ts
+++ b/src/main/lsusb-detection.ts
@@ -1,0 +1,221 @@
+/**
+ * lsusb-based scanner detection.
+ *
+ * Detects Epson scanners using `lsusb` system commands instead of SANE.
+ * This avoids SANE's process-wide global state issues and device lock contamination.
+ *
+ * Two commands are used:
+ * - `lsusb` — lists USB devices with bus/device/vendor/product
+ * - `lsusb -t` — tree view with stable port numbers
+ */
+
+import { execFileSync } from 'child_process';
+import type { DetectedScanner } from '../types/graviscan';
+
+/** Epson vendor ID */
+const EPSON_VENDOR_ID = '04b8';
+
+/** Known Epson scanner product IDs → model names */
+const EPSON_MODELS: Record<string, string> = {
+  '013a': 'Perfection V600 Photo',
+  '0144': 'Perfection V850 Pro',
+};
+
+interface LsusbDevice {
+  bus: number;
+  device: number;
+  vendorId: string;
+  productId: string;
+}
+
+interface LsusbTreeEntry {
+  bus: number;
+  port: number;
+  device: number;
+}
+
+/**
+ * Parse `lsusb` output for Epson scanners.
+ *
+ * Example line: Bus 001 Device 007: ID 04b8:013a EPSON EPSON Scanner
+ */
+function parseLsusb(output: string): LsusbDevice[] {
+  const devices: LsusbDevice[] = [];
+  const regex = /Bus (\d+) Device (\d+): ID ([0-9a-f]{4}):([0-9a-f]{4})/gi;
+
+  let match;
+  while ((match = regex.exec(output)) !== null) {
+    const vendorId = match[3].toLowerCase();
+    const productId = match[4].toLowerCase();
+    // Filter by vendor AND known scanner product IDs — ignore Epson printers etc.
+    if (vendorId === EPSON_VENDOR_ID && productId in EPSON_MODELS) {
+      devices.push({
+        bus: parseInt(match[1], 10),
+        device: parseInt(match[2], 10),
+        vendorId,
+        productId,
+      });
+    }
+  }
+
+  return devices;
+}
+
+/**
+ * Parse `lsusb -t` output to map Bus:Device → Port for stable identification.
+ *
+ * Example output:
+ *   /:  Bus 001.Port 001: Dev 001, ...
+ *       |__ Port 001: Dev 007, ...
+ *       |__ Port 009: Dev 013, ...
+ */
+function parseLsusbTree(output: string): LsusbTreeEntry[] {
+  const entries: LsusbTreeEntry[] = [];
+  let currentBus = 0;
+
+  for (const line of output.split('\n')) {
+    // Match bus root: "/:  Bus 001.Port 001: Dev 001, ..."
+    const busMatch = line.match(/Bus (\d+)\.Port \d+: Dev \d+/);
+    if (busMatch) {
+      currentBus = parseInt(busMatch[1], 10);
+      continue;
+    }
+
+    // Match port entries: "|__ Port 001: Dev 007, ..."
+    const portMatch = line.match(/Port (\d+): Dev (\d+)/);
+    if (portMatch && currentBus > 0) {
+      entries.push({
+        bus: currentBus,
+        port: parseInt(portMatch[1], 10),
+        device: parseInt(portMatch[2], 10),
+      });
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Build the SANE device name from bus and device numbers.
+ * Format: epkowa:interpreter:001:007
+ */
+function buildSaneName(bus: number, device: number): string {
+  return `epkowa:interpreter:${String(bus).padStart(3, '0')}:${String(device).padStart(3, '0')}`;
+}
+
+/**
+ * Build a display name from the product ID.
+ */
+function buildDisplayName(productId: string): string {
+  return EPSON_MODELS[productId] || `Epson Scanner (${productId})`;
+}
+
+/**
+ * Build a stable USB port string from bus and port numbers.
+ * Format: "1-7" (bus 1, port 7)
+ */
+function buildUsbPort(bus: number, port: number): string {
+  return `${bus}-${port}`;
+}
+
+/**
+ * Detect Epson scanners using lsusb.
+ *
+ * @returns Array of detected scanners with USB identifiers and computed SANE names.
+ */
+export function detectEpsonScanners(): {
+  success: boolean;
+  scanners: DetectedScanner[];
+  count: number;
+  error?: string;
+} {
+  try {
+    // Run lsusb to find Epson devices
+    const lsusbOutput = execFileSync('lsusb', [], {
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    const epsonDevices = parseLsusb(lsusbOutput);
+
+    if (epsonDevices.length === 0) {
+      return { success: true, scanners: [], count: 0 };
+    }
+
+    // Run lsusb -t to get stable port mappings
+    let treeEntries: LsusbTreeEntry[] = [];
+    try {
+      const treeOutput = execFileSync('lsusb', ['-t'], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'ignore'],
+      });
+      treeEntries = parseLsusbTree(treeOutput);
+    } catch {
+      console.warn('[lsusb] lsusb -t failed, port mapping unavailable');
+    }
+
+    // Build device→port lookup
+    const portMap = new Map<string, number>();
+    for (const entry of treeEntries) {
+      portMap.set(`${entry.bus}:${entry.device}`, entry.port);
+    }
+
+    // Build DetectedScanner array
+    const scanners: DetectedScanner[] = epsonDevices.map((dev) => {
+      const port = portMap.get(`${dev.bus}:${dev.device}`);
+      return {
+        name: buildDisplayName(dev.productId),
+        scanner_id: '', // Will be matched against DB by caller
+        usb_bus: dev.bus,
+        usb_device: dev.device,
+        usb_port: port !== undefined ? buildUsbPort(dev.bus, port) : '',
+        is_available: true,
+        vendor_id: dev.vendorId,
+        product_id: dev.productId,
+        sane_name: buildSaneName(dev.bus, dev.device),
+      };
+    });
+
+    // Deduplicate by usb_port — USB re-enumeration can create ghost entries
+    // where a scanner appears under both old and new device numbers on the same port.
+    // Keep the entry with the highest usb_device number (most recent enumeration).
+    const deduped: DetectedScanner[] = [];
+    const byPort = new Map<string, DetectedScanner>();
+    for (const s of scanners) {
+      if (!s.usb_port) {
+        // No port info — can't deduplicate, include as-is
+        deduped.push(s);
+        continue;
+      }
+      const existing = byPort.get(s.usb_port);
+      if (!existing || s.usb_device > existing.usb_device) {
+        byPort.set(s.usb_port, s);
+      }
+    }
+    deduped.push(...byPort.values());
+
+    return { success: true, scanners: deduped, count: deduped.length };
+  } catch (error) {
+    // lsusb command not available or failed
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes('ENOENT') || message.includes('not found')) {
+      return {
+        success: false,
+        scanners: [],
+        count: 0,
+        error: 'lsusb not available',
+      };
+    }
+
+    return {
+      success: false,
+      scanners: [],
+      count: 0,
+      error: `lsusb detection failed: ${message}`,
+    };
+  }
+}
+
+// Exported for testing
+export { parseLsusb, parseLsusbTree, buildSaneName, buildDisplayName };

--- a/tests/unit/graviscan/image-handlers.test.ts
+++ b/tests/unit/graviscan/image-handlers.test.ts
@@ -102,12 +102,16 @@ describe('image-handlers', () => {
 
       getOutputDir();
 
-      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), {
+        recursive: true,
+      });
     });
 
     it('should return error when mkdirSync fails', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
-      vi.mocked(fs.mkdirSync).mockImplementation(() => { throw new Error('EACCES'); });
+      vi.mocked(fs.mkdirSync).mockImplementation(() => {
+        throw new Error('EACCES');
+      });
 
       const result = getOutputDir();
 
@@ -147,7 +151,10 @@ describe('image-handlers', () => {
   describe('uploadAllScans', () => {
     it('should trigger box backup and report results', async () => {
       mockRunBoxBackup.mockResolvedValue({
-        success: true, experiments: 1, filesCopied: 5, errors: [],
+        success: true,
+        experiments: 1,
+        filesCopied: 5,
+        errors: [],
       } as any);
 
       const onProgress = vi.fn();
@@ -188,23 +195,29 @@ describe('image-handlers', () => {
     });
 
     it('should copy images and write metadata CSV', async () => {
-      db.graviScan.findMany.mockResolvedValue([{
-        wave_number: 0,
-        plate_barcode: 'PLATE-001',
-        plate_index: '00',
-        grid_mode: '2grid',
-        capture_date: new Date('2026-04-01'),
-        experiment: { accession: { graviPlateAccessions: [] } },
-        images: [{ path: '/scan/image.tiff' }],
-      }]);
+      db.graviScan.findMany.mockResolvedValue([
+        {
+          wave_number: 0,
+          plate_barcode: 'PLATE-001',
+          plate_index: '00',
+          grid_mode: '2grid',
+          capture_date: new Date('2026-04-01'),
+          experiment: { accession: { graviPlateAccessions: [] } },
+          images: [{ path: '/scan/image.tiff' }],
+        },
+      ]);
       mockResolvePath.mockReturnValue('/scan/image.tiff');
 
       const onProgress = vi.fn();
-      const result = await downloadImages(db, {
-        experimentId: 'exp-1',
-        experimentName: 'Test Exp',
-        targetDir: '/tmp/download',
-      }, onProgress);
+      const result = await downloadImages(
+        db,
+        {
+          experimentId: 'exp-1',
+          experimentName: 'Test Exp',
+          targetDir: '/tmp/download',
+        },
+        onProgress
+      );
 
       expect(result.total).toBe(1);
       expect(result.copied).toBe(1);

--- a/tests/unit/graviscan/image-handlers.test.ts
+++ b/tests/unit/graviscan/image-handlers.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Module mocks — must be before imports
@@ -162,7 +163,7 @@ describe('image-handlers', () => {
       mockRunBoxBackup.mockReturnValue(new Promise(() => {}));
 
       // Start first upload (will hang)
-      const first = uploadAllScans(db);
+      void uploadAllScans(db);
       // Try second immediately
       const second = await uploadAllScans(db);
 

--- a/tests/unit/graviscan/image-handlers.test.ts
+++ b/tests/unit/graviscan/image-handlers.test.ts
@@ -10,13 +10,15 @@ vi.mock('electron', () => ({
   },
 }));
 
+const sharpMockInstance = {
+  resize: vi.fn().mockReturnThis(),
+  jpeg: vi.fn().mockReturnValue({
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from('fake-jpeg-data')),
+  }),
+};
+
 vi.mock('sharp', () => ({
-  default: vi.fn(() => ({
-    resize: vi.fn().mockReturnThis(),
-    jpeg: vi.fn().mockReturnValue({
-      toBuffer: vi.fn().mockResolvedValue(Buffer.from('fake-jpeg-data')),
-    }),
-  })),
+  default: vi.fn(() => sharpMockInstance),
 }));
 
 vi.mock('../../../src/main/graviscan-path-utils', () => ({
@@ -74,6 +76,11 @@ describe('image-handlers', () => {
     mockResolvePath.mockReset();
     mockRunBoxBackup.mockReset();
     resetUploadState();
+    sharpMockInstance.resize.mockClear();
+    sharpMockInstance.jpeg.mockClear();
+    sharpMockInstance.jpeg.mockReturnValue({
+      toBuffer: vi.fn().mockResolvedValue(Buffer.from('fake-jpeg-data')),
+    });
   });
 
   describe('getOutputDir', () => {
@@ -123,11 +130,14 @@ describe('image-handlers', () => {
   describe('readScanImage', () => {
     it('should return base64 data URI for thumbnail', async () => {
       mockResolvePath.mockReturnValue('/scan/image.tiff');
-
       const result = await readScanImage('/scan/image.tiff');
 
       expect(result.success).toBe(true);
       expect(result.dataUri).toMatch(/^data:image\/jpeg;base64,/);
+      expect(sharpMockInstance.resize).toHaveBeenCalledWith(400, null, {
+        withoutEnlargement: true,
+      });
+      expect(sharpMockInstance.jpeg).toHaveBeenCalledWith({ quality: 85 });
     });
 
     it('should return full-resolution data URI when full option is true', async () => {
@@ -136,6 +146,8 @@ describe('image-handlers', () => {
 
       expect(result.success).toBe(true);
       expect(result.dataUri).toMatch(/^data:image\/jpeg;base64,/);
+      expect(sharpMockInstance.resize).not.toHaveBeenCalled();
+      expect(sharpMockInstance.jpeg).toHaveBeenCalledWith({ quality: 95 });
     });
 
     it('should return error when file not found', async () => {
@@ -145,6 +157,18 @@ describe('image-handlers', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('not found');
+    });
+
+    it('should return error when sharp processing fails', async () => {
+      mockResolvePath.mockReturnValue('/scan/corrupt.tiff');
+      sharpMockInstance.jpeg.mockReturnValueOnce({
+        toBuffer: vi.fn().mockRejectedValue(new Error('Invalid TIFF')),
+      });
+
+      const result = await readScanImage('/scan/corrupt.tiff');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid TIFF');
     });
   });
 
@@ -192,6 +216,39 @@ describe('image-handlers', () => {
       expect(result.success).toBe(true);
       expect(result.total).toBe(0);
       expect(result.copied).toBe(0);
+    });
+
+    it('should continue copying remaining files when one fails', async () => {
+      db.graviScan.findMany.mockResolvedValue([
+        {
+          wave_number: 0,
+          plate_barcode: 'PLATE-001',
+          plate_index: '00',
+          grid_mode: '2grid',
+          capture_date: new Date('2026-04-01'),
+          experiment: { accession: { graviPlateAccessions: [] } },
+          images: [
+            { path: '/scan/good.tiff' },
+            { path: '/scan/bad.tiff' },
+            { path: '/scan/also-good.tiff' },
+          ],
+        },
+      ]);
+      mockResolvePath.mockImplementation((p: string) => p);
+      vi.mocked(fs.promises.copyFile).mockImplementation(async (src: any) => {
+        if (String(src).includes('bad')) throw new Error('Disk full');
+      });
+
+      const result = await downloadImages(db, {
+        experimentId: 'exp-1',
+        experimentName: 'Test Exp',
+        targetDir: '/tmp/download',
+      });
+
+      expect(result.total).toBe(3);
+      expect(result.copied).toBe(2);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('Disk full');
     });
 
     it('should copy images and write metadata CSV', async () => {

--- a/tests/unit/graviscan/image-handlers.test.ts
+++ b/tests/unit/graviscan/image-handlers.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Module mocks — must be before imports
+vi.mock('electron', () => ({
+  app: {
+    getAppPath: vi.fn().mockReturnValue('/mock/app'),
+    getPath: vi.fn().mockReturnValue('/mock/home'),
+  },
+}));
+
+vi.mock('sharp', () => ({
+  default: vi.fn(() => ({
+    resize: vi.fn().mockReturnThis(),
+    jpeg: vi.fn().mockReturnValue({
+      toBuffer: vi.fn().mockResolvedValue(Buffer.from('fake-jpeg-data')),
+    }),
+  })),
+}));
+
+vi.mock('../../../src/main/graviscan-path-utils', () => ({
+  resolveGraviScanPath: vi.fn(),
+}));
+
+vi.mock('../../../src/main/box-backup', () => ({
+  runBoxBackup: vi.fn(),
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(true),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    promises: {
+      copyFile: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+import { app } from 'electron';
+import { resolveGraviScanPath } from '../../../src/main/graviscan-path-utils';
+import { runBoxBackup } from '../../../src/main/box-backup';
+import * as fs from 'fs';
+
+const mockResolvePath = vi.mocked(resolveGraviScanPath);
+const mockRunBoxBackup = vi.mocked(runBoxBackup);
+
+function createMockDb() {
+  return {
+    graviScan: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  } as any;
+}
+
+import {
+  getOutputDir,
+  readScanImage,
+  uploadAllScans,
+  downloadImages,
+  resetUploadState,
+} from '../../../src/main/graviscan/image-handlers';
+
+describe('image-handlers', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+    mockResolvePath.mockReset();
+    mockRunBoxBackup.mockReset();
+    resetUploadState();
+  });
+
+  describe('getOutputDir', () => {
+    it('should return dev path when NODE_ENV is development', async () => {
+      vi.stubEnv('NODE_ENV', 'development');
+      vi.mocked(app.getAppPath).mockReturnValue('/project/root');
+
+      const result = getOutputDir();
+
+      expect(result.success).toBe(true);
+      expect(result.path).toContain('.graviscan');
+    });
+
+    it('should return production path when NODE_ENV is production', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.mocked(app.getPath).mockReturnValue('/home/user');
+
+      const result = getOutputDir();
+
+      expect(result.success).toBe(true);
+      expect(result.path).toContain('.bloom');
+    });
+
+    it('should create directory if missing', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      getOutputDir();
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+    });
+
+    it('should return error when mkdirSync fails', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.mkdirSync).mockImplementation(() => { throw new Error('EACCES'); });
+
+      const result = getOutputDir();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('EACCES');
+    });
+  });
+
+  describe('readScanImage', () => {
+    it('should return base64 data URI for thumbnail', async () => {
+      mockResolvePath.mockReturnValue('/scan/image.tiff');
+
+      const result = await readScanImage('/scan/image.tiff');
+
+      expect(result.success).toBe(true);
+      expect(result.dataUri).toMatch(/^data:image\/jpeg;base64,/);
+    });
+
+    it('should return full-resolution data URI when full option is true', async () => {
+      mockResolvePath.mockReturnValue('/scan/image.tiff');
+      const result = await readScanImage('/scan/image.tiff', { full: true });
+
+      expect(result.success).toBe(true);
+      expect(result.dataUri).toMatch(/^data:image\/jpeg;base64,/);
+    });
+
+    it('should return error when file not found', async () => {
+      mockResolvePath.mockReturnValue(null);
+
+      const result = await readScanImage('/missing/image.tiff');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+  });
+
+  describe('uploadAllScans', () => {
+    it('should trigger box backup and report results', async () => {
+      mockRunBoxBackup.mockResolvedValue({
+        success: true, experiments: 1, filesCopied: 5, errors: [],
+      } as any);
+
+      const onProgress = vi.fn();
+      const result = await uploadAllScans(db, onProgress);
+
+      expect(result.success).toBe(true);
+      expect(result.uploaded).toBe(5);
+      expect(mockRunBoxBackup).toHaveBeenCalled();
+    });
+
+    it('should reject concurrent uploads', async () => {
+      // Make first upload hang
+      mockRunBoxBackup.mockReturnValue(new Promise(() => {}));
+
+      // Start first upload (will hang)
+      const first = uploadAllScans(db);
+      // Try second immediately
+      const second = await uploadAllScans(db);
+
+      expect(second.success).toBe(false);
+      expect(second.errors).toContain('Upload already in progress');
+    });
+  });
+
+  describe('downloadImages', () => {
+    it('should return zero counts when no images found', async () => {
+      db.graviScan.findMany.mockResolvedValue([]);
+
+      const result = await downloadImages(db, {
+        experimentId: 'exp-1',
+        experimentName: 'Test Exp',
+        targetDir: '/tmp/download',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.total).toBe(0);
+      expect(result.copied).toBe(0);
+    });
+
+    it('should copy images and write metadata CSV', async () => {
+      db.graviScan.findMany.mockResolvedValue([{
+        wave_number: 0,
+        plate_barcode: 'PLATE-001',
+        plate_index: '00',
+        grid_mode: '2grid',
+        capture_date: new Date('2026-04-01'),
+        experiment: { accession: { graviPlateAccessions: [] } },
+        images: [{ path: '/scan/image.tiff' }],
+      }]);
+      mockResolvePath.mockReturnValue('/scan/image.tiff');
+
+      const onProgress = vi.fn();
+      const result = await downloadImages(db, {
+        experimentId: 'exp-1',
+        experimentName: 'Test Exp',
+        targetDir: '/tmp/download',
+      }, onProgress);
+
+      expect(result.total).toBe(1);
+      expect(result.copied).toBe(1);
+      expect(fs.writeFileSync).toHaveBeenCalled(); // metadata CSV
+      expect(fs.promises.copyFile).toHaveBeenCalled();
+      expect(onProgress).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/graviscan/scanner-handlers.test.ts
+++ b/tests/unit/graviscan/scanner-handlers.test.ts
@@ -77,7 +77,16 @@ describe('scanner-handlers', () => {
     it('should return mock scanners when GRAVISCAN_MOCK is true', async () => {
       vi.stubEnv('GRAVISCAN_MOCK', 'true');
       db.graviScanner.findMany.mockResolvedValue([
-        { id: 'db-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a', usb_bus: 1, usb_device: 1, usb_port: '1-1', enabled: true },
+        {
+          id: 'db-1',
+          name: 'Scanner 1',
+          vendor_id: '04b8',
+          product_id: '013a',
+          usb_bus: 1,
+          usb_device: 1,
+          usb_port: '1-1',
+          enabled: true,
+        },
       ]);
 
       const result = await detectScanners(db);
@@ -106,14 +115,26 @@ describe('scanner-handlers', () => {
     it('should create new scanner records', async () => {
       db.graviScanner.findFirst.mockResolvedValue(null);
       db.graviScanner.create.mockResolvedValue({
-        id: 'new-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
-        usb_bus: 1, usb_device: 2, usb_port: '1-2', enabled: true,
+        id: 'new-1',
+        name: 'Scanner 1',
+        vendor_id: '04b8',
+        product_id: '013a',
+        usb_bus: 1,
+        usb_device: 2,
+        usb_port: '1-2',
+        enabled: true,
       });
 
-      const result = await saveScannersToDB(db, [{
-        name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
-        usb_bus: 1, usb_device: 2, usb_port: '1-2',
-      }]);
+      const result = await saveScannersToDB(db, [
+        {
+          name: 'Scanner 1',
+          vendor_id: '04b8',
+          product_id: '013a',
+          usb_bus: 1,
+          usb_device: 2,
+          usb_port: '1-2',
+        },
+      ]);
 
       expect(result.success).toBe(true);
       expect(result.scanners).toHaveLength(1);
@@ -123,19 +144,36 @@ describe('scanner-handlers', () => {
     it('should update existing scanner matched by USB port', async () => {
       db.graviScanner.findFirst.mockImplementation(async ({ where }: any) => {
         if (where?.usb_port === '1-2') {
-          return { id: 'existing-1', name: 'Old Name', usb_port: '1-2', display_name: null };
+          return {
+            id: 'existing-1',
+            name: 'Old Name',
+            usb_port: '1-2',
+            display_name: null,
+          };
         }
         return null;
       });
       db.graviScanner.update.mockResolvedValue({
-        id: 'existing-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
-        usb_bus: 1, usb_device: 2, usb_port: '1-2', enabled: true,
+        id: 'existing-1',
+        name: 'Scanner 1',
+        vendor_id: '04b8',
+        product_id: '013a',
+        usb_bus: 1,
+        usb_device: 2,
+        usb_port: '1-2',
+        enabled: true,
       });
 
-      const result = await saveScannersToDB(db, [{
-        name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
-        usb_bus: 1, usb_device: 2, usb_port: '1-2',
-      }]);
+      const result = await saveScannersToDB(db, [
+        {
+          name: 'Scanner 1',
+          vendor_id: '04b8',
+          product_id: '013a',
+          usb_bus: 1,
+          usb_device: 2,
+          usb_port: '1-2',
+        },
+      ]);
 
       expect(result.success).toBe(true);
       expect(result.scanners[0].id).toBe('existing-1');
@@ -146,7 +184,10 @@ describe('scanner-handlers', () => {
   describe('getConfig', () => {
     it('should return config from database', async () => {
       db.graviConfig.findFirst.mockResolvedValue({
-        id: '1', grid_mode: '2grid', resolution: 600, format: 'tiff',
+        id: '1',
+        grid_mode: '2grid',
+        resolution: 600,
+        format: 'tiff',
       });
 
       const result = await getConfig(db);
@@ -169,10 +210,16 @@ describe('scanner-handlers', () => {
     it('should create config when none exists', async () => {
       db.graviConfig.findFirst.mockResolvedValue(null);
       db.graviConfig.create.mockResolvedValue({
-        id: '1', grid_mode: '4grid', resolution: 1200, format: 'tiff',
+        id: '1',
+        grid_mode: '4grid',
+        resolution: 1200,
+        format: 'tiff',
       });
 
-      const result = await saveConfig(db, { grid_mode: '4grid', resolution: 1200 });
+      const result = await saveConfig(db, {
+        grid_mode: '4grid',
+        resolution: 1200,
+      });
 
       expect(result.success).toBe(true);
       expect(db.graviConfig.create).toHaveBeenCalled();
@@ -181,10 +228,16 @@ describe('scanner-handlers', () => {
     it('should update existing config', async () => {
       db.graviConfig.findFirst.mockResolvedValue({ id: '1' });
       db.graviConfig.update.mockResolvedValue({
-        id: '1', grid_mode: '2grid', resolution: 600, format: 'tiff',
+        id: '1',
+        grid_mode: '2grid',
+        resolution: 600,
+        format: 'tiff',
       });
 
-      const result = await saveConfig(db, { grid_mode: '2grid', resolution: 600 });
+      const result = await saveConfig(db, {
+        grid_mode: '2grid',
+        resolution: 600,
+      });
 
       expect(result.success).toBe(true);
       expect(db.graviConfig.update).toHaveBeenCalled();
@@ -195,11 +248,17 @@ describe('scanner-handlers', () => {
     const originalPlatform = process.platform;
 
     afterEach(() => {
-      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
     });
 
     it('should return sane backend on linux', async () => {
-      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
       const result = await getPlatformInfo();
 
       expect(result.success).toBe(true);
@@ -207,7 +266,10 @@ describe('scanner-handlers', () => {
     });
 
     it('should return unsupported on darwin', async () => {
-      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        configurable: true,
+      });
       const result = await getPlatformInfo();
 
       expect(result.supported).toBe(false);
@@ -236,7 +298,14 @@ describe('scanner-handlers', () => {
 
     it('should match saved scanners by USB port', async () => {
       db.graviScanner.findMany.mockResolvedValue([
-        { id: 's1', name: 'Scanner 1', usb_port: '1-2', vendor_id: '04b8', product_id: '013a', enabled: true },
+        {
+          id: 's1',
+          name: 'Scanner 1',
+          usb_port: '1-2',
+          vendor_id: '04b8',
+          product_id: '013a',
+          enabled: true,
+        },
       ]);
       mockDetect.mockReturnValue({
         success: true,
@@ -254,7 +323,14 @@ describe('scanner-handlers', () => {
 
     it('should report missing scanners', async () => {
       db.graviScanner.findMany.mockResolvedValue([
-        { id: 's1', name: 'Scanner 1', usb_port: '1-2', vendor_id: '04b8', product_id: '013a', enabled: true },
+        {
+          id: 's1',
+          name: 'Scanner 1',
+          usb_port: '1-2',
+          vendor_id: '04b8',
+          product_id: '013a',
+          enabled: true,
+        },
       ]);
       mockDetect.mockReturnValue({ success: true, scanners: [], count: 0 });
 
@@ -276,7 +352,13 @@ describe('scanner-handlers', () => {
 
     it('should validate cached scanners against detected hardware', async () => {
       db.graviScanner.findMany.mockResolvedValue([
-        { id: 's1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a', enabled: true },
+        {
+          id: 's1',
+          name: 'Scanner 1',
+          vendor_id: '04b8',
+          product_id: '013a',
+          enabled: true,
+        },
       ]);
       mockDetect.mockReturnValue({
         success: true,

--- a/tests/unit/graviscan/scanner-handlers.test.ts
+++ b/tests/unit/graviscan/scanner-handlers.test.ts
@@ -57,6 +57,7 @@ describe('scanner-handlers', () => {
     db = createMockDb();
     vi.stubEnv('GRAVISCAN_MOCK', '');
     mockDetect.mockReset();
+    resetSessionValidation();
   });
 
   describe('detectScanners', () => {
@@ -94,6 +95,17 @@ describe('scanner-handlers', () => {
       expect(result.success).toBe(true);
       expect(result.mock).toBe(true);
       expect(mockDetect).not.toHaveBeenCalled();
+    });
+
+    it('should return error when database throws', async () => {
+      db.graviScanner.findMany.mockRejectedValue(
+        new Error('DB connection lost')
+      );
+
+      const result = await detectScanners(db);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('DB connection lost');
     });
 
     it('should propagate detection failure', async () => {
@@ -139,6 +151,45 @@ describe('scanner-handlers', () => {
       expect(result.success).toBe(true);
       expect(result.scanners).toHaveLength(1);
       expect(db.graviScanner.create).toHaveBeenCalled();
+    });
+
+    it('should update existing scanner matched by USB bus+device', async () => {
+      db.graviScanner.findFirst.mockImplementation(async ({ where }: any) => {
+        if (where?.usb_bus === 1 && where?.usb_device === 2) {
+          return {
+            id: 'existing-1',
+            name: 'Old Name',
+            usb_bus: 1,
+            usb_device: 2,
+            display_name: null,
+          };
+        }
+        return null;
+      });
+      db.graviScanner.update.mockResolvedValue({
+        id: 'existing-1',
+        name: 'Scanner 1',
+        vendor_id: '04b8',
+        product_id: '013a',
+        usb_bus: 1,
+        usb_device: 2,
+        usb_port: '1-2',
+        enabled: true,
+      });
+
+      const result = await saveScannersToDB(db, [
+        {
+          name: 'Scanner 1',
+          vendor_id: '04b8',
+          product_id: '013a',
+          usb_bus: 1,
+          usb_device: 2,
+          usb_port: '1-2',
+        },
+      ]);
+
+      expect(result.success).toBe(true);
+      expect(result.scanners[0].id).toBe('existing-1');
     });
 
     it('should update existing scanner matched by USB port', async () => {
@@ -381,6 +432,35 @@ describe('scanner-handlers', () => {
       expect(state.isValidating).toBe(false);
       expect(state.isValidated).toBe(false);
       expect(state.detectedScanners).toEqual([]);
+    });
+
+    it('should return a copy that does not affect internal state', async () => {
+      // Run validation to populate state
+      db.graviScanner.findMany.mockResolvedValue([
+        {
+          id: 's1',
+          name: 'Scanner 1',
+          vendor_id: '04b8',
+          product_id: '013a',
+          enabled: true,
+        },
+      ]);
+      mockDetect.mockReturnValue({
+        success: true,
+        scanners: [{ ...MOCK_SCANNER, scanner_id: 's1' }],
+        count: 1,
+      });
+      await runStartupScannerValidation(db, ['s1']);
+
+      const state = getSessionValidationState();
+      // Mutate the returned copy
+      state.detectedScanners.push({ ...MOCK_SCANNER, scanner_id: 'injected' });
+      state.cachedScannerIds.push('injected-id');
+
+      // Internal state should be unaffected
+      const freshState = getSessionValidationState();
+      expect(freshState.detectedScanners).toHaveLength(1);
+      expect(freshState.cachedScannerIds).toHaveLength(1);
     });
   });
 });

--- a/tests/unit/graviscan/scanner-handlers.test.ts
+++ b/tests/unit/graviscan/scanner-handlers.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../../src/main/lsusb-detection', () => ({

--- a/tests/unit/graviscan/scanner-handlers.test.ts
+++ b/tests/unit/graviscan/scanner-handlers.test.ts
@@ -1,0 +1,303 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../../src/main/lsusb-detection', () => ({
+  detectEpsonScanners: vi.fn(),
+}));
+
+import { detectEpsonScanners } from '../../../src/main/lsusb-detection';
+import {
+  detectScanners,
+  saveScannersToDB,
+  getConfig,
+  saveConfig,
+  getPlatformInfo,
+  validateConfig,
+  runStartupScannerValidation,
+  getSessionValidationState,
+  resetSessionValidation,
+} from '../../../src/main/graviscan/scanner-handlers';
+import type { DetectedScanner } from '../../../src/types/graviscan';
+
+const mockDetect = vi.mocked(detectEpsonScanners);
+
+function createMockDb() {
+  return {
+    graviScanner: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    graviConfig: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  } as any;
+}
+
+const MOCK_SCANNER: DetectedScanner = {
+  name: 'Perfection V600 Photo',
+  scanner_id: 'scanner-1',
+  usb_bus: 1,
+  usb_device: 2,
+  usb_port: '1-2',
+  is_available: true,
+  vendor_id: '04b8',
+  product_id: '013a',
+  sane_name: 'epkowa:interpreter:001:002',
+};
+
+describe('scanner-handlers', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    vi.stubEnv('GRAVISCAN_MOCK', '');
+    mockDetect.mockReset();
+  });
+
+  describe('detectScanners', () => {
+    it('should return detected scanners from lsusb', async () => {
+      mockDetect.mockReturnValue({
+        success: true,
+        scanners: [MOCK_SCANNER],
+        count: 1,
+      });
+
+      const result = await detectScanners(db);
+
+      expect(result.success).toBe(true);
+      expect(result.scanners).toHaveLength(1);
+      expect(result.scanners[0].vendor_id).toBe('04b8');
+    });
+
+    it('should return mock scanners when GRAVISCAN_MOCK is true', async () => {
+      vi.stubEnv('GRAVISCAN_MOCK', 'true');
+      db.graviScanner.findMany.mockResolvedValue([
+        { id: 'db-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a', usb_bus: 1, usb_device: 1, usb_port: '1-1', enabled: true },
+      ]);
+
+      const result = await detectScanners(db);
+
+      expect(result.success).toBe(true);
+      expect(result.mock).toBe(true);
+      expect(mockDetect).not.toHaveBeenCalled();
+    });
+
+    it('should propagate detection failure', async () => {
+      mockDetect.mockReturnValue({
+        success: false,
+        error: 'lsusb not found',
+        scanners: [],
+        count: 0,
+      });
+
+      const result = await detectScanners(db);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('lsusb not found');
+    });
+  });
+
+  describe('saveScannersToDB', () => {
+    it('should create new scanner records', async () => {
+      db.graviScanner.findFirst.mockResolvedValue(null);
+      db.graviScanner.create.mockResolvedValue({
+        id: 'new-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
+        usb_bus: 1, usb_device: 2, usb_port: '1-2', enabled: true,
+      });
+
+      const result = await saveScannersToDB(db, [{
+        name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
+        usb_bus: 1, usb_device: 2, usb_port: '1-2',
+      }]);
+
+      expect(result.success).toBe(true);
+      expect(result.scanners).toHaveLength(1);
+      expect(db.graviScanner.create).toHaveBeenCalled();
+    });
+
+    it('should update existing scanner matched by USB port', async () => {
+      db.graviScanner.findFirst.mockImplementation(async ({ where }: any) => {
+        if (where?.usb_port === '1-2') {
+          return { id: 'existing-1', name: 'Old Name', usb_port: '1-2', display_name: null };
+        }
+        return null;
+      });
+      db.graviScanner.update.mockResolvedValue({
+        id: 'existing-1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
+        usb_bus: 1, usb_device: 2, usb_port: '1-2', enabled: true,
+      });
+
+      const result = await saveScannersToDB(db, [{
+        name: 'Scanner 1', vendor_id: '04b8', product_id: '013a',
+        usb_bus: 1, usb_device: 2, usb_port: '1-2',
+      }]);
+
+      expect(result.success).toBe(true);
+      expect(result.scanners[0].id).toBe('existing-1');
+      expect(result.scanners[0].name).toBe('Scanner 1');
+    });
+  });
+
+  describe('getConfig', () => {
+    it('should return config from database', async () => {
+      db.graviConfig.findFirst.mockResolvedValue({
+        id: '1', grid_mode: '2grid', resolution: 600, format: 'tiff',
+      });
+
+      const result = await getConfig(db);
+
+      expect(result.success).toBe(true);
+      expect(result.config?.grid_mode).toBe('2grid');
+    });
+
+    it('should return null when no config exists', async () => {
+      db.graviConfig.findFirst.mockResolvedValue(null);
+
+      const result = await getConfig(db);
+
+      expect(result.success).toBe(true);
+      expect(result.config).toBeNull();
+    });
+  });
+
+  describe('saveConfig', () => {
+    it('should create config when none exists', async () => {
+      db.graviConfig.findFirst.mockResolvedValue(null);
+      db.graviConfig.create.mockResolvedValue({
+        id: '1', grid_mode: '4grid', resolution: 1200, format: 'tiff',
+      });
+
+      const result = await saveConfig(db, { grid_mode: '4grid', resolution: 1200 });
+
+      expect(result.success).toBe(true);
+      expect(db.graviConfig.create).toHaveBeenCalled();
+    });
+
+    it('should update existing config', async () => {
+      db.graviConfig.findFirst.mockResolvedValue({ id: '1' });
+      db.graviConfig.update.mockResolvedValue({
+        id: '1', grid_mode: '2grid', resolution: 600, format: 'tiff',
+      });
+
+      const result = await saveConfig(db, { grid_mode: '2grid', resolution: 600 });
+
+      expect(result.success).toBe(true);
+      expect(db.graviConfig.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('getPlatformInfo', () => {
+    const originalPlatform = process.platform;
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    });
+
+    it('should return sane backend on linux', async () => {
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      const result = await getPlatformInfo();
+
+      expect(result.success).toBe(true);
+      expect(result.backend).toBe('sane');
+    });
+
+    it('should return unsupported on darwin', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      const result = await getPlatformInfo();
+
+      expect(result.supported).toBe(false);
+      expect(result.backend).toBe('unsupported');
+    });
+
+    it('should return mock platform info when GRAVISCAN_MOCK is true', async () => {
+      vi.stubEnv('GRAVISCAN_MOCK', 'true');
+      const result = await getPlatformInfo();
+
+      expect(result.success).toBe(true);
+      expect(result.supported).toBe(true);
+      expect(result.mock_enabled).toBe(true);
+    });
+  });
+
+  describe('validateConfig', () => {
+    it('should return no-config when no saved scanners', async () => {
+      db.graviScanner.findMany.mockResolvedValue([]);
+
+      const result = await validateConfig(db);
+
+      expect(result.success).toBe(true);
+      expect(result.status).toBe('no-config');
+    });
+
+    it('should match saved scanners by USB port', async () => {
+      db.graviScanner.findMany.mockResolvedValue([
+        { id: 's1', name: 'Scanner 1', usb_port: '1-2', vendor_id: '04b8', product_id: '013a', enabled: true },
+      ]);
+      mockDetect.mockReturnValue({
+        success: true,
+        scanners: [{ ...MOCK_SCANNER, usb_port: '1-2' }],
+        count: 1,
+      });
+
+      const result = await validateConfig(db);
+
+      expect(result.success).toBe(true);
+      expect(result.status).toBe('valid');
+      expect(result.matched).toHaveLength(1);
+      expect(result.missing).toHaveLength(0);
+    });
+
+    it('should report missing scanners', async () => {
+      db.graviScanner.findMany.mockResolvedValue([
+        { id: 's1', name: 'Scanner 1', usb_port: '1-2', vendor_id: '04b8', product_id: '013a', enabled: true },
+      ]);
+      mockDetect.mockReturnValue({ success: true, scanners: [], count: 0 });
+
+      const result = await validateConfig(db);
+
+      expect(result.status).toBe('mismatch');
+      expect(result.missing).toHaveLength(1);
+    });
+  });
+
+  describe('runStartupScannerValidation', () => {
+    it('should skip validation when no cached scanners', async () => {
+      resetSessionValidation();
+      const result = await runStartupScannerValidation(db, []);
+
+      expect(result.isValidated).toBe(false);
+      expect(result.isValidating).toBe(false);
+    });
+
+    it('should validate cached scanners against detected hardware', async () => {
+      db.graviScanner.findMany.mockResolvedValue([
+        { id: 's1', name: 'Scanner 1', vendor_id: '04b8', product_id: '013a', enabled: true },
+      ]);
+      mockDetect.mockReturnValue({
+        success: true,
+        scanners: [{ ...MOCK_SCANNER, scanner_id: 's1' }],
+        count: 1,
+      });
+
+      resetSessionValidation();
+      const result = await runStartupScannerValidation(db, ['s1']);
+
+      expect(result.isValidated).toBe(true);
+      expect(result.allScannersAvailable).toBe(true);
+    });
+  });
+
+  describe('getSessionValidationState / resetSessionValidation', () => {
+    it('should return current state and reset', () => {
+      resetSessionValidation();
+      const state = getSessionValidationState();
+      expect(state.isValidating).toBe(false);
+      expect(state.isValidated).toBe(false);
+      expect(state.detectedScanners).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/graviscan/session-handlers.test.ts
+++ b/tests/unit/graviscan/session-handlers.test.ts
@@ -165,12 +165,29 @@ describe('session-handlers', () => {
       expect(sessionArg.totalCycles).toBe(5); // 300 / 60
     });
 
+    it('should ceil totalCycles for non-even division', async () => {
+      const continuousParams = {
+        ...baseParams,
+        interval: { intervalSeconds: 60, durationSeconds: 350 },
+      };
+
+      await startScan(coordinator, continuousParams, sessionFns, onError);
+
+      const sessionArg = sessionFns.setScanSession.mock.calls[0][0];
+      expect(sessionArg.totalCycles).toBe(6); // Math.ceil(350/60) = 6
+    });
+
     it('should not set session state if coordinator.initialize throws', async () => {
       coordinator = createMockCoordinator({
         initialize: vi.fn().mockRejectedValue(new Error('USB init failed')),
       } as any);
 
-      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+      const result = await startScan(
+        coordinator,
+        baseParams,
+        sessionFns,
+        onError
+      );
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('USB init failed');

--- a/tests/unit/graviscan/session-handlers.test.ts
+++ b/tests/unit/graviscan/session-handlers.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Types matching Ben's ScanCoordinator + PlateConfig
+interface ScanCoordinatorLike {
+  readonly isScanning: boolean;
+  initialize(scanners: any[]): Promise<void>;
+  scanOnce(platesPerScanner: Map<string, any[]>): Promise<void>;
+  scanInterval(platesPerScanner: Map<string, any[]>, intervalMs: number, durationMs: number): Promise<void>;
+  cancelAll(): void;
+  shutdown(): Promise<void>;
+  on(event: string, listener: (...args: any[]) => void): this;
+}
+
+function createMockCoordinator(overrides: Partial<ScanCoordinatorLike> = {}): ScanCoordinatorLike {
+  return {
+    isScanning: false,
+    initialize: vi.fn().mockResolvedValue(undefined),
+    scanOnce: vi.fn().mockResolvedValue(undefined),
+    scanInterval: vi.fn().mockResolvedValue(undefined),
+    cancelAll: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn().mockReturnThis(),
+    ...overrides,
+  };
+}
+
+function createMockSessionFns() {
+  return {
+    getScanSession: vi.fn().mockReturnValue(null),
+    setScanSession: vi.fn(),
+    markScanJobRecorded: vi.fn(),
+  };
+}
+
+// Static imports — added after implementation exists
+import {
+  startScan,
+  getScanStatus,
+  markJobRecorded,
+  cancelScan,
+} from '../../../src/main/graviscan/session-handlers';
+
+describe('session-handlers', () => {
+  let coordinator: ReturnType<typeof createMockCoordinator>;
+  let sessionFns: ReturnType<typeof createMockSessionFns>;
+  let onError: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    coordinator = createMockCoordinator();
+    sessionFns = createMockSessionFns();
+    onError = vi.fn();
+  });
+
+  describe('startScan', () => {
+    const baseParams = {
+      scanners: [{
+        scannerId: 's1',
+        saneName: 'epkowa:interpreter:001:002',
+        plates: [{ plate_index: '00', grid_mode: '2grid', resolution: 600, output_path: '/tmp/scan' }],
+      }],
+      metadata: {
+        experimentId: 'exp-1',
+        phenotyperId: 'pheno-1',
+        resolution: 600,
+      },
+    };
+
+    it('should reject when coordinator is null', async () => {
+      const result = await startScan(null as any, baseParams, sessionFns, onError);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not initialized');
+    });
+
+    it('should reject when scan already in progress', async () => {
+      coordinator = createMockCoordinator({ isScanning: true } as any);
+
+      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('already in progress');
+    });
+
+    it('should initialize coordinator and call scanOnce for one-shot', async () => {
+      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+
+      expect(result.success).toBe(true);
+      expect(coordinator.initialize).toHaveBeenCalled();
+      expect(coordinator.scanOnce).toHaveBeenCalled();
+      expect(sessionFns.setScanSession).toHaveBeenCalled();
+    });
+
+    it('should call scanInterval for continuous mode', async () => {
+      const continuousParams = {
+        ...baseParams,
+        interval: { intervalSeconds: 300, durationSeconds: 3600 },
+      };
+
+      const result = await startScan(coordinator, continuousParams, sessionFns, onError);
+
+      expect(result.success).toBe(true);
+      expect(coordinator.scanInterval).toHaveBeenCalledWith(
+        expect.any(Map),
+        300000,
+        3600000,
+      );
+    });
+
+    it('should build correct session state with jobs map', async () => {
+      await startScan(coordinator, baseParams, sessionFns, onError);
+
+      const sessionArg = sessionFns.setScanSession.mock.calls[0][0];
+      expect(sessionArg.isActive).toBe(true);
+      expect(sessionArg.experimentId).toBe('exp-1');
+      expect(sessionArg.jobs['s1:00']).toBeDefined();
+      expect(sessionArg.jobs['s1:00'].status).toBe('pending');
+    });
+
+    it('should calculate totalCycles for continuous mode', async () => {
+      const continuousParams = {
+        ...baseParams,
+        interval: { intervalSeconds: 60, durationSeconds: 300 },
+      };
+
+      await startScan(coordinator, continuousParams, sessionFns, onError);
+
+      const sessionArg = sessionFns.setScanSession.mock.calls[0][0];
+      expect(sessionArg.totalCycles).toBe(5); // 300 / 60
+    });
+
+    it('should call onError and clear session when fire-and-forget rejects', async () => {
+      const deferred = { reject: (_e: Error) => {} };
+      const scanPromise = new Promise<void>((_resolve, reject) => {
+        deferred.reject = reject;
+      });
+      coordinator = createMockCoordinator({
+        scanOnce: vi.fn().mockReturnValue(scanPromise),
+      } as any);
+
+      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+      expect(result.success).toBe(true);
+
+      // Now reject the detached promise
+      deferred.reject(new Error('Subprocess crashed'));
+      // Wait for the .catch() handler to execute
+      await vi.waitFor(() => {
+        expect(onError).toHaveBeenCalled();
+      });
+      expect(sessionFns.setScanSession).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('getScanStatus', () => {
+    it('should return isActive false when no session', () => {
+      const result = getScanStatus(sessionFns);
+
+      expect(result.isActive).toBe(false);
+    });
+
+    it('should return full session state when active', async () => {
+      sessionFns.getScanSession.mockReturnValue({
+        isActive: true,
+        experimentId: 'exp-1',
+        phenotyperId: 'pheno-1',
+        resolution: 600,
+        sessionId: null,
+        jobs: { 's1:00': { status: 'pending' } },
+        isContinuous: false,
+        currentCycle: 0,
+        totalCycles: 1,
+        intervalMs: 0,
+        scanStartedAt: Date.now(),
+        scanDurationMs: 0,
+        coordinatorState: 'scanning',
+        nextScanAt: null,
+        waveNumber: 0,
+      });
+
+      const result = getScanStatus(sessionFns);
+
+      expect(result.isActive).toBe(true);
+      expect(result.experimentId).toBe('exp-1');
+      expect(result.jobs).toBeDefined();
+    });
+  });
+
+  describe('markJobRecorded', () => {
+    it('should delegate to injected markScanJobRecorded', () => {
+      markJobRecorded(sessionFns, 's1:00');
+
+      expect(sessionFns.markScanJobRecorded).toHaveBeenCalledWith('s1:00');
+    });
+  });
+
+  describe('cancelScan', () => {
+    it('should call cancelAll and shutdown then clear session', async () => {
+      const result = await cancelScan(coordinator, sessionFns);
+
+      expect(result.success).toBe(true);
+      expect(coordinator.cancelAll).toHaveBeenCalled();
+      expect(coordinator.shutdown).toHaveBeenCalled();
+      expect(sessionFns.setScanSession).toHaveBeenCalledWith(null);
+    });
+
+    it('should return error when coordinator is null', async () => {
+      const result = await cancelScan(null as any, sessionFns);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not initialized');
+    });
+
+    it('should return success when no scan session is active', async () => {
+      // Coordinator exists but no scan in progress
+      coordinator = createMockCoordinator({ isScanning: false } as any);
+      const result = await cancelScan(coordinator, sessionFns);
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/tests/unit/graviscan/session-handlers.test.ts
+++ b/tests/unit/graviscan/session-handlers.test.ts
@@ -252,6 +252,19 @@ describe('session-handlers', () => {
       expect(result.error).toContain('not initialized');
     });
 
+    it('should clear session state even when shutdown throws', async () => {
+      coordinator = createMockCoordinator({
+        shutdown: vi.fn().mockRejectedValue(new Error('SANE device busy')),
+      } as any);
+
+      const result = await cancelScan(coordinator, sessionFns);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('SANE device busy');
+      // Session MUST be cleared even on shutdown failure — otherwise it gets stuck
+      expect(sessionFns.setScanSession).toHaveBeenCalledWith(null);
+    });
+
     it('should return success when no scan session is active', async () => {
       // Coordinator exists but no scan in progress
       coordinator = createMockCoordinator({ isScanning: false } as any);

--- a/tests/unit/graviscan/session-handlers.test.ts
+++ b/tests/unit/graviscan/session-handlers.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Types matching Ben's ScanCoordinator + PlateConfig
@@ -130,6 +131,7 @@ describe('session-handlers', () => {
     });
 
     it('should call onError and clear session when fire-and-forget rejects', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const deferred = { reject: (_e: Error) => {} };
       const scanPromise = new Promise<void>((_resolve, reject) => {
         deferred.reject = reject;

--- a/tests/unit/graviscan/session-handlers.test.ts
+++ b/tests/unit/graviscan/session-handlers.test.ts
@@ -7,13 +7,19 @@ interface ScanCoordinatorLike {
   readonly isScanning: boolean;
   initialize(scanners: any[]): Promise<void>;
   scanOnce(platesPerScanner: Map<string, any[]>): Promise<void>;
-  scanInterval(platesPerScanner: Map<string, any[]>, intervalMs: number, durationMs: number): Promise<void>;
+  scanInterval(
+    platesPerScanner: Map<string, any[]>,
+    intervalMs: number,
+    durationMs: number
+  ): Promise<void>;
   cancelAll(): void;
   shutdown(): Promise<void>;
   on(event: string, listener: (...args: any[]) => void): this;
 }
 
-function createMockCoordinator(overrides: Partial<ScanCoordinatorLike> = {}): ScanCoordinatorLike {
+function createMockCoordinator(
+  overrides: Partial<ScanCoordinatorLike> = {}
+): ScanCoordinatorLike {
   return {
     isScanning: false,
     initialize: vi.fn().mockResolvedValue(undefined),
@@ -55,11 +61,20 @@ describe('session-handlers', () => {
 
   describe('startScan', () => {
     const baseParams = {
-      scanners: [{
-        scannerId: 's1',
-        saneName: 'epkowa:interpreter:001:002',
-        plates: [{ plate_index: '00', grid_mode: '2grid', resolution: 600, output_path: '/tmp/scan' }],
-      }],
+      scanners: [
+        {
+          scannerId: 's1',
+          saneName: 'epkowa:interpreter:001:002',
+          plates: [
+            {
+              plate_index: '00',
+              grid_mode: '2grid',
+              resolution: 600,
+              output_path: '/tmp/scan',
+            },
+          ],
+        },
+      ],
       metadata: {
         experimentId: 'exp-1',
         phenotyperId: 'pheno-1',
@@ -68,7 +83,12 @@ describe('session-handlers', () => {
     };
 
     it('should reject when coordinator is null', async () => {
-      const result = await startScan(null as any, baseParams, sessionFns, onError);
+      const result = await startScan(
+        null as any,
+        baseParams,
+        sessionFns,
+        onError
+      );
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('not initialized');
@@ -77,14 +97,24 @@ describe('session-handlers', () => {
     it('should reject when scan already in progress', async () => {
       coordinator = createMockCoordinator({ isScanning: true } as any);
 
-      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+      const result = await startScan(
+        coordinator,
+        baseParams,
+        sessionFns,
+        onError
+      );
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('already in progress');
     });
 
     it('should initialize coordinator and call scanOnce for one-shot', async () => {
-      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+      const result = await startScan(
+        coordinator,
+        baseParams,
+        sessionFns,
+        onError
+      );
 
       expect(result.success).toBe(true);
       expect(coordinator.initialize).toHaveBeenCalled();
@@ -98,13 +128,18 @@ describe('session-handlers', () => {
         interval: { intervalSeconds: 300, durationSeconds: 3600 },
       };
 
-      const result = await startScan(coordinator, continuousParams, sessionFns, onError);
+      const result = await startScan(
+        coordinator,
+        continuousParams,
+        sessionFns,
+        onError
+      );
 
       expect(result.success).toBe(true);
       expect(coordinator.scanInterval).toHaveBeenCalledWith(
         expect.any(Map),
         300000,
-        3600000,
+        3600000
       );
     });
 
@@ -140,7 +175,12 @@ describe('session-handlers', () => {
         scanOnce: vi.fn().mockReturnValue(scanPromise),
       } as any);
 
-      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+      const result = await startScan(
+        coordinator,
+        baseParams,
+        sessionFns,
+        onError
+      );
       expect(result.success).toBe(true);
 
       // Now reject the detached promise

--- a/tests/unit/graviscan/session-handlers.test.ts
+++ b/tests/unit/graviscan/session-handlers.test.ts
@@ -165,6 +165,19 @@ describe('session-handlers', () => {
       expect(sessionArg.totalCycles).toBe(5); // 300 / 60
     });
 
+    it('should not set session state if coordinator.initialize throws', async () => {
+      coordinator = createMockCoordinator({
+        initialize: vi.fn().mockRejectedValue(new Error('USB init failed')),
+      } as any);
+
+      const result = await startScan(coordinator, baseParams, sessionFns, onError);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('USB init failed');
+      // Session should NOT have been set since initialize failed
+      expect(sessionFns.setScanSession).not.toHaveBeenCalled();
+    });
+
     it('should call onError and clear session when fire-and-forget rejects', async () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const deferred = { reject: (_e: Error) => {} };

--- a/tests/unit/graviscan/session-handlers.test.ts
+++ b/tests/unit/graviscan/session-handlers.test.ts
@@ -177,6 +177,23 @@ describe('session-handlers', () => {
       expect(sessionArg.totalCycles).toBe(6); // Math.ceil(350/60) = 6
     });
 
+    it('should reject when interval parameters are invalid', async () => {
+      const invalidParams = {
+        ...baseParams,
+        interval: { intervalSeconds: 0, durationSeconds: 300 },
+      };
+
+      const result = await startScan(
+        coordinator,
+        invalidParams,
+        sessionFns,
+        onError
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('positive');
+    });
+
     it('should not set session state if coordinator.initialize throws', async () => {
       coordinator = createMockCoordinator({
         initialize: vi.fn().mockRejectedValue(new Error('USB init failed')),


### PR DESCRIPTION
## Summary

- Split monolithic `graviscan-handlers.ts` (1,338 lines) from PR #138 into 3 focused, testable modules in `src/main/graviscan/`
- **scanner-handlers.ts** — 7 handlers + 3 validation state functions (scanner detection, config, platform info, USB validation)
- **session-handlers.ts** — 4 scan lifecycle functions (start, status, cancel, mark-recorded) with injected `ScanCoordinatorLike` interface
- **image-handlers.ts** — 4 image operation functions (output dir, TIFF→JPEG read, Box backup upload, experiment image export with metadata CSV)
- **index.ts** — barrel export with IPC channel → function mapping JSDoc for Increment 3c wiring
- Cherry-picked 3 utility files from PR #138: `lsusb-detection.ts`, `graviscan-path-utils.ts`, `box-backup.ts`
- 42 unit tests across 3 test files, all passing
- No `main.ts` or `preload.ts` changes — IPC wiring deferred to Increment 3c
- Scanner model: Epson Perfection V600 (USB `04b8:013a`)

## Key design decisions

- **Testable via direct import, not pure functions**: modules have module-level state (`sessionValidation`, `uploadInProgress`) and module-mocked external deps — honest about what's injected (Prisma, coordinator, session fns, callbacks) vs what's module-mocked (`detectEpsonScanners`, `sharp`, `fs`, `app`)
- **`ScanCoordinatorLike` interface defined locally** in session-handlers (coordinator implementation comes in Increment 3b)
- **Progress events via callback injection** instead of `mainWindow.webContents.send()` — `downloadImages` and `uploadAllScans` accept `onProgress` callbacks
- **`downloadImages` accepts `targetDir` parameter** — `dialog.showOpenDialog()` handling deferred to 3c wiring layer

## Test plan

- [x] 42 vitest unit tests pass (`npx vitest run tests/unit/graviscan/`)
- [x] 572 total tests pass (full suite, no regressions)
- [x] `npx tsc --noEmit` clean
- [x] All 31 OpenSpec spec scenarios covered by tests

## References

- Design spec: `docs/superpowers/specs/2026-04-03-graviscan-integration-design.md` (Increment 3a)
- OpenSpec proposal: `openspec/changes/add-graviscan-handler-modules/`
- Implementation plan: `docs/superpowers/plans/2026-04-09-graviscan-handler-modules.md`
- Source: PR #138 (`origin/graviscan/4-main-process`)
- Coverage issue: #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)