### PR TITLE
feat: GraviScan coordinator + subprocess — Increment 3b

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -56,6 +56,33 @@ This document describes all configurable constants and default values in the Blo
 - **Gain**: Use only when lighting is insufficient (adds noise)
 - **Gamma**: Adjust for non-linear brightness correction (typically 1.0-2.2)
 
+## GraviScan Settings
+
+### Scan Coordination
+
+| Constant               | Type     | Default | Description                                                                                             | Location                                                                            | Admin Configurable          |
+| ---------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | --------------------------- |
+| `USB_STAGGER_DELAY_MS` | `number` | `5000`  | Delay (ms) between starting scanners within a grid row. Prevents epkowa SANE backend USB contention.    | [src/main/graviscan/scan-coordinator.ts](../src/main/graviscan/scan-coordinator.ts) | ❌ No - Hardware constraint |
+| `SCAN_ROW_TIMEOUT_MS`  | `number` | `90000` | Per-row scan timeout (ms). If a subprocess doesn't respond within this window, it is treated as failed. | [src/main/graviscan/scan-coordinator.ts](../src/main/graviscan/scan-coordinator.ts) | ❌ No - Safety timeout      |
+
+### Logging
+
+| Constant             | Type     | Default | Description                                                                                                                      | Location                                                                  | Admin Configurable   |
+| -------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | -------------------- |
+| `LOG_RETENTION_DAYS` | `number` | `180`   | Days to retain scan log files before cleanup. Default 180 days for scientific workflows where analysis/publication takes months. | [src/main/graviscan/scan-logger.ts](../src/main/graviscan/scan-logger.ts) | ✅ Yes - via env var |
+
+### Environment Variables
+
+| Variable                       | Default | Description                                                                                                               |
+| ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `GRAVISCAN_LOG_RETENTION_DAYS` | `180`   | Override log retention period (days). Set before app launch. Must be a positive integer; invalid values fall back to 180. |
+
+**Example:**
+
+```bash
+GRAVISCAN_LOG_RETENTION_DAYS=365 npm start
+```
+
 ## File Locations
 
 All default settings are defined in TypeScript type definition files:

--- a/openspec/changes/add-graviscan-coordinator-subprocess/design.md
+++ b/openspec/changes/add-graviscan-coordinator-subprocess/design.md
@@ -1,0 +1,87 @@
+# Design: GraviScan Coordinator + Subprocess
+
+## Overview
+
+This is Increment 3b of the GraviScan integration (see `docs/superpowers/specs/2026-04-03-graviscan-integration-design.md`). It introduces two modules that together manage the lifecycle of parallel flatbed scanning across multiple Epson scanners.
+
+## Architecture
+
+```
+session-handlers.ts (Increment 3a — already merged)
+  │  calls coordinator.initialize(), scanOnce(), scanInterval()
+  ▼
+scan-coordinator.ts (this increment)
+  │  orchestrates multiple subprocesses
+  │  manages grid sequencing and interval timing
+  ▼
+scanner-subprocess.ts (this increment)
+  │  one instance per physical scanner
+  │  spawns and communicates with Python scan_worker.py
+  ▼
+scan_worker.py (already exists in python/graviscan/)
+  │  SANE hardware interaction
+```
+
+## Key Design Decisions
+
+### 1. Type Placement: PlateConfig + ScannerConfig in src/types/graviscan.ts
+
+These types are used across session-handlers (IPC boundary), scan-coordinator, and scanner-subprocess. They will become IPC-facing in Increment 3c when the renderer sends `graviscan:start-scan` params. Placing them in `src/types/graviscan.ts` follows the dominant codebase pattern (daq.ts, scanner.ts, graviscan.ts all host IPC-facing types).
+
+Session-handlers currently has a comment `// Local interface types (will move to shared types in a later increment)` — this increment fulfills that intent.
+
+**Re-export policy:** Consumers should import `PlateConfig`/`ScannerConfig` directly from `src/types/graviscan.ts`, not through the barrel in `index.ts`. Session-handlers.ts will import (not re-export) them. This avoids creating a dependency on the barrel for types that live in the shared types file.
+
+### 2. ScanCoordinator implements ScanCoordinatorLike
+
+The `ScanCoordinatorLike` interface in session-handlers.ts defines the contract. Making `ScanCoordinator` explicitly `implements ScanCoordinatorLike` catches contract drift at compile time. The interface stays in session-handlers.ts (it's the consumer's contract definition).
+
+### 3. scan-logger.ts in src/main/graviscan/
+
+scan-logger.ts is a GraviScan-specific utility (logs to `~/.bloom/logs/graviscan-*.log`). It doesn't exist on main yet and is a dependency of both coordinator and subprocess. Placing it in `src/main/graviscan/` keeps GraviScan modules self-contained for packaging.
+
+**Retention:** Configurable via `LOG_RETENTION_DAYS` constant (default 180 days). 30 days is too short for scientific workflows where analysis/publication takes months.
+
+### 4. Sequential Subprocess Initialization (kept, with tracked issue)
+
+Ben's code initializes scanners sequentially. Issue #144 argues this is unnecessary since each subprocess has its own SANE context. We keep sequential init for now because switching to parallel requires designing error semantics for partial init failure (what if 3/4 scanners init but one fails?). A GitHub issue will be filed to track this optimization.
+
+### 5. Grid-Based Scanning with USB Stagger
+
+Within a scan cycle, grids are scanned sequentially (all scanners scan grid 0, then grid 1, etc.). Within a grid, scanners are triggered with a `USB_STAGGER_DELAY_MS = 5000` stagger delay due to epkowa SANE backend limitations. This is a hardware constraint, not a software choice. The stagger delay is logged via `scanLog()` for traceability.
+
+**Note for 4-grid mode:** Grids are grouped by row (00/01 = top row, 10/11 = bottom row). Both grids in a row share the same `scan_started_at` and `scan_ended_at` timestamps. The end timestamp reflects when the LAST scanner completed that row.
+
+### 6. Per-Grid Timestamps
+
+Each grid scan gets its own start/end timestamps injected into filenames (`_st_YYYYMMDD_HHmmss` and `_et_YYYYMMDD_HHmmss` patterns). The coordinator renames output files after all scanners complete a grid to include the end timestamp.
+
+### 7. Cross-Module Type Dependencies
+
+- `PlateConfig`, `ScannerConfig` → `src/types/graviscan.ts` (shared, IPC-facing)
+- `ScanCoordinatorLike` → `session-handlers.ts` (consumer contract)
+- `ScanWorkerEvent` → `scanner-subprocess.ts` (internal, imported by scan-coordinator.ts — may move to shared types in 3c if needed by IPC handlers)
+- `CoordinatorEvent` → removed (dead code on Ben's branch)
+
+## Adaptations from Ben's Branch
+
+Ben's files live at `src/main/scan-coordinator.ts` and `src/main/scanner-subprocess.ts` (top-level). We:
+
+1. Move to `src/main/graviscan/` for module isolation
+2. Update imports: `PlateConfig`/`ScannerConfig` from `../../types/graviscan`, `ScannerSubprocess`/`ScanWorkerEvent` from `./scanner-subprocess`, `scanLog` from `./scan-logger`
+3. Add `implements ScanCoordinatorLike` to ScanCoordinator class
+4. Surface rename failures as error events (not silent `console.error`)
+5. Add file existence + non-zero size check after `scan-complete`
+6. Add `scanLog()` calls during USB stagger with scanner ID and delay
+7. Make log retention configurable (default 180 days)
+8. Extract `USB_STAGGER_DELAY_MS` as named constant
+9. Remove dead `CoordinatorEvent` type
+
+## Test Strategy
+
+Tests mock at the JS level using `vi.mock('child_process')`, consistent with CylinderScan test patterns. All new test files use `// @vitest-environment node` directive.
+
+- **ScannerSubprocess tests**: Mock `child_process.spawn`, use real EventEmitter for stdout, simulate `EVENT:` protocol messages. Cover: spawn/ready, scan command, event parsing, cancel, shutdown, spawn failure (ENOENT), malformed EVENT lines, partial stdout buffering, non-zero exit code.
+- **ScanCoordinator tests**: Mock `ScannerSubprocess` class entirely, test orchestration logic. Cover: staggered init, grid sequencing, interval timing, cancel (including during interval wait), shutdown, partial scanner failure, zero scanners, file verification after scan-complete, rename error surfacing.
+- **Scan-logger tests**: Mock `fs` operations. Cover: write entry, configurable retention cleanup, close stream, directory creation.
+- **No Python required**: All tests run without Python/SANE

--- a/openspec/changes/add-graviscan-coordinator-subprocess/proposal.md
+++ b/openspec/changes/add-graviscan-coordinator-subprocess/proposal.md
@@ -1,0 +1,55 @@
+# Proposal: Add GraviScan Coordinator + Subprocess Modules
+
+**Change ID:** add-graviscan-coordinator-subprocess
+**Status:** draft
+**Created:** 2026-04-10
+
+## Why
+
+Increment 3b of the GraviScan integration requires the scan-coordinator and scanner-subprocess modules that orchestrate multi-scanner parallel scanning. The handler modules (Increment 3a) are merged and session-handlers defines a `ScanCoordinatorLike` interface, but no real implementation exists on main yet. These modules must be cherry-picked from Ben's feature branch, moved into `src/main/graviscan/`, type-reconciled with the existing codebase, and unit-tested before wiring into main.ts (Increment 3c).
+
+## What Changes
+
+- Cherry-pick `scan-coordinator.ts` and `scanner-subprocess.ts` from `origin/graviscan/4-main-process` (PR #138, issue #130) into `src/main/graviscan/`
+- Cherry-pick `scan-logger.ts` (dependency of both modules) into `src/main/graviscan/`
+- Move `PlateConfig` and `ScannerConfig` types from session-handlers.ts local definitions into `src/types/graviscan.ts` (they are IPC-facing types needed by coordinator, subprocess, and session-handlers)
+- Update session-handlers.ts to import `PlateConfig` and `ScannerConfig` from `src/types/graviscan.ts` instead of defining them locally
+- `ScanCoordinator` class explicitly `implements ScanCoordinatorLike`
+- Unit tests for `ScanCoordinator` (orchestration logic: staggered init, grid sequencing, interval timing, cancellation, shutdown)
+- Unit tests for `ScannerSubprocess` (spawn, command protocol, event parsing, shutdown)
+- Unit tests for `scan-logger` (log writing, configurable retention, stream management)
+- Tests mock `child_process.spawn` at the JS level using `vi.mock()`, consistent with CylinderScan test patterns (e.g., camera-process.test.ts, python-process.test.ts)
+- **No** IPC handler registration, no changes to main.ts, no changes to graviscan/index.ts exports
+
+**Adaptations from Ben's branch (not cherry-picked as-is):**
+
+- Rename failures surfaced as error events instead of silently caught with `console.error`
+- File existence + size check after `scan-complete` before emitting `grid-complete`
+- USB stagger delay logged via `scanLog()` with scanner ID and delay duration
+- Log retention configurable (default 180 days, up from hardcoded 30 days)
+- Remove dead `CoordinatorEvent` type
+- Extract `USB_STAGGER_DELAY_MS = 5000` as named module-level constant
+- Import `PlateConfig`/`ScannerConfig` from `src/types/graviscan.ts` instead of local definitions
+- `ScanWorkerEvent` stays in scanner-subprocess.ts (future migration to shared types in 3c if needed)
+
+**Known design decisions deferred to future issues:**
+
+- Sequential subprocess initialization kept as-is; parallel init deferred (see #144 — requires error-handling design for partial init failure)
+- Database path vs filesystem divergence after `_et_` rename (needs 3c wiring to reconcile)
+- Per-session cycle number disambiguation (needs session wiring in 3c)
+- `scanner-stagger-wait` UI event (deferred to renderer increment)
+
+**Related issues:** #130 (parent), #126 (epic), #144 (parallel init), #125 (subprocess recovery), #168 (per-scanner reconnect), #177 (row-merge at 1200 DPI)
+
+## Impact
+
+- Affected specs: `scanning` (adds requirements for coordinator, subprocess, logger, shared types)
+- Affected code:
+  - `src/main/graviscan/scan-coordinator.ts` (new)
+  - `src/main/graviscan/scanner-subprocess.ts` (new)
+  - `src/main/graviscan/scan-logger.ts` (new)
+  - `src/types/graviscan.ts` (adds PlateConfig, ScannerConfig)
+  - `src/main/graviscan/session-handlers.ts` (remove local type defs, import from shared types)
+  - `tests/unit/graviscan/scan-coordinator.test.ts` (new)
+  - `tests/unit/graviscan/scanner-subprocess.test.ts` (new)
+  - `tests/unit/graviscan/scan-logger.test.ts` (new)

--- a/openspec/changes/add-graviscan-coordinator-subprocess/specs/scanning/spec.md
+++ b/openspec/changes/add-graviscan-coordinator-subprocess/specs/scanning/spec.md
@@ -1,0 +1,219 @@
+## ADDED Requirements
+
+### Requirement: ScanCoordinator Multi-Scanner Orchestration
+
+The system SHALL provide a `ScanCoordinator` class in `src/main/graviscan/scan-coordinator.ts` that orchestrates multiple `ScannerSubprocess` instances for parallel scanning, with staggered initialization, grid-based scan sequencing, interval/continuous mode timing, and graceful shutdown. The USB stagger delay SHALL be defined as a named module-level constant `USB_STAGGER_DELAY_MS = 5000`.
+
+#### Scenario: Staggered scanner initialization
+
+- **GIVEN** a `ScanCoordinator` is constructed with a Python path and packaging flag
+- **WHEN** `initialize(scanners)` is called with a list of `ScannerConfig` objects
+- **THEN** the coordinator SHALL spawn one `ScannerSubprocess` per scanner
+- **AND** subprocesses SHALL be initialized sequentially (one at a time) to prevent SANE global state contention
+- **AND** existing subprocesses not in the new config SHALL be shut down
+- **AND** existing subprocesses that are already ready SHALL be reused
+
+#### Scenario: Initialize with zero scanners
+
+- **GIVEN** a `ScanCoordinator` is constructed
+- **WHEN** `initialize([])` is called with an empty list
+- **THEN** the coordinator SHALL shut down any existing subprocesses
+- **AND** the subprocess map SHALL be empty
+- **AND** the coordinator SHALL resolve without error
+
+#### Scenario: Single-cycle scan with grid sequencing
+
+- **GIVEN** the coordinator is initialized with scanners
+- **WHEN** `scanOnce(platesPerScanner)` is called with a `Map<string, PlateConfig[]>`
+- **THEN** the coordinator SHALL scan grids sequentially (all scanners scan grid 0, then grid 1, etc.)
+- **AND** within each grid, scanners SHALL be triggered with a `USB_STAGGER_DELAY_MS` (5-second) stagger delay
+- **AND** each stagger delay SHALL be logged via `scanLog()` with the scanner ID and delay duration
+- **AND** the coordinator SHALL wait for all scanners to complete a grid before proceeding to the next
+- **AND** output files SHALL be renamed to append `_et_YYYYMMDD_HHmmss` end-timestamp after grid completion
+- **AND** the coordinator SHALL emit `grid-start`, `grid-complete`, and `cycle-complete` events
+
+#### Scenario: File verification after scan-complete
+
+- **GIVEN** a subprocess emits a `scan-complete` event with an output file path
+- **WHEN** the coordinator processes the completion
+- **THEN** the coordinator SHALL verify the output file exists and has non-zero size
+- **AND** if the file is missing or zero-size, the coordinator SHALL emit a `scan-error` event for that scanner/plate
+
+#### Scenario: Rename failure surfaces as error event
+
+- **GIVEN** all scanners have completed a grid
+- **WHEN** the coordinator attempts to rename output files to include end timestamps
+- **AND** a rename operation fails (e.g., disk full, permissions)
+- **THEN** the coordinator SHALL emit a `rename-error` event with the failure details and affected file path
+- **AND** the `grid-complete` event SHALL include a `renameErrors` array (empty on success)
+
+#### Scenario: Partial scanner failure mid-grid
+
+- **GIVEN** the coordinator is scanning a grid with multiple scanners
+- **WHEN** one scanner emits a `scan-error` while others complete successfully
+- **THEN** the coordinator SHALL mark the failed scanner's output as errored
+- **AND** the coordinator SHALL still wait for remaining scanners to complete
+- **AND** the coordinator SHALL proceed to the next grid
+
+#### Scenario: Interval scanning with duration
+
+- **GIVEN** the coordinator is initialized with scanners
+- **WHEN** `scanInterval(platesPerScanner, intervalMs, durationMs)` is called
+- **THEN** the coordinator SHALL repeat `scanOnce()` at the specified interval
+- **AND** scanning SHALL stop when the duration is exceeded or `cancelAll()` is called
+- **AND** the coordinator SHALL emit `interval-start`, `interval-waiting`, and `interval-complete` events
+- **AND** if a cycle takes longer than the interval, the coordinator SHALL emit an `overtime` event
+
+#### Scenario: Cancel all scanning
+
+- **GIVEN** the coordinator is actively scanning
+- **WHEN** `cancelAll()` is called
+- **THEN** all active scans SHALL be cancelled
+- **AND** any interval timer SHALL be cleared
+- **AND** a `cancelled` event SHALL be emitted
+
+#### Scenario: Cancel during interval wait
+
+- **GIVEN** the coordinator is waiting between interval cycles (not actively scanning)
+- **WHEN** `cancelAll()` is called
+- **THEN** the interval timer SHALL be cleared
+- **AND** a `cancelled` event SHALL be emitted
+- **AND** no further scan cycles SHALL be started
+
+#### Scenario: Graceful shutdown
+
+- **GIVEN** the coordinator has active subprocesses
+- **WHEN** `shutdown()` is called
+- **THEN** the coordinator SHALL send quit commands to all subprocesses
+- **AND** force-kill any subprocess that does not exit within 5 seconds
+- **AND** clear the subprocess map
+
+#### Scenario: Coordinator implements ScanCoordinatorLike
+
+- **GIVEN** the `ScanCoordinatorLike` interface is defined in session-handlers.ts
+- **WHEN** the `ScanCoordinator` class is compiled
+- **THEN** it SHALL explicitly `implements ScanCoordinatorLike`
+- **AND** the `isScanning` readonly property SHALL return `true` when state is `scanning` or `waiting`
+
+### Requirement: ScannerSubprocess Worker Management
+
+The system SHALL provide a `ScannerSubprocess` class in `src/main/graviscan/scanner-subprocess.ts` that manages a single long-lived Python `scan_worker.py` subprocess per physical scanner, communicating via line-delimited JSON on stdin and `EVENT:`-prefixed JSON on stdout.
+
+#### Scenario: Subprocess spawn and ready signal
+
+- **GIVEN** a `ScannerSubprocess` is constructed with a scanner ID and SANE name
+- **WHEN** `spawn()` is called
+- **THEN** the subprocess SHALL spawn a Python process with appropriate arguments
+- **AND** in development mode, SHALL use `python -m graviscan.scan_worker`
+- **AND** in packaged mode, SHALL use `bloom-hardware --scan-worker`
+- **AND** the subprocess SHALL wait for an `EVENT:ready` signal before resolving
+
+#### Scenario: Spawn failure
+
+- **GIVEN** a `ScannerSubprocess` is constructed
+- **WHEN** `spawn()` is called and the Python binary is not found (ENOENT) or not executable (EACCES)
+- **THEN** the spawn promise SHALL reject with a descriptive error
+- **AND** the subprocess state SHALL transition to `dead`
+
+#### Scenario: Send scan command
+
+- **GIVEN** the subprocess is in the `ready` state
+- **WHEN** `scan(plates)` is called with a list of `PlateConfig` objects
+- **THEN** the subprocess SHALL write `{action: 'scan', plates}` as JSON to stdin
+- **AND** the state SHALL transition to `scanning`
+
+#### Scenario: Parse EVENT protocol messages
+
+- **GIVEN** the subprocess stdout emits lines prefixed with `EVENT:`
+- **WHEN** a line like `EVENT:{"type":"scan-complete","scanner_id":"..."}` is received
+- **THEN** the subprocess SHALL parse the JSON payload
+- **AND** emit typed events: `scan-started`, `scan-complete`, `scan-error`, `scan-cancelled`, `cycle-done`
+- **AND** emit a generic `event` for the coordinator to forward
+
+#### Scenario: Malformed EVENT protocol line
+
+- **GIVEN** the subprocess stdout emits a line `EVENT:not-valid-json`
+- **WHEN** the line is parsed
+- **THEN** the malformed line SHALL be logged as a warning via `scanLog()`
+- **AND** the subprocess SHALL NOT crash or change state
+
+#### Scenario: Partial stdout line buffering
+
+- **GIVEN** the subprocess stdout emits a JSON event split across multiple data chunks
+- **WHEN** the chunks are received
+- **THEN** the line reader SHALL reassemble complete lines before parsing
+- **AND** no partial JSON SHALL be passed to the parser
+
+#### Scenario: Cancel scan
+
+- **GIVEN** the subprocess is scanning
+- **WHEN** `cancel()` is called
+- **THEN** the subprocess SHALL write `{action: 'cancel'}` to stdin
+- **AND** the worker SHALL finish the current plate then return to idle
+
+#### Scenario: Process exit with non-zero code
+
+- **GIVEN** the subprocess is alive
+- **WHEN** the process exits with a non-zero exit code or a signal
+- **THEN** the subprocess SHALL emit an `exit` event with the code and signal
+- **AND** the state SHALL transition to `dead`
+- **AND** any pending operations SHALL be rejected
+
+#### Scenario: Graceful subprocess shutdown
+
+- **GIVEN** the subprocess is alive
+- **WHEN** `shutdown(timeoutMs)` is called
+- **THEN** the subprocess SHALL send a `quit` command
+- **AND** force-kill with SIGKILL if the process does not exit within the timeout
+- **AND** resolve when the process exits
+
+### Requirement: GraviScan Persistent Scan Logging
+
+The system SHALL provide scan logging in `src/main/graviscan/scan-logger.ts` that writes timestamped entries to `~/.bloom/logs/graviscan-YYYY-MM-DD.log` with configurable log retention (default 180 days).
+
+#### Scenario: Write scan log entry
+
+- **GIVEN** the scan logger is available
+- **WHEN** `scanLog(message)` is called
+- **THEN** the message SHALL be written with an ISO timestamp to the daily log file
+- **AND** the log directory SHALL be created if it does not exist
+
+#### Scenario: Configurable log retention
+
+- **GIVEN** `LOG_RETENTION_DAYS` is set to N days (default 180)
+- **WHEN** `cleanupOldLogs()` is called
+- **THEN** log files older than N days SHALL be deleted
+- **AND** recent log files SHALL be preserved
+
+#### Scenario: Close scan log stream
+
+- **GIVEN** the scan logger has an open write stream
+- **WHEN** `closeScanLog()` is called
+- **THEN** the write stream SHALL be flushed and closed
+- **AND** subsequent calls to `scanLog()` SHALL open a new stream
+
+### Requirement: GraviScan Shared Type Definitions
+
+The `PlateConfig` and `ScannerConfig` interfaces SHALL be defined in `src/types/graviscan.ts` (moved from local definitions in session-handlers.ts) so they can be shared across session-handlers, scan-coordinator, and scanner-subprocess modules.
+
+#### Scenario: PlateConfig available as shared type
+
+- **GIVEN** the `PlateConfig` interface is defined in `src/types/graviscan.ts`
+- **WHEN** any GraviScan module needs plate configuration
+- **THEN** it SHALL import `PlateConfig` from `../../types/graviscan` (or appropriate relative path)
+- **AND** `PlateConfig` SHALL have fields: `plate_index: string`, `grid_mode: string`, `resolution: number`, `output_path: string`
+
+#### Scenario: ScannerConfig available as shared type
+
+- **GIVEN** the `ScannerConfig` interface is defined in `src/types/graviscan.ts`
+- **WHEN** any GraviScan module needs scanner configuration
+- **THEN** it SHALL import `ScannerConfig` from `../../types/graviscan` (or appropriate relative path)
+- **AND** `ScannerConfig` SHALL have fields: `scannerId: string`, `saneName: string`, `plates: PlateConfig[]`
+
+#### Scenario: Session-handlers imports shared types
+
+- **GIVEN** `PlateConfig` and `ScannerConfig` are defined in `src/types/graviscan.ts`
+- **WHEN** `session-handlers.ts` is compiled
+- **THEN** it SHALL import both types from `../../types/graviscan`
+- **AND** the local type definitions SHALL be removed
+- **AND** the `ScanCoordinatorLike` interface SHALL remain in session-handlers.ts

--- a/openspec/changes/add-graviscan-coordinator-subprocess/specs/scanning/spec.md
+++ b/openspec/changes/add-graviscan-coordinator-subprocess/specs/scanning/spec.md
@@ -29,7 +29,7 @@ The system SHALL provide a `ScanCoordinator` class in `src/main/graviscan/scan-c
 - **AND** within each grid, scanners SHALL be triggered with a `USB_STAGGER_DELAY_MS` (5-second) stagger delay
 - **AND** each stagger delay SHALL be logged via `scanLog()` with the scanner ID and delay duration
 - **AND** the coordinator SHALL wait for all scanners to complete a grid before proceeding to the next
-- **AND** output files SHALL be renamed to append `_et_YYYYMMDD_HHmmss` end-timestamp after grid completion
+- **AND** output files SHALL be renamed to append `_et_YYYYMMDDTHHMMSS` end-timestamp after grid completion
 - **AND** the coordinator SHALL emit `grid-start`, `grid-complete`, and `cycle-complete` events
 
 #### Scenario: File verification after scan-complete

--- a/openspec/changes/add-graviscan-coordinator-subprocess/specs/scanning/spec.md
+++ b/openspec/changes/add-graviscan-coordinator-subprocess/specs/scanning/spec.md
@@ -29,7 +29,7 @@ The system SHALL provide a `ScanCoordinator` class in `src/main/graviscan/scan-c
 - **AND** within each grid, scanners SHALL be triggered with a `USB_STAGGER_DELAY_MS` (5-second) stagger delay
 - **AND** each stagger delay SHALL be logged via `scanLog()` with the scanner ID and delay duration
 - **AND** the coordinator SHALL wait for all scanners to complete a grid before proceeding to the next
-- **AND** output files SHALL be renamed to append `_et_YYYYMMDDTHHMMSS` end-timestamp after grid completion
+- **AND** output files SHALL be renamed to append `_et_YYYYMMDDTHHMMSS` end-timestamp after grid completion (regex applied to `path.basename` only, not the full path)
 - **AND** the coordinator SHALL emit `grid-start`, `grid-complete`, and `cycle-complete` events
 
 #### Scenario: File verification after scan-complete
@@ -72,13 +72,38 @@ The system SHALL provide a `ScanCoordinator` class in `src/main/graviscan/scan-c
 - **AND** any interval timer SHALL be cleared
 - **AND** a `cancelled` event SHALL be emitted
 
-#### Scenario: Cancel during interval wait
+#### Scenario: Cancel during interval wait resets state to idle
 
-- **GIVEN** the coordinator is waiting between interval cycles (not actively scanning)
+- **GIVEN** the coordinator is waiting between interval cycles (state is `waiting`)
 - **WHEN** `cancelAll()` is called
 - **THEN** the interval timer SHALL be cleared
 - **AND** a `cancelled` event SHALL be emitted
 - **AND** no further scan cycles SHALL be started
+- **AND** after `scanInterval()` returns, `isScanning` SHALL be `false`
+
+#### Scenario: Per-row scan timeout prevents infinite hang
+
+- **GIVEN** the coordinator is scanning a grid row
+- **AND** one or more subprocesses have not emitted `cycle-done` or `exit`
+- **WHEN** a configurable per-row timeout (`SCAN_ROW_TIMEOUT_MS`) is exceeded
+- **THEN** the timed-out subprocesses SHALL be treated as failed
+- **AND** the coordinator SHALL proceed to the next row group
+- **AND** a `scan-error` event SHALL be emitted for each timed-out subprocess
+
+#### Scenario: Forwarded scan events do not include stale timestamps
+
+- **GIVEN** the coordinator forwards subprocess events via `scan-event`
+- **WHEN** a `scan-complete` event is emitted before the row has finished
+- **THEN** the forwarded event SHALL include `scan_started_at` (the row start time)
+- **AND** the forwarded event SHALL NOT include `scan_ended_at` (which is unknown until the row completes)
+
+#### Scenario: Cancel during active scanOnce aborts cleanly
+
+- **GIVEN** the coordinator is actively awaiting `scanOnce()` completion
+- **WHEN** `cancelAll()` is called
+- **THEN** the coordinator SHALL check `this.cancelled` after each row completes
+- **AND** the coordinator SHALL skip file verification and renaming for unfinished rows
+- **AND** `isScanning` SHALL return `false` after `scanOnce()` returns
 
 #### Scenario: Graceful shutdown
 

--- a/openspec/changes/add-graviscan-coordinator-subprocess/tasks.md
+++ b/openspec/changes/add-graviscan-coordinator-subprocess/tasks.md
@@ -1,0 +1,94 @@
+# Tasks: Add GraviScan Coordinator + Subprocess
+
+All new test files MUST include `// @vitest-environment node` at line 1.
+
+## Task 1: Move PlateConfig and ScannerConfig to shared types
+
+Move `PlateConfig` and `ScannerConfig` from `session-handlers.ts` local definitions into `src/types/graviscan.ts`. Update `session-handlers.ts` to import from the shared types file. Remove local definitions. Do NOT re-export from session-handlers.ts — consumers should import types directly from `src/types/graviscan`.
+
+**TDD:** Write a test that imports `PlateConfig` and `ScannerConfig` from `src/types/graviscan`, creates conforming objects, and asserts the expected properties. Also import `ScanCoordinatorLike` from session-handlers to verify it references the shared types.
+
+- [x] Write type import test in existing `tests/unit/graviscan-types.test.ts`
+- [x] Add `PlateConfig` and `ScannerConfig` to `src/types/graviscan.ts`
+- [x] Update `session-handlers.ts` to import from `../../types/graviscan`, remove local definitions
+- [x] Gate: `npx tsc --noEmit` passes AND existing session-handlers tests pass
+
+## Task 2: Add scan-logger.ts to src/main/graviscan/
+
+Cherry-pick `scan-logger.ts` from `origin/graviscan/4-main-process` into `src/main/graviscan/scan-logger.ts`. Adapt: make log retention configurable via `LOG_RETENTION_DAYS` constant (default 180 days, up from hardcoded 30 days).
+
+**TDD:** Write unit tests first, then adapt the module. Mock `fs` operations.
+
+- [x] Write `tests/unit/graviscan/scan-logger.test.ts` (tests first)
+  - `scanLog()` writes timestamped entry to daily log file
+  - `scanLog()` creates log directory if it does not exist
+  - `cleanupOldLogs()` deletes files older than `LOG_RETENTION_DAYS`
+  - `cleanupOldLogs()` preserves recent log files
+  - `closeScanLog()` flushes and closes stream
+  - Subsequent `scanLog()` after close opens a new stream
+- [x] Cherry-pick and adapt scan-logger.ts (configurable retention, 180-day default)
+- [x] Gate: tests pass, `npx tsc --noEmit` passes
+
+## Task 3: Add scanner-subprocess.ts to src/main/graviscan/
+
+Cherry-pick `scanner-subprocess.ts` from `origin/graviscan/4-main-process` into `src/main/graviscan/scanner-subprocess.ts`. Update imports: `PlateConfig` from `../../types/graviscan`, `scanLog` from `./scan-logger`. Keep `ScanWorkerEvent` defined and exported locally (may move to shared types in 3c).
+
+**TDD:** Write unit tests first, then adapt the module. Tests mock `child_process.spawn` with `vi.mock()` and use real EventEmitter for stdout (Pattern B from python-process.test.ts).
+
+- [x] Write `tests/unit/graviscan/scanner-subprocess.test.ts` (tests first)
+  - `spawn()` — spawns process, waits for `EVENT:ready`, transitions to ready state
+  - `spawn()` packaged mode — uses `bloom-hardware --scan-worker` args
+  - `spawn()` failure — ENOENT rejects with error, state transitions to dead
+  - `scan(plates)` — sends JSON command to stdin, sets state to scanning
+  - `cancel()` — sends cancel command to stdin
+  - Event parsing — `EVENT:{...}` lines emitted as typed events (`scan-started`, `scan-complete`, `scan-error`, `scan-cancelled`, `cycle-done`)
+  - Event parsing — generic `event` emitted for coordinator forwarding
+  - Malformed EVENT line — logged as warning, no crash or state change
+  - Partial stdout buffering — split chunks reassembled before parsing
+  - Process exit with non-zero code — emits `exit` event, state to dead
+  - `shutdown()` — sends quit, force-kills after timeout
+- [x] Cherry-pick and adapt scanner-subprocess.ts
+- [x] Gate: tests pass, `npx tsc --noEmit` passes
+
+## Task 4: Add scan-coordinator.ts to src/main/graviscan/
+
+Cherry-pick `scan-coordinator.ts` from `origin/graviscan/4-main-process` into `src/main/graviscan/scan-coordinator.ts`. Adaptations:
+- Import `PlateConfig`, `ScannerConfig` from `../../types/graviscan` (remove local definitions)
+- Import `ScannerSubprocess`, `ScanWorkerEvent` from `./scanner-subprocess`
+- Import `ScanCoordinatorLike` from `./session-handlers`, add `implements ScanCoordinatorLike`
+- Remove dead `CoordinatorEvent` type
+- Extract `USB_STAGGER_DELAY_MS = 5000` as named module-level constant
+- Add `scanLog()` calls during USB stagger with scanner ID and delay
+- Surface rename failures as `rename-error` events (not silent `console.error`)
+- Add file existence + non-zero size check after `scan-complete`
+
+**TDD:** Write unit tests first, then adapt the module. Tests mock the `ScannerSubprocess` class entirely (no real subprocesses). Use `vi.useFakeTimers()` for stagger delay and interval timing.
+
+- [x] Write `tests/unit/graviscan/scan-coordinator.test.ts` (tests first)
+  - `initialize()` — staggered init (sequential, not parallel), reuses ready subprocesses, shuts down stale ones
+  - `initialize([])` — zero scanners, shuts down existing, resolves without error
+  - `scanOnce()` — grid sequencing, USB stagger delay logged, grid-start/grid-complete/cycle-complete events
+  - `scanOnce()` — file verification after scan-complete (exists + non-zero size)
+  - `scanOnce()` — rename failure emits `rename-error` event, `grid-complete` includes `renameErrors`
+  - `scanOnce()` — partial scanner failure mid-grid, waits for others, proceeds to next grid
+  - `scanInterval()` — repeats at interval, stops after duration, overtime event
+  - `cancelAll()` — cancels subprocesses, clears interval, emits cancelled
+  - `cancelAll()` — cancel during interval wait (not active scan)
+  - `shutdown()` — quit + force-kill timeout pattern
+  - `isScanning` — true when state is scanning or waiting
+  - Implements `ScanCoordinatorLike` — TypeScript compilation verifies contract
+- [x] Cherry-pick and adapt scan-coordinator.ts with all adaptations listed above
+- [x] Gate: tests pass, `npx tsc --noEmit` passes
+
+## Task 5: Verify all tests pass and no regressions
+
+Run full unit test suite and TypeScript compilation to confirm no regressions from type moves or new modules.
+
+- [x] `npx tsc --noEmit` passes (full project compilation)
+- [x] `npm run test:unit` passes (all unit tests including new files)
+- [x] New test files discovered and run by Vitest
+
+## Task 6: Deferred work
+
+- [x] File issue #185: Parallel subprocess initialization (references #144) — design error semantics for partial init failure
+- [x] Log retention made configurable at runtime via `GRAVISCAN_LOG_RETENTION_DAYS` env var (default 180 days)

--- a/openspec/changes/add-graviscan-coordinator-subprocess/tasks.md
+++ b/openspec/changes/add-graviscan-coordinator-subprocess/tasks.md
@@ -89,6 +89,47 @@ Run full unit test suite and TypeScript compilation to confirm no regressions fr
 - [x] `npm run test:unit` passes (all unit tests including new files)
 - [x] New test files discovered and run by Vitest
 
+## Task 7: Fix blocking review issues (TDD red-green)
+
+**B1: scanInterval leaves state as 'waiting' after cancelAll during sleep**
+
+- [ ] Write test: after cancelAll during interval wait, isScanning returns false (RED)
+- [ ] Fix: scanInterval sets state='idle' before emitting interval-complete (GREEN)
+
+**B2: No timeout on Promise.all in scanOnce — hang risk**
+
+- [ ] Write test: per-row scan timeout triggers scan-error for non-responding subprocess (RED)
+- [ ] Fix: add SCAN_ROW_TIMEOUT_MS with per-row timeout that rejects hanging promises (GREEN)
+
+**B3: scan_ended_at: null injected into forwarded events**
+
+- [ ] Write test: forwarded scan-complete events do not include scan_ended_at (RED)
+- [ ] Fix: remove scan_ended_at from forwarded events (only include in grid-complete) (GREEN)
+
+**B4: Multi-scanner tests use real 5s stagger delay**
+
+- [ ] Refactor stagger/partial-failure/cancel tests to use vi.useFakeTimers (no behavioral change)
+
+**B5: Flaky cancel-during-interval test**
+
+- [ ] Rewrite to use fake timers with deterministic advancement (no behavioral change)
+
+**I1: Regex path rewriting applied to full path, not just basename**
+
+- [ ] Write test: output_path with date-like directory name doesn't get mangled (RED)
+- [ ] Fix: apply regex to path.basename only, rejoin with dirname (GREEN)
+
+**I2: scanOnce doesn't check cancelled after Promise.all**
+
+- [ ] Write test: after cancel during active scan, no grid-complete emitted for remaining rows (RED)
+- [ ] Fix: check this.cancelled after Promise.all returns, skip file verification (GREEN)
+
+## Task 8: Verify all fixes pass and no regressions
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npm run test:unit` passes (all tests including new ones)
+- [ ] Multi-scanner tests complete in <2s (no real stagger delays)
+
 ## Task 6: Deferred work
 
 - [x] File issue #185: Parallel subprocess initialization (references #144) — design error semantics for partial init failure

--- a/openspec/changes/add-graviscan-coordinator-subprocess/tasks.md
+++ b/openspec/changes/add-graviscan-coordinator-subprocess/tasks.md
@@ -53,6 +53,7 @@ Cherry-pick `scanner-subprocess.ts` from `origin/graviscan/4-main-process` into 
 ## Task 4: Add scan-coordinator.ts to src/main/graviscan/
 
 Cherry-pick `scan-coordinator.ts` from `origin/graviscan/4-main-process` into `src/main/graviscan/scan-coordinator.ts`. Adaptations:
+
 - Import `PlateConfig`, `ScannerConfig` from `../../types/graviscan` (remove local definitions)
 - Import `ScannerSubprocess`, `ScanWorkerEvent` from `./scanner-subprocess`
 - Import `ScanCoordinatorLike` from `./session-handlers`, add `implements ScanCoordinatorLike`

--- a/openspec/specs/scanning/spec.md
+++ b/openspec/specs/scanning/spec.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 TBD - created by archiving change fix-scanner-event-listener-leak. Update Purpose after archive.
+
 ## Requirements
+
 ### Requirement: Scanner Event Listener Lifecycle
 
 Scanner event listeners SHALL be properly cleaned up when component unmounts or dependencies change to prevent memory leaks and duplicate event handling.
@@ -1391,4 +1393,3 @@ The system SHALL provide image reading, export, and cloud backup as testable fun
 - **GIVEN** an upload is already in progress (module-level `uploadInProgress` guard)
 - **WHEN** `uploadAllScans(db, onProgress)` is called
 - **THEN** the system SHALL return `{ success: false, errors: ['Upload already in progress'], uploaded: 0, skipped: 0, failed: 0 }`
-

--- a/src/main/graviscan/scan-coordinator.ts
+++ b/src/main/graviscan/scan-coordinator.ts
@@ -33,6 +33,13 @@ import type { ScanCoordinatorLike } from './session-handlers';
  */
 export const USB_STAGGER_DELAY_MS = 5000;
 
+/**
+ * Per-row scan timeout in milliseconds. If any subprocess does not emit
+ * cycle-done or exit within this window, it is treated as failed and
+ * the coordinator proceeds to the next row group.
+ */
+export const SCAN_ROW_TIMEOUT_MS = 90_000;
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -135,14 +142,16 @@ export class ScanCoordinator
           this.mock
         );
 
-        // Forward all events, injecting cycle number and per-grid timestamps
+        // Forward all events, injecting cycle number and grid start time.
+        // scan_ended_at is NOT included here — it is unknown until the row
+        // completes. It is available in the grid-complete event instead.
         sub.on('event', (event: ScanWorkerEvent) => {
-          this.emit('scan-event', {
+          const forwarded: Record<string, unknown> = {
             ...event,
             cycle_number: this.currentCycle,
             scan_started_at: this.currentGridStartedAt,
-            scan_ended_at: this.currentGridEndedAt,
-          });
+          };
+          this.emit('scan-event', forwarded);
         });
 
         sub.on('exit', (info: { scannerId: string; code: number | null }) => {
@@ -257,21 +266,31 @@ export class ScanCoordinator
         }
         isFirst = false;
 
-        // Update timestamps and cycle numbers in output paths
-        const platesToScan: PlateConfig[] = rowPlates.map((plate) => ({
-          ...plate,
-          output_path: plate.output_path
+        // Update timestamps and cycle numbers in output filenames only
+        // (apply regex to basename to avoid mangling date-like directory names)
+        const platesToScan: PlateConfig[] = rowPlates.map((plate) => {
+          const dir = path.dirname(plate.output_path);
+          const basename = path
+            .basename(plate.output_path)
             .replace(/(\d{8}T\d{6})/, stTimestamp)
-            .replace(/_cy\d+_/, `_cy${this.currentCycle}_`),
-        }));
+            .replace(/_cy\d+_/, `_cy${this.currentCycle}_`);
+          return {
+            ...plate,
+            output_path: path.join(dir, basename),
+          };
+        });
 
         const promise = new Promise<{
           scannerId: string;
           outputPaths: { plateIndex: string; path: string }[];
         } | null>((resolve) => {
-          const onCycleDone = () => {
+          const cleanup = () => {
+            clearTimeout(rowTimeout);
             sub.removeListener('cycle-done', onCycleDone);
             sub.removeListener('exit', onExit);
+          };
+          const onCycleDone = () => {
+            cleanup();
             resolve({
               scannerId,
               outputPaths: platesToScan.map((p) => ({
@@ -281,10 +300,20 @@ export class ScanCoordinator
             });
           };
           const onExit = () => {
-            sub.removeListener('cycle-done', onCycleDone);
-            sub.removeListener('exit', onExit);
+            cleanup();
             resolve(null);
           };
+          const rowTimeout = setTimeout(() => {
+            cleanup();
+            scanLog(
+              `[${scannerId}] Row scan timeout after ${SCAN_ROW_TIMEOUT_MS}ms`
+            );
+            this.emit('scan-error', {
+              scannerId,
+              error: `Row scan timeout after ${SCAN_ROW_TIMEOUT_MS}ms`,
+            });
+            resolve(null);
+          }, SCAN_ROW_TIMEOUT_MS);
           sub.on('cycle-done', onCycleDone);
           sub.on('exit', onExit);
         });
@@ -295,6 +324,10 @@ export class ScanCoordinator
 
       // Wait for ALL scanners to complete this row
       const results = await Promise.all(rowDonePromises);
+
+      // Check cancelled after await — if cancel fired during the scan,
+      // skip file verification and renaming for this row
+      if (this.cancelled) break;
 
       const gridEndedAt = new Date();
       const etTimestamp = gridEndedAt
@@ -469,6 +502,7 @@ export class ScanCoordinator
       }
     }
 
+    this.state = 'idle';
     const elapsed = Date.now() - this.startedAt;
     this.emit('interval-complete', {
       cyclesCompleted: this.currentCycle,

--- a/src/main/graviscan/scan-coordinator.ts
+++ b/src/main/graviscan/scan-coordinator.ts
@@ -331,8 +331,20 @@ export class ScanCoordinator
             continue;
           }
 
-          const stat = fs.statSync(outputPath);
-          if (stat.size === 0) {
+          let fileSize: number;
+          try {
+            fileSize = fs.statSync(outputPath).size;
+          } catch (statErr) {
+            const msg = `Cannot stat output file: ${outputPath}: ${statErr instanceof Error ? statErr.message : String(statErr)}`;
+            scanLog(`[${result.scannerId}] ${msg}`);
+            this.emit('scan-error', {
+              scannerId: result.scannerId,
+              plateIndex,
+              error: msg,
+            });
+            continue;
+          }
+          if (fileSize === 0) {
             const msg = `Output file is zero-size: ${outputPath}`;
             scanLog(`[${result.scannerId}] ${msg}`);
             this.emit('scan-error', {

--- a/src/main/graviscan/scan-coordinator.ts
+++ b/src/main/graviscan/scan-coordinator.ts
@@ -1,0 +1,540 @@
+/**
+ * Scan Coordinator
+ *
+ * Orchestrates multiple ScannerSubprocess instances for parallel scanning.
+ * Handles staggered subprocess startup, simultaneous scan triggers,
+ * interval/continuous mode timing, and cleanup.
+ *
+ * Adapted from Ben's scan-coordinator.ts (PR #138) with:
+ * - Types imported from shared types file
+ * - Implements ScanCoordinatorLike interface
+ * - Rename failures surfaced as events
+ * - File verification after scan-complete
+ * - USB stagger delay logged
+ * - Dead CoordinatorEvent type removed
+ */
+
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as path from 'path';
+import { ScannerSubprocess, ScanWorkerEvent } from './scanner-subprocess';
+import { scanLog } from './scan-logger';
+import type { PlateConfig, ScannerConfig } from '../../types/graviscan';
+import type { ScanCoordinatorLike } from './session-handlers';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * USB stagger delay in milliseconds between scanner device.start() calls.
+ * The epkowa SANE backend uses shared USB resources; simultaneous
+ * device.start() calls on the same USB bus cause "Invalid argument".
+ */
+export const USB_STAGGER_DELAY_MS = 5000;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type CoordinatorState =
+  | 'idle'
+  | 'initializing'
+  | 'scanning'
+  | 'waiting'
+  | 'shutting-down';
+
+// =============================================================================
+// ScanCoordinator
+// =============================================================================
+
+export class ScanCoordinator
+  extends EventEmitter
+  implements ScanCoordinatorLike
+{
+  private pythonPath: string;
+  private isPackaged: boolean;
+  private mock: boolean;
+  private subprocesses: Map<string, ScannerSubprocess> = new Map();
+  private state: CoordinatorState = 'idle';
+  private intervalTimer: ReturnType<typeof setTimeout> | null = null;
+  private sleepResolve: (() => void) | null = null;
+  private cancelled = false;
+  private currentCycle = 0;
+  private totalCycles = 0;
+  private startedAt: number | null = null;
+  // Per-grid timestamps (set during scanOnce, injected into scan events)
+  private currentGridStartedAt: string | null = null;
+  private currentGridEndedAt: string | null = null;
+
+  constructor(pythonPath: string, isPackaged: boolean, mock = false) {
+    super();
+    this.pythonPath = pythonPath;
+    this.isPackaged = isPackaged;
+    this.mock = mock;
+  }
+
+  get isScanning(): boolean {
+    return this.state === 'scanning' || this.state === 'waiting';
+  }
+
+  /**
+   * Staggered initialization: spawn subprocesses one at a time,
+   * waiting for each to signal ready before starting the next.
+   * This prevents SANE init contention.
+   *
+   * NOTE: Issue #144 argues that subprocess isolation makes sequential
+   * init unnecessary. Kept sequential for now; parallel init deferred
+   * to a future increment that designs partial-failure error semantics.
+   */
+  async initialize(scanners: ScannerConfig[]): Promise<void> {
+    this.state = 'initializing';
+    this.cancelled = false;
+
+    // Shut down subprocesses for scanners NOT in the new config
+    for (const [id, sub] of this.subprocesses) {
+      if (!scanners.find((s) => s.scannerId === id)) {
+        console.log(`[ScanCoordinator] Shutting down stale subprocess ${id}`);
+        await sub.shutdown(5000);
+        this.subprocesses.delete(id);
+      }
+    }
+
+    console.log(
+      `[ScanCoordinator] Initializing ${scanners.length} scanner(s)...`
+    );
+
+    for (const scanner of scanners) {
+      if (this.cancelled) break;
+
+      // Reuse existing subprocess if it's still alive and ready
+      const existing = this.subprocesses.get(scanner.scannerId);
+      if (existing && existing.isReady) {
+        console.log(
+          `[ScanCoordinator] Scanner ${scanner.scannerId} already ready, reusing`
+        );
+        continue;
+      }
+
+      // Shut down dead/stuck subprocess before respawning
+      if (existing) {
+        console.log(
+          `[ScanCoordinator] Scanner ${scanner.scannerId} subprocess not ready, respawning`
+        );
+        existing.removeAllListeners();
+        await existing.shutdown(5000);
+        this.subprocesses.delete(scanner.scannerId);
+      }
+
+      const sub = new ScannerSubprocess(
+        this.pythonPath,
+        this.isPackaged,
+        scanner.scannerId,
+        scanner.saneName,
+        this.mock
+      );
+
+      // Forward all events, injecting cycle number and per-grid timestamps
+      sub.on('event', (event: ScanWorkerEvent) => {
+        this.emit('scan-event', {
+          ...event,
+          cycle_number: this.currentCycle,
+          scan_started_at: this.currentGridStartedAt,
+          scan_ended_at: this.currentGridEndedAt,
+        });
+      });
+
+      sub.on('exit', (info: { scannerId: string; code: number | null }) => {
+        console.log(
+          `[ScanCoordinator] Subprocess ${info.scannerId} exited with code ${info.code}`
+        );
+        this.subprocesses.delete(info.scannerId);
+      });
+
+      this.subprocesses.set(scanner.scannerId, sub);
+
+      console.log(
+        `[ScanCoordinator] Spawning subprocess for scanner ${scanner.scannerId}...`
+      );
+      await sub.spawn();
+      console.log(`[ScanCoordinator] Scanner ${scanner.scannerId} ready`);
+    }
+
+    this.state = 'idle';
+    console.log(
+      `[ScanCoordinator] All ${scanners.length} scanner(s) initialized`
+    );
+  }
+
+  /**
+   * Scan all plates once, orchestrated per-grid.
+   *
+   * Iterates grids sequentially: for each grid index, all scanners scan
+   * that grid in parallel (with USB stagger), then we wait for all to
+   * finish before moving to the next grid.
+   */
+  async scanOnce(platesPerScanner: Map<string, PlateConfig[]>): Promise<void> {
+    this.state = 'scanning';
+    this.currentCycle++;
+
+    // Extract unique grid indices across all scanners, preserving order
+    const gridIndices: string[] = [];
+    for (const plates of platesPerScanner.values()) {
+      for (const plate of plates) {
+        if (!gridIndices.includes(plate.plate_index)) {
+          gridIndices.push(plate.plate_index);
+        }
+      }
+    }
+
+    // Group grids by row for 4grid mode (same-row grids scanned together)
+    const gridMode =
+      platesPerScanner.values().next().value?.[0]?.grid_mode || '2grid';
+    const rowGroups: string[][] = [];
+    if (gridMode === '4grid') {
+      const topRow = gridIndices.filter((i) => ['00', '01'].includes(i));
+      const bottomRow = gridIndices.filter((i) => ['10', '11'].includes(i));
+      if (topRow.length > 0) rowGroups.push(topRow);
+      if (bottomRow.length > 0) rowGroups.push(bottomRow);
+    } else {
+      // 2grid: each plate is its own row group
+      for (const gi of gridIndices) rowGroups.push([gi]);
+    }
+
+    console.log(
+      `[ScanCoordinator] Cycle ${this.currentCycle}: scanning ${gridIndices.length} grid(s) [${gridIndices.join(', ')}] in ${rowGroups.length} row group(s) across ${this.subprocesses.size} scanner(s)`
+    );
+
+    // Iterate row groups sequentially
+    for (const rowGrids of rowGroups) {
+      if (this.cancelled) break;
+
+      const gridStartedAt = new Date();
+      const stTimestamp = gridStartedAt
+        .toISOString()
+        .replace(/[-:]/g, '')
+        .slice(0, 15);
+      this.currentGridStartedAt = gridStartedAt.toISOString();
+      this.currentGridEndedAt = null;
+
+      // Emit grid-start for each grid in the row
+      for (const gridIndex of rowGrids) {
+        this.emit('grid-start', {
+          cycle: this.currentCycle,
+          gridIndex,
+          scanStartedAt: gridStartedAt.toISOString(),
+        });
+      }
+
+      scanLog(
+        `Cycle ${this.currentCycle}: row [${rowGrids.join(',')}] starting (st_${stTimestamp})`
+      );
+
+      // For each scanner, find all plates in this row and send them together
+      const rowDonePromises: Promise<{
+        scannerId: string;
+        outputPaths: { plateIndex: string; path: string }[];
+      } | null>[] = [];
+      let isFirst = true;
+
+      for (const [scannerId, sub] of this.subprocesses) {
+        const allPlates = platesPerScanner.get(scannerId);
+        if (!allPlates) continue;
+
+        const rowPlates = allPlates.filter((p) =>
+          rowGrids.includes(p.plate_index)
+        );
+        if (rowPlates.length === 0) continue;
+
+        if (!isFirst) {
+          scanLog(
+            `USB stagger: delaying scanner ${scannerId} by ${USB_STAGGER_DELAY_MS}ms`
+          );
+          await new Promise((r) => setTimeout(r, USB_STAGGER_DELAY_MS));
+        }
+        isFirst = false;
+
+        // Update timestamps and cycle numbers in output paths
+        const platesToScan: PlateConfig[] = rowPlates.map((plate) => ({
+          ...plate,
+          output_path: plate.output_path
+            .replace(/(\d{8}T\d{6})/, stTimestamp)
+            .replace(/_cy\d+_/, `_cy${this.currentCycle}_`),
+        }));
+
+        const promise = new Promise<{
+          scannerId: string;
+          outputPaths: { plateIndex: string; path: string }[];
+        } | null>((resolve) => {
+          const onCycleDone = () => {
+            sub.removeListener('cycle-done', onCycleDone);
+            sub.removeListener('exit', onExit);
+            resolve({
+              scannerId,
+              outputPaths: platesToScan.map((p) => ({
+                plateIndex: p.plate_index,
+                path: p.output_path,
+              })),
+            });
+          };
+          const onExit = () => {
+            sub.removeListener('cycle-done', onCycleDone);
+            sub.removeListener('exit', onExit);
+            resolve(null);
+          };
+          sub.on('cycle-done', onCycleDone);
+          sub.on('exit', onExit);
+        });
+
+        rowDonePromises.push(promise);
+        sub.scan(platesToScan);
+      }
+
+      // Wait for ALL scanners to complete this row
+      const results = await Promise.all(rowDonePromises);
+
+      const gridEndedAt = new Date();
+      const etTimestamp = gridEndedAt
+        .toISOString()
+        .replace(/[-:]/g, '')
+        .slice(0, 15);
+      this.currentGridEndedAt = gridEndedAt.toISOString();
+
+      scanLog(
+        `Cycle ${this.currentCycle}: row [${rowGrids.join(',')}] complete (et_${etTimestamp})`
+      );
+
+      // Verify output files and rename with end timestamps
+      const renamedByGrid: Map<
+        string,
+        { oldPath: string; newPath: string; scannerId: string }[]
+      > = new Map();
+      const renameErrors: {
+        scannerId: string;
+        filePath: string;
+        error: string;
+      }[] = [];
+      for (const gridIndex of rowGrids) renamedByGrid.set(gridIndex, []);
+
+      for (const result of results) {
+        if (!result) continue;
+        for (const { plateIndex, path: outputPath } of result.outputPaths) {
+          // Verify file existence and non-zero size
+          if (!fs.existsSync(outputPath)) {
+            const msg = `Output file missing after scan-complete: ${outputPath}`;
+            scanLog(`[${result.scannerId}] ${msg}`);
+            this.emit('scan-error', {
+              scannerId: result.scannerId,
+              plateIndex,
+              error: msg,
+            });
+            continue;
+          }
+
+          const stat = fs.statSync(outputPath);
+          if (stat.size === 0) {
+            const msg = `Output file is zero-size: ${outputPath}`;
+            scanLog(`[${result.scannerId}] ${msg}`);
+            this.emit('scan-error', {
+              scannerId: result.scannerId,
+              plateIndex,
+              error: msg,
+            });
+            continue;
+          }
+
+          // Rename to include end timestamp
+          try {
+            const dir = path.dirname(outputPath);
+            const ext = path.extname(outputPath);
+            const base = path.basename(outputPath, ext);
+
+            const newBase = base.replace(
+              /(_st_\d{8}T\d{6})/,
+              `$1_et_${etTimestamp}`
+            );
+            const newPath = path.join(dir, newBase + ext);
+
+            fs.renameSync(outputPath, newPath);
+            console.log(
+              `[ScanCoordinator] Renamed: ${path.basename(outputPath)} → ${path.basename(newPath)}`
+            );
+            renamedByGrid.get(plateIndex)?.push({
+              oldPath: outputPath,
+              newPath,
+              scannerId: result.scannerId,
+            });
+          } catch (err) {
+            const errMsg = err instanceof Error ? err.message : String(err);
+            scanLog(
+              `[${result.scannerId}] Failed to rename ${outputPath}: ${errMsg}`
+            );
+            renameErrors.push({
+              scannerId: result.scannerId,
+              filePath: outputPath,
+              error: errMsg,
+            });
+            this.emit('rename-error', {
+              scannerId: result.scannerId,
+              filePath: outputPath,
+              error: errMsg,
+            });
+          }
+        }
+      }
+
+      // Emit grid-complete per grid with shared row timestamps
+      for (const gridIndex of rowGrids) {
+        this.emit('grid-complete', {
+          cycle: this.currentCycle,
+          renamedFiles: renamedByGrid.get(gridIndex) || [],
+          renameErrors,
+          gridIndex,
+          scanStartedAt: gridStartedAt.toISOString(),
+          scanEndedAt: gridEndedAt.toISOString(),
+        });
+      }
+    }
+
+    this.emit('cycle-complete', { cycle: this.currentCycle });
+    this.state = 'idle';
+  }
+
+  /**
+   * Repeated scanning at intervals.
+   *
+   * Scans all plates, waits intervalMs, scans again, repeating until
+   * all expected cycles are completed or cancelled.
+   */
+  async scanInterval(
+    platesPerScanner: Map<string, PlateConfig[]>,
+    intervalMs: number,
+    durationMs: number
+  ): Promise<void> {
+    this.cancelled = false;
+    this.currentCycle = 0;
+    this.totalCycles = Math.ceil(durationMs / intervalMs);
+    this.startedAt = Date.now();
+
+    this.emit('interval-start', {
+      totalCycles: this.totalCycles,
+      intervalMs,
+      durationMs,
+      startedAt: this.startedAt,
+    });
+
+    while (!this.cancelled && this.currentCycle < this.totalCycles) {
+      const cycleStartMs = Date.now();
+      await this.scanOnce(platesPerScanner);
+      const scanDurationMs = Date.now() - cycleStartMs;
+
+      if (this.cancelled || this.currentCycle >= this.totalCycles) break;
+
+      // Emit overtime event if we've exceeded the original duration
+      const elapsed = Date.now() - this.startedAt;
+      if (elapsed > durationMs) {
+        this.emit('overtime', {
+          cycle: this.currentCycle,
+          totalCycles: this.totalCycles,
+          overtimeMs: elapsed - durationMs,
+        });
+      }
+
+      // Wait for remaining time: interval is st→st, so subtract scan duration
+      const remainingMs = Math.max(0, intervalMs - scanDurationMs);
+      this.state = 'waiting';
+      this.emit('interval-waiting', {
+        cycle: this.currentCycle,
+        totalCycles: this.totalCycles,
+        nextScanMs: remainingMs,
+      });
+
+      if (remainingMs > 0) {
+        await this.sleep(remainingMs);
+      }
+    }
+
+    const elapsed = Date.now() - this.startedAt;
+    this.emit('interval-complete', {
+      cyclesCompleted: this.currentCycle,
+      totalCycles: this.totalCycles,
+      cancelled: this.cancelled,
+      overtimeMs: Math.max(0, elapsed - durationMs),
+    });
+  }
+
+  /**
+   * Cancel all scanning. Stops interval timer and sends cancel to all subprocesses.
+   */
+  cancelAll(): void {
+    this.cancelled = true;
+
+    if (this.intervalTimer) {
+      clearTimeout(this.intervalTimer);
+      this.intervalTimer = null;
+    }
+    // Resolve any pending sleep so scanInterval loop can exit
+    if (this.sleepResolve) {
+      this.sleepResolve();
+      this.sleepResolve = null;
+    }
+
+    for (const sub of this.subprocesses.values()) {
+      sub.cancel();
+    }
+
+    this.state = 'idle';
+    this.emit('cancelled');
+  }
+
+  /**
+   * Graceful shutdown: quit all subprocesses, force-kill after timeout.
+   */
+  async shutdown(): Promise<void> {
+    this.state = 'shutting-down';
+    this.cancelled = true;
+
+    if (this.intervalTimer) {
+      clearTimeout(this.intervalTimer);
+      this.intervalTimer = null;
+    }
+    if (this.sleepResolve) {
+      this.sleepResolve();
+      this.sleepResolve = null;
+    }
+
+    const shutdownPromises = Array.from(this.subprocesses.values()).map((sub) =>
+      sub.shutdown(5000)
+    );
+
+    await Promise.all(shutdownPromises);
+    this.subprocesses.clear();
+    this.state = 'idle';
+  }
+
+  /**
+   * Force-kill all subprocesses (for app quit fallback).
+   */
+  killAll(): void {
+    for (const sub of this.subprocesses.values()) {
+      sub.kill();
+    }
+    this.subprocesses.clear();
+    this.state = 'idle';
+  }
+
+  // ===========================================================================
+  // Private
+  // ===========================================================================
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.sleepResolve = resolve;
+      this.intervalTimer = setTimeout(() => {
+        this.intervalTimer = null;
+        this.sleepResolve = null;
+        resolve();
+      }, ms);
+    });
+  }
+}

--- a/src/main/graviscan/scan-coordinator.ts
+++ b/src/main/graviscan/scan-coordinator.ts
@@ -104,63 +104,66 @@ export class ScanCoordinator
       `[ScanCoordinator] Initializing ${scanners.length} scanner(s)...`
     );
 
-    for (const scanner of scanners) {
-      if (this.cancelled) break;
+    try {
+      for (const scanner of scanners) {
+        if (this.cancelled) break;
 
-      // Reuse existing subprocess if it's still alive and ready
-      const existing = this.subprocesses.get(scanner.scannerId);
-      if (existing && existing.isReady) {
-        console.log(
-          `[ScanCoordinator] Scanner ${scanner.scannerId} already ready, reusing`
+        // Reuse existing subprocess if it's still alive and ready
+        const existing = this.subprocesses.get(scanner.scannerId);
+        if (existing && existing.isReady) {
+          console.log(
+            `[ScanCoordinator] Scanner ${scanner.scannerId} already ready, reusing`
+          );
+          continue;
+        }
+
+        // Shut down dead/stuck subprocess before respawning
+        if (existing) {
+          console.log(
+            `[ScanCoordinator] Scanner ${scanner.scannerId} subprocess not ready, respawning`
+          );
+          existing.removeAllListeners();
+          await existing.shutdown(5000);
+          this.subprocesses.delete(scanner.scannerId);
+        }
+
+        const sub = new ScannerSubprocess(
+          this.pythonPath,
+          this.isPackaged,
+          scanner.scannerId,
+          scanner.saneName,
+          this.mock
         );
-        continue;
-      }
 
-      // Shut down dead/stuck subprocess before respawning
-      if (existing) {
-        console.log(
-          `[ScanCoordinator] Scanner ${scanner.scannerId} subprocess not ready, respawning`
-        );
-        existing.removeAllListeners();
-        await existing.shutdown(5000);
-        this.subprocesses.delete(scanner.scannerId);
-      }
-
-      const sub = new ScannerSubprocess(
-        this.pythonPath,
-        this.isPackaged,
-        scanner.scannerId,
-        scanner.saneName,
-        this.mock
-      );
-
-      // Forward all events, injecting cycle number and per-grid timestamps
-      sub.on('event', (event: ScanWorkerEvent) => {
-        this.emit('scan-event', {
-          ...event,
-          cycle_number: this.currentCycle,
-          scan_started_at: this.currentGridStartedAt,
-          scan_ended_at: this.currentGridEndedAt,
+        // Forward all events, injecting cycle number and per-grid timestamps
+        sub.on('event', (event: ScanWorkerEvent) => {
+          this.emit('scan-event', {
+            ...event,
+            cycle_number: this.currentCycle,
+            scan_started_at: this.currentGridStartedAt,
+            scan_ended_at: this.currentGridEndedAt,
+          });
         });
-      });
 
-      sub.on('exit', (info: { scannerId: string; code: number | null }) => {
+        sub.on('exit', (info: { scannerId: string; code: number | null }) => {
+          console.log(
+            `[ScanCoordinator] Subprocess ${info.scannerId} exited with code ${info.code}`
+          );
+          this.subprocesses.delete(info.scannerId);
+        });
+
+        this.subprocesses.set(scanner.scannerId, sub);
+
         console.log(
-          `[ScanCoordinator] Subprocess ${info.scannerId} exited with code ${info.code}`
+          `[ScanCoordinator] Spawning subprocess for scanner ${scanner.scannerId}...`
         );
-        this.subprocesses.delete(info.scannerId);
-      });
-
-      this.subprocesses.set(scanner.scannerId, sub);
-
-      console.log(
-        `[ScanCoordinator] Spawning subprocess for scanner ${scanner.scannerId}...`
-      );
-      await sub.spawn();
-      console.log(`[ScanCoordinator] Scanner ${scanner.scannerId} ready`);
+        await sub.spawn();
+        console.log(`[ScanCoordinator] Scanner ${scanner.scannerId} ready`);
+      }
+    } finally {
+      this.state = 'idle';
     }
 
-    this.state = 'idle';
     console.log(
       `[ScanCoordinator] All ${scanners.length} scanner(s) initialized`
     );
@@ -495,7 +498,9 @@ export class ScanCoordinator
       sub.cancel();
     }
 
-    this.state = 'idle';
+    // Don't set state to idle here — scanOnce() or scanInterval() will
+    // set it when they exit after checking this.cancelled. Setting it
+    // prematurely would make isScanning return false while work is in-flight.
     this.emit('cancelled');
   }
 

--- a/src/main/graviscan/scan-logger.ts
+++ b/src/main/graviscan/scan-logger.ts
@@ -1,0 +1,96 @@
+/**
+ * Persistent file-based logging for GraviScan scan sessions.
+ *
+ * Writes to ~/.bloom/logs/graviscan-YYYY-MM-DD.log so scan runs are
+ * recorded and reviewable even in the packaged app (where stdout is lost).
+ *
+ * Adapted from Ben's scan-logger.ts (PR #138) with configurable retention.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const LOGS_DIR = path.join(os.homedir(), '.bloom', 'logs');
+
+/**
+ * Log retention in days. Default 180 for scientific workflows.
+ * Configurable via GRAVISCAN_LOG_RETENTION_DAYS environment variable.
+ */
+export const LOG_RETENTION_DAYS = parseInt(
+  process.env.GRAVISCAN_LOG_RETENTION_DAYS || '180',
+  10
+);
+
+let logStream: fs.WriteStream | null = null;
+let currentLogDate: string | null = null;
+
+function getLogDate(): string {
+  return new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+function getLogPath(date: string): string {
+  return path.join(LOGS_DIR, `graviscan-${date}.log`);
+}
+
+function ensureStream(): fs.WriteStream {
+  const today = getLogDate();
+  if (logStream && currentLogDate === today) return logStream;
+
+  // Close previous day's stream
+  if (logStream) {
+    logStream.end();
+  }
+
+  fs.mkdirSync(LOGS_DIR, { recursive: true });
+  logStream = fs.createWriteStream(getLogPath(today), { flags: 'a' });
+  currentLogDate = today;
+  return logStream;
+}
+
+/**
+ * Write a log entry with ISO timestamp prefix.
+ */
+export function scanLog(message: string): void {
+  const ts = new Date().toISOString();
+  const line = `${ts}  ${message}\n`;
+  try {
+    ensureStream().write(line);
+  } catch {
+    // Logging should never crash the app
+  }
+  // Also keep console output for dev mode
+  console.log(`[ScanLog] ${message}`);
+}
+
+/**
+ * Delete log files older than LOG_RETENTION_DAYS.
+ * Call once on app startup.
+ */
+export function cleanupOldLogs(): void {
+  try {
+    if (!fs.existsSync(LOGS_DIR)) return;
+    const cutoff = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    for (const file of fs.readdirSync(LOGS_DIR)) {
+      if (!file.startsWith('graviscan-') || !file.endsWith('.log')) continue;
+      const filePath = path.join(LOGS_DIR, file);
+      const stat = fs.statSync(filePath);
+      if (stat.mtimeMs < cutoff) {
+        fs.unlinkSync(filePath);
+      }
+    }
+  } catch {
+    // Non-critical — don't crash on cleanup failure
+  }
+}
+
+/**
+ * Close the log stream (call on app quit).
+ */
+export function closeScanLog(): void {
+  if (logStream) {
+    logStream.end();
+    logStream = null;
+    currentLogDate = null;
+  }
+}

--- a/src/main/graviscan/scan-logger.ts
+++ b/src/main/graviscan/scan-logger.ts
@@ -13,13 +13,21 @@ import * as path from 'path';
 
 const LOGS_DIR = path.join(os.homedir(), '.bloom', 'logs');
 
+const DEFAULT_LOG_RETENTION_DAYS = 180;
+
+function parseLogRetentionDays(value: string | undefined): number {
+  const parsed = parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_LOG_RETENTION_DAYS;
+}
+
 /**
  * Log retention in days. Default 180 for scientific workflows.
  * Configurable via GRAVISCAN_LOG_RETENTION_DAYS environment variable.
  */
-export const LOG_RETENTION_DAYS = parseInt(
-  process.env.GRAVISCAN_LOG_RETENTION_DAYS || '180',
-  10
+export const LOG_RETENTION_DAYS = parseLogRetentionDays(
+  process.env.GRAVISCAN_LOG_RETENTION_DAYS
 );
 
 let logStream: fs.WriteStream | null = null;

--- a/src/main/graviscan/scanner-subprocess.ts
+++ b/src/main/graviscan/scanner-subprocess.ts
@@ -246,7 +246,7 @@ export class ScannerSubprocess extends EventEmitter {
         resolve();
       }, timeoutMs);
 
-      this.proc!.on('exit', () => {
+      this.proc!.once('exit', () => {
         clearTimeout(timeout);
         resolve();
       });

--- a/src/main/graviscan/scanner-subprocess.ts
+++ b/src/main/graviscan/scanner-subprocess.ts
@@ -1,0 +1,318 @@
+/**
+ * Scanner Subprocess Manager
+ *
+ * Manages a single long-lived Python scan_worker.py subprocess.
+ * Each physical scanner gets its own ScannerSubprocess instance with
+ * an independent SANE context (sane.init/sane.open).
+ *
+ * Communication:
+ *   - stdin: JSON commands (scan, cancel, quit)
+ *   - stdout: EVENT: prefixed JSON events (ready, scan-started, scan-complete, etc.)
+ *   - stderr: Debug logging (not parsed)
+ *
+ * Adapted from Ben's scanner-subprocess.ts (PR #138).
+ */
+
+import { ChildProcess, spawn } from 'child_process';
+import { EventEmitter } from 'events';
+import path from 'path';
+import * as readline from 'readline';
+import { scanLog } from './scan-logger';
+import type { PlateConfig } from '../../types/graviscan';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ScanWorkerEvent {
+  type: string;
+  scanner_id: string;
+  plate_index?: string;
+  job_id?: string;
+  path?: string;
+  duration_ms?: number;
+  error?: string;
+  cycle?: number;
+  // Injected by ScanCoordinator for per-grid timestamp tracking
+  cycle_number?: number;
+  scan_started_at?: string | null;
+  scan_ended_at?: string | null;
+}
+
+type SubprocessState = 'idle' | 'starting' | 'ready' | 'scanning' | 'dead';
+
+// =============================================================================
+// ScannerSubprocess
+// =============================================================================
+
+export class ScannerSubprocess extends EventEmitter {
+  readonly scannerId: string;
+  readonly saneName: string;
+  private pythonPath: string;
+  private isPackaged: boolean;
+  private mock: boolean;
+  private proc: ChildProcess | null = null;
+  private state: SubprocessState = 'idle';
+  private rl: readline.Interface | null = null;
+
+  constructor(
+    pythonPath: string,
+    isPackaged: boolean,
+    scannerId: string,
+    saneName: string,
+    mock = false
+  ) {
+    super();
+    this.pythonPath = pythonPath;
+    this.isPackaged = isPackaged;
+    this.scannerId = scannerId;
+    this.saneName = saneName;
+    this.mock = mock;
+  }
+
+  get isReady(): boolean {
+    return this.state === 'ready';
+  }
+
+  get isAlive(): boolean {
+    return this.state !== 'dead' && this.state !== 'idle';
+  }
+
+  /**
+   * Spawn the subprocess and wait for the EVENT:ready signal.
+   * Resolves when the worker has completed sane.init() + sane.open().
+   */
+  async spawn(): Promise<void> {
+    if (this.proc) {
+      throw new Error(
+        `Subprocess for scanner ${this.scannerId} already spawned`
+      );
+    }
+
+    this.state = 'starting';
+
+    // In production (PyInstaller bundle): bloom-hardware --scan-worker --scanner-id ...
+    // In development (Python interpreter): python -m graviscan.scan_worker --scanner-id ...
+    const args = this.isPackaged
+      ? ['--scan-worker', '--scanner-id', this.scannerId]
+      : ['-m', 'graviscan.scan_worker', '--scanner-id', this.scannerId];
+    if (this.mock) {
+      args.push('--mock');
+    } else {
+      args.push('--device', this.saneName);
+    }
+
+    console.log(
+      `[ScannerSubprocess:${this.scannerId}] Spawning: ${this.pythonPath} ${args.join(' ')}`
+    );
+
+    this.proc = spawn(this.pythonPath, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        // In dev: ensure `python/` is on PYTHONPATH so `-m graviscan.scan_worker` resolves
+        PYTHONPATH: [path.join(process.cwd(), 'python'), process.env.PYTHONPATH]
+          .filter(Boolean)
+          .join(':'),
+      },
+    });
+
+    // Parse stdout line-by-line for EVENT: messages
+    this.rl = readline.createInterface({ input: this.proc.stdout! });
+    this.rl.on('line', (line) => this.handleLine(line));
+
+    // Log stderr to console + persistent log file
+    const stderrRl = readline.createInterface({ input: this.proc.stderr! });
+    stderrRl.on('line', (line) => {
+      console.log(`[ScanWorker:${this.scannerId}] ${line}`);
+      scanLog(`[${this.scannerId}] ${line}`);
+    });
+
+    // Handle process exit
+    this.proc.on('exit', (code, signal) => {
+      console.log(
+        `[ScannerSubprocess:${this.scannerId}] Exited: code=${code}, signal=${signal}`
+      );
+      this.state = 'dead';
+      this.emit('exit', { scannerId: this.scannerId, code, signal });
+    });
+
+    this.proc.on('error', (err) => {
+      console.error(
+        `[ScannerSubprocess:${this.scannerId}] Process error:`,
+        err
+      );
+      this.state = 'dead';
+      this.emit('error', { scannerId: this.scannerId, error: err.message });
+    });
+
+    // Wait for ready signal (no timeout — SANE open can be slow with some backends)
+    return new Promise<void>((resolve, reject) => {
+      const onReady = () => {
+        this.removeListener('ready', onReady);
+        this.removeListener('init-error', onError);
+        this.removeListener('exit', onExit);
+        resolve();
+      };
+
+      const onError = (event: ScanWorkerEvent) => {
+        this.removeListener('ready', onReady);
+        this.removeListener('init-error', onError);
+        this.removeListener('exit', onExit);
+        reject(
+          new Error(`Scanner ${this.scannerId} init failed: ${event.error}`)
+        );
+      };
+
+      const onExit = (info: { scannerId: string; code: number | null }) => {
+        this.removeListener('ready', onReady);
+        this.removeListener('init-error', onError);
+        this.removeListener('exit', onExit);
+        reject(
+          new Error(
+            `Scanner ${this.scannerId} process exited (code ${info.code}) before becoming ready`
+          )
+        );
+      };
+
+      this.on('ready', onReady);
+      this.on('init-error', onError);
+      this.on('exit', onExit);
+    });
+  }
+
+  /**
+   * Send a scan command for a batch of plates.
+   * Returns immediately — listen for events to track progress.
+   */
+  scan(plates: PlateConfig[]): void {
+    this.sendCommand({ action: 'scan', plates });
+    this.state = 'scanning';
+  }
+
+  /**
+   * Send cancel command — worker finishes current plate then returns to idle.
+   */
+  cancel(): void {
+    this.sendCommand({ action: 'cancel' });
+  }
+
+  /**
+   * Send quit command for clean shutdown.
+   */
+  quit(): void {
+    this.sendCommand({ action: 'quit' });
+  }
+
+  /**
+   * Force-kill the subprocess.
+   */
+  kill(): void {
+    if (this.proc && !this.proc.killed) {
+      this.proc.kill('SIGKILL');
+    }
+    this.state = 'dead';
+  }
+
+  /**
+   * Quit gracefully, then force-kill after timeout.
+   */
+  async shutdown(timeoutMs = 5000): Promise<void> {
+    if (!this.proc || this.state === 'dead' || this.state === 'idle') return;
+
+    this.quit();
+
+    return new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        console.warn(
+          `[ScannerSubprocess:${this.scannerId}] Force-killing after timeout`
+        );
+        this.kill();
+        resolve();
+      }, timeoutMs);
+
+      this.proc!.on('exit', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+  }
+
+  // ===========================================================================
+  // Private
+  // ===========================================================================
+
+  private sendCommand(cmd: Record<string, unknown>): void {
+    if (!this.proc || !this.proc.stdin || this.proc.killed) {
+      console.warn(
+        `[ScannerSubprocess:${this.scannerId}] Cannot send command — process not running`
+      );
+      return;
+    }
+    this.proc.stdin.write(JSON.stringify(cmd) + '\n');
+  }
+
+  private handleLine(line: string): void {
+    if (!line.startsWith('EVENT:')) {
+      // Non-event stdout — log it
+      console.log(`[ScanWorker:${this.scannerId}:stdout] ${line}`);
+      return;
+    }
+
+    const jsonStr = line.substring(6);
+    let event: ScanWorkerEvent;
+    try {
+      event = JSON.parse(jsonStr);
+    } catch {
+      scanLog(`[${this.scannerId}] Invalid EVENT JSON: ${jsonStr}`);
+      return;
+    }
+
+    switch (event.type) {
+      case 'ready':
+        this.state = 'ready';
+        this.emit('ready', event);
+        break;
+
+      case 'error':
+        // Init-time error (before ready)
+        if (this.state === 'starting') {
+          this.emit('init-error', event);
+        } else {
+          this.emit('scan-error', event);
+        }
+        break;
+
+      case 'scan-started':
+        this.emit('scan-started', event);
+        break;
+
+      case 'scan-complete':
+        this.emit('scan-complete', event);
+        break;
+
+      case 'scan-error':
+        this.emit('scan-error', event);
+        break;
+
+      case 'scan-cancelled':
+        this.emit('scan-cancelled', event);
+        break;
+
+      case 'cycle-done':
+        this.state = 'ready';
+        this.emit('cycle-done', event);
+        break;
+
+      default:
+        console.log(
+          `[ScannerSubprocess:${this.scannerId}] Unknown event: ${event.type}`
+        );
+        break;
+    }
+
+    // Also emit as a generic 'event' for the coordinator
+    this.emit('event', event);
+  }
+}

--- a/src/main/graviscan/scanner-subprocess.ts
+++ b/src/main/graviscan/scanner-subprocess.ts
@@ -114,7 +114,7 @@ export class ScannerSubprocess extends EventEmitter {
         // In dev: ensure `python/` is on PYTHONPATH so `-m graviscan.scan_worker` resolves
         PYTHONPATH: [path.join(process.cwd(), 'python'), process.env.PYTHONPATH]
           .filter(Boolean)
-          .join(':'),
+          .join(path.delimiter),
       },
     });
 
@@ -138,37 +138,43 @@ export class ScannerSubprocess extends EventEmitter {
       this.emit('exit', { scannerId: this.scannerId, code, signal });
     });
 
+    // Use 'process-error' instead of 'error' to avoid Node's special
+    // EventEmitter behavior that throws if no 'error' listener is attached.
     this.proc.on('error', (err) => {
       console.error(
         `[ScannerSubprocess:${this.scannerId}] Process error:`,
         err
       );
       this.state = 'dead';
-      this.emit('error', { scannerId: this.scannerId, error: err.message });
+      this.emit('process-error', {
+        scannerId: this.scannerId,
+        error: err.message,
+      });
     });
 
     // Wait for ready signal (no timeout — SANE open can be slow with some backends)
     return new Promise<void>((resolve, reject) => {
-      const onReady = () => {
+      const cleanup = () => {
         this.removeListener('ready', onReady);
-        this.removeListener('init-error', onError);
+        this.removeListener('init-error', onInitError);
         this.removeListener('exit', onExit);
+        this.removeListener('process-error', onProcessError);
+      };
+
+      const onReady = () => {
+        cleanup();
         resolve();
       };
 
-      const onError = (event: ScanWorkerEvent) => {
-        this.removeListener('ready', onReady);
-        this.removeListener('init-error', onError);
-        this.removeListener('exit', onExit);
+      const onInitError = (event: ScanWorkerEvent) => {
+        cleanup();
         reject(
           new Error(`Scanner ${this.scannerId} init failed: ${event.error}`)
         );
       };
 
       const onExit = (info: { scannerId: string; code: number | null }) => {
-        this.removeListener('ready', onReady);
-        this.removeListener('init-error', onError);
-        this.removeListener('exit', onExit);
+        cleanup();
         reject(
           new Error(
             `Scanner ${this.scannerId} process exited (code ${info.code}) before becoming ready`
@@ -176,9 +182,17 @@ export class ScannerSubprocess extends EventEmitter {
         );
       };
 
+      const onProcessError = (info: { scannerId: string; error: string }) => {
+        cleanup();
+        reject(
+          new Error(`Scanner ${this.scannerId} spawn failed: ${info.error}`)
+        );
+      };
+
       this.on('ready', onReady);
-      this.on('init-error', onError);
+      this.on('init-error', onInitError);
       this.on('exit', onExit);
+      this.on('process-error', onProcessError);
     });
   }
 

--- a/src/main/graviscan/session-handlers.ts
+++ b/src/main/graviscan/session-handlers.ts
@@ -7,8 +7,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { PlateConfig, ScannerConfig } from '../../types/graviscan';
+
 // ---------------------------------------------------------------------------
-// Local interface types (will move to shared types in a later increment)
+// Interface types
 // ---------------------------------------------------------------------------
 
 export interface ScanCoordinatorLike {
@@ -23,19 +25,6 @@ export interface ScanCoordinatorLike {
   cancelAll(): void;
   shutdown(): Promise<void>;
   on(event: string, listener: (...args: any[]) => void): this;
-}
-
-export interface ScannerConfig {
-  scannerId: string;
-  saneName: string;
-  plates: PlateConfig[];
-}
-
-export interface PlateConfig {
-  plate_index: string;
-  grid_mode: string;
-  resolution: number;
-  output_path: string;
 }
 
 export interface SessionFns {

--- a/src/types/graviscan.ts
+++ b/src/types/graviscan.ts
@@ -185,7 +185,7 @@ export const PLATE_INDICES: Record<GridMode, string[]> = {
  */
 export interface PlateConfig {
   plate_index: string;
-  grid_mode: string;
+  grid_mode: GridMode;
   resolution: number;
   output_path: string;
 }

--- a/src/types/graviscan.ts
+++ b/src/types/graviscan.ts
@@ -180,6 +180,27 @@ export const PLATE_INDICES: Record<GridMode, string[]> = {
 };
 
 /**
+ * Plate configuration for a single scan operation.
+ * Used by scan-coordinator, scanner-subprocess, and session-handlers.
+ */
+export interface PlateConfig {
+  plate_index: string;
+  grid_mode: string;
+  resolution: number;
+  output_path: string;
+}
+
+/**
+ * Scanner configuration for coordinator initialization.
+ * Maps a physical scanner to its SANE name and plate assignments.
+ */
+export interface ScannerConfig {
+  scannerId: string;
+  saneName: string;
+  plates: PlateConfig[];
+}
+
+/**
  * Scanner state during scan operations.
  */
 export type ScannerState =

--- a/tests/unit/graviscan-types.test.ts
+++ b/tests/unit/graviscan-types.test.ts
@@ -181,9 +181,10 @@ describe('GraviScan TypeScript Types', () => {
   });
 
   describe('ScanCoordinatorLike references shared types', () => {
-    it('interface accepts ScannerConfig in initialize()', () => {
-      // Verify ScanCoordinatorLike.initialize accepts ScannerConfig[]
-      // by creating a conforming mock — this is a compile-time check
+    it('can construct a conforming mock with shared types', () => {
+      // Verifies that ScanCoordinatorLike, ScannerConfig, and PlateConfig
+      // are importable and compatible. The `implements` clause on
+      // ScanCoordinator enforces this at tsc compile time for src/.
       /* eslint-disable @typescript-eslint/no-unused-vars */
       const mockCoordinator: ScanCoordinatorLike = {
         isScanning: false,

--- a/tests/unit/graviscan-types.test.ts
+++ b/tests/unit/graviscan-types.test.ts
@@ -184,6 +184,7 @@ describe('GraviScan TypeScript Types', () => {
     it('interface accepts ScannerConfig in initialize()', () => {
       // Verify ScanCoordinatorLike.initialize accepts ScannerConfig[]
       // by creating a conforming mock — this is a compile-time check
+      /* eslint-disable @typescript-eslint/no-unused-vars */
       const mockCoordinator: ScanCoordinatorLike = {
         isScanning: false,
         initialize: async (_scanners: ScannerConfig[]) => {},
@@ -199,6 +200,7 @@ describe('GraviScan TypeScript Types', () => {
           return this;
         } as ScanCoordinatorLike['on'],
       };
+      /* eslint-enable @typescript-eslint/no-unused-vars */
       expect(mockCoordinator.isScanning).toBe(false);
     });
   });

--- a/tests/unit/graviscan-types.test.ts
+++ b/tests/unit/graviscan-types.test.ts
@@ -12,6 +12,8 @@ import {
   generateScannerSlots,
   createEmptyScannerAssignment,
 } from '../../src/types/graviscan';
+import type { PlateConfig, ScannerConfig } from '../../src/types/graviscan';
+import type { ScanCoordinatorLike } from '../../src/main/graviscan/session-handlers';
 
 describe('GraviScan TypeScript Types', () => {
   describe('constants', () => {
@@ -139,6 +141,65 @@ describe('GraviScan TypeScript Types', () => {
     it('returns correct slot name for index 2', () => {
       const assignment = createEmptyScannerAssignment(2);
       expect(assignment.slot).toBe('Scanner 3');
+    });
+  });
+
+  describe('PlateConfig shared type', () => {
+    it('has expected fields', () => {
+      const plate: PlateConfig = {
+        plate_index: '00',
+        grid_mode: '2grid',
+        resolution: 600,
+        output_path: '/tmp/scan/plate00.tif',
+      };
+      expect(plate.plate_index).toBe('00');
+      expect(plate.grid_mode).toBe('2grid');
+      expect(plate.resolution).toBe(600);
+      expect(plate.output_path).toBe('/tmp/scan/plate00.tif');
+    });
+  });
+
+  describe('ScannerConfig shared type', () => {
+    it('has expected fields with PlateConfig array', () => {
+      const config: ScannerConfig = {
+        scannerId: 'scanner-1',
+        saneName: 'epkowa:interpreter:001:002',
+        plates: [
+          {
+            plate_index: '00',
+            grid_mode: '2grid',
+            resolution: 600,
+            output_path: '/tmp/scan/plate00.tif',
+          },
+        ],
+      };
+      expect(config.scannerId).toBe('scanner-1');
+      expect(config.saneName).toBe('epkowa:interpreter:001:002');
+      expect(config.plates).toHaveLength(1);
+      expect(config.plates[0].plate_index).toBe('00');
+    });
+  });
+
+  describe('ScanCoordinatorLike references shared types', () => {
+    it('interface accepts ScannerConfig in initialize()', () => {
+      // Verify ScanCoordinatorLike.initialize accepts ScannerConfig[]
+      // by creating a conforming mock — this is a compile-time check
+      const mockCoordinator: ScanCoordinatorLike = {
+        isScanning: false,
+        initialize: async (_scanners: ScannerConfig[]) => {},
+        scanOnce: async (_plates: Map<string, PlateConfig[]>) => {},
+        scanInterval: async (
+          _plates: Map<string, PlateConfig[]>,
+          _interval: number,
+          _duration: number
+        ) => {},
+        cancelAll: () => {},
+        shutdown: async () => {},
+        on: function () {
+          return this;
+        } as ScanCoordinatorLike['on'],
+      };
+      expect(mockCoordinator.isScanning).toBe(false);
     });
   });
 });

--- a/tests/unit/graviscan/scan-coordinator.test.ts
+++ b/tests/unit/graviscan/scan-coordinator.test.ts
@@ -1,0 +1,476 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Mock ScannerSubprocess
+vi.mock('../../../src/main/graviscan/scanner-subprocess', () => {
+  return {
+    ScannerSubprocess: vi.fn(),
+  };
+});
+
+vi.mock('../../../src/main/graviscan/scan-logger', () => ({
+  scanLog: vi.fn(),
+}));
+
+vi.mock('fs');
+
+import * as fs from 'fs';
+import { ScannerSubprocess } from '../../../src/main/graviscan/scanner-subprocess';
+import { scanLog } from '../../../src/main/graviscan/scan-logger';
+import type { PlateConfig, ScannerConfig } from '../../../src/types/graviscan';
+
+// Helper to create a mock subprocess instance
+function createMockSubprocess(scannerId: string): EventEmitter & {
+  scannerId: string;
+  isReady: boolean;
+  isAlive: boolean;
+  spawn: ReturnType<typeof vi.fn>;
+  scan: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+  quit: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+  shutdown: ReturnType<typeof vi.fn>;
+  removeAllListeners: ReturnType<typeof vi.fn>;
+} {
+  const emitter = new EventEmitter();
+  return Object.assign(emitter, {
+    scannerId,
+    isReady: true,
+    isAlive: true,
+    spawn: vi.fn().mockResolvedValue(undefined),
+    scan: vi.fn(),
+    cancel: vi.fn(),
+    quit: vi.fn(),
+    kill: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    removeAllListeners: vi.fn().mockReturnThis(),
+  });
+}
+
+// Track created subprocesses
+let createdSubprocesses: ReturnType<typeof createMockSubprocess>[];
+
+describe('ScanCoordinator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createdSubprocesses = [];
+
+    // Each time ScannerSubprocess is constructed, return a mock
+    vi.mocked(ScannerSubprocess).mockImplementation(
+      (_pythonPath, _isPackaged, scannerId) => {
+        const mock = createMockSubprocess(scannerId as string);
+        createdSubprocesses.push(mock);
+        return mock as unknown as ScannerSubprocess;
+      }
+    );
+
+    // Mock fs
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.renameSync).mockReturnValue(undefined);
+    vi.mocked(fs.statSync).mockReturnValue({ size: 1024 } as fs.Stats);
+
+    // Suppress console
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  // Helper to import fresh module (avoids state leaks between tests)
+  async function createCoordinator() {
+    // Dynamic import to get fresh module state isn't needed since
+    // ScanCoordinator is a class — each new instance is fresh
+    const { ScanCoordinator } = await import(
+      '../../../src/main/graviscan/scan-coordinator'
+    );
+    return new ScanCoordinator('/usr/bin/python3', false, false);
+  }
+
+  function makeScanners(count: number): ScannerConfig[] {
+    return Array.from({ length: count }, (_, i) => ({
+      scannerId: `scanner-${i + 1}`,
+      saneName: `epkowa:interpreter:001:${String(i + 2).padStart(3, '0')}`,
+      plates: [],
+    }));
+  }
+
+  function makePlatesMap(
+    scannerIds: string[],
+    gridMode = '2grid'
+  ): Map<string, PlateConfig[]> {
+    const plates: PlateConfig[] =
+      gridMode === '4grid'
+        ? [
+            {
+              plate_index: '00',
+              grid_mode: '4grid',
+              resolution: 600,
+              output_path: '/tmp/scan_st_20260410T120000_cy1_S1_00.tif',
+            },
+            {
+              plate_index: '01',
+              grid_mode: '4grid',
+              resolution: 600,
+              output_path: '/tmp/scan_st_20260410T120000_cy1_S1_01.tif',
+            },
+            {
+              plate_index: '10',
+              grid_mode: '4grid',
+              resolution: 600,
+              output_path: '/tmp/scan_st_20260410T120000_cy1_S1_10.tif',
+            },
+            {
+              plate_index: '11',
+              grid_mode: '4grid',
+              resolution: 600,
+              output_path: '/tmp/scan_st_20260410T120000_cy1_S1_11.tif',
+            },
+          ]
+        : [
+            {
+              plate_index: '00',
+              grid_mode: '2grid',
+              resolution: 600,
+              output_path: '/tmp/scan_st_20260410T120000_cy1_S1_00.tif',
+            },
+            {
+              plate_index: '01',
+              grid_mode: '2grid',
+              resolution: 600,
+              output_path: '/tmp/scan_st_20260410T120000_cy1_S1_01.tif',
+            },
+          ];
+
+    const map = new Map<string, PlateConfig[]>();
+    for (const id of scannerIds) {
+      map.set(id, [...plates]);
+    }
+    return map;
+  }
+
+  describe('initialize()', () => {
+    it('spawns subprocesses sequentially', async () => {
+      const coordinator = await createCoordinator();
+      const scanners = makeScanners(2);
+
+      await coordinator.initialize(scanners);
+
+      expect(ScannerSubprocess).toHaveBeenCalledTimes(2);
+      // Both should have spawn called
+      expect(createdSubprocesses[0].spawn).toHaveBeenCalled();
+      expect(createdSubprocesses[1].spawn).toHaveBeenCalled();
+    });
+
+    it('reuses ready subprocesses', async () => {
+      const coordinator = await createCoordinator();
+      const scanners = makeScanners(1);
+
+      // First init
+      await coordinator.initialize(scanners);
+      expect(ScannerSubprocess).toHaveBeenCalledTimes(1);
+
+      // Second init with same scanner — should reuse
+      await coordinator.initialize(scanners);
+      // Should NOT create a second subprocess
+      expect(ScannerSubprocess).toHaveBeenCalledTimes(1);
+    });
+
+    it('shuts down stale subprocesses', async () => {
+      const coordinator = await createCoordinator();
+
+      // Initialize with scanner-1 and scanner-2
+      await coordinator.initialize(makeScanners(2));
+      const sub1 = createdSubprocesses[0];
+      const sub2 = createdSubprocesses[1];
+
+      // Re-initialize with only scanner-1
+      await coordinator.initialize(makeScanners(1));
+
+      // scanner-2 should be shut down
+      expect(sub2.shutdown).toHaveBeenCalled();
+      // scanner-1 should be reused (no new spawn)
+      expect(sub1.spawn).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles zero scanners', async () => {
+      const coordinator = await createCoordinator();
+
+      // Initialize with 2 then re-init with 0
+      await coordinator.initialize(makeScanners(2));
+      const sub1 = createdSubprocesses[0];
+      const sub2 = createdSubprocesses[1];
+
+      await coordinator.initialize([]);
+
+      expect(sub1.shutdown).toHaveBeenCalled();
+      expect(sub2.shutdown).toHaveBeenCalled();
+    });
+  });
+
+  describe('scanOnce()', () => {
+    it('emits grid-start, grid-complete, and cycle-complete events', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      // When scan() is called, immediately emit cycle-done
+      sub.scan.mockImplementation(() => {
+        process.nextTick(() => sub.emit('cycle-done', {}));
+      });
+
+      const gridStart = vi.fn();
+      const gridComplete = vi.fn();
+      const cycleComplete = vi.fn();
+      coordinator.on('grid-start', gridStart);
+      coordinator.on('grid-complete', gridComplete);
+      coordinator.on('cycle-complete', cycleComplete);
+
+      const platesMap = makePlatesMap(['scanner-1']);
+      await coordinator.scanOnce(platesMap);
+
+      expect(gridStart).toHaveBeenCalled();
+      expect(gridComplete).toHaveBeenCalled();
+      expect(cycleComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ cycle: 1 })
+      );
+    });
+
+    it('logs USB stagger delay between scanners', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(2));
+
+      const sub1 = createdSubprocesses[0];
+      const sub2 = createdSubprocesses[1];
+
+      // Both emit cycle-done after scan
+      sub1.scan.mockImplementation(() => {
+        setImmediate(() => sub1.emit('cycle-done', {}));
+      });
+      sub2.scan.mockImplementation(() => {
+        setImmediate(() => sub2.emit('cycle-done', {}));
+      });
+
+      const platesMap = makePlatesMap(['scanner-1', 'scanner-2']);
+      await coordinator.scanOnce(platesMap);
+
+      // scanLog should have been called for stagger delay
+      expect(scanLog).toHaveBeenCalledWith(expect.stringContaining('stagger'));
+    }, 15000);
+
+    it('verifies file existence after scan-complete', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      sub.scan.mockImplementation(() => {
+        process.nextTick(() => sub.emit('cycle-done', {}));
+      });
+
+      const platesMap = makePlatesMap(['scanner-1']);
+      await coordinator.scanOnce(platesMap);
+
+      // fs.existsSync should have been called to verify output files
+      expect(fs.existsSync).toHaveBeenCalled();
+    });
+
+    it('emits rename-error when rename fails', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      sub.scan.mockImplementation(() => {
+        process.nextTick(() => sub.emit('cycle-done', {}));
+      });
+
+      // Make rename fail
+      vi.mocked(fs.renameSync).mockImplementation(() => {
+        throw new Error('ENOSPC: no space left on device');
+      });
+
+      const renameError = vi.fn();
+      coordinator.on('rename-error', renameError);
+
+      const platesMap = makePlatesMap(['scanner-1']);
+      await coordinator.scanOnce(platesMap);
+
+      expect(renameError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('ENOSPC'),
+        })
+      );
+    });
+
+    it('handles partial scanner failure mid-grid', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(2));
+
+      const sub1 = createdSubprocesses[0];
+      const sub2 = createdSubprocesses[1];
+
+      // sub1 completes normally
+      sub1.scan.mockImplementation(() => {
+        setImmediate(() => sub1.emit('cycle-done', {}));
+      });
+      // sub2 exits (crash)
+      sub2.scan.mockImplementation(() => {
+        setImmediate(() => sub2.emit('exit', {}));
+      });
+
+      const cycleComplete = vi.fn();
+      coordinator.on('cycle-complete', cycleComplete);
+
+      const platesMap = makePlatesMap(['scanner-1', 'scanner-2']);
+      await coordinator.scanOnce(platesMap);
+
+      // Should still complete the cycle
+      expect(cycleComplete).toHaveBeenCalled();
+    }, 15000);
+  });
+
+  describe('scanInterval()', () => {
+    it('repeats at interval and stops after duration', async () => {
+      vi.useFakeTimers();
+
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      sub.scan.mockImplementation(() => {
+        process.nextTick(() => sub.emit('cycle-done', {}));
+      });
+
+      const intervalStart = vi.fn();
+      const intervalComplete = vi.fn();
+      coordinator.on('interval-start', intervalStart);
+      coordinator.on('interval-complete', intervalComplete);
+
+      const platesMap = makePlatesMap(['scanner-1']);
+      const intervalPromise = coordinator.scanInterval(platesMap, 10000, 25000);
+
+      // Advance through all cycles
+      await vi.advanceTimersByTimeAsync(30000);
+      await intervalPromise;
+
+      expect(intervalStart).toHaveBeenCalled();
+      expect(intervalComplete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          totalCycles: 3, // ceil(25000/10000)
+        })
+      );
+    });
+  });
+
+  describe('cancelAll()', () => {
+    it('cancels subprocesses and emits cancelled event', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const cancelled = vi.fn();
+      coordinator.on('cancelled', cancelled);
+
+      coordinator.cancelAll();
+
+      expect(createdSubprocesses[0].cancel).toHaveBeenCalled();
+      expect(cancelled).toHaveBeenCalled();
+    });
+
+    it('cancels during interval wait', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      sub.scan.mockImplementation(() => {
+        setImmediate(() => sub.emit('cycle-done', {}));
+      });
+
+      const intervalComplete = vi.fn();
+      coordinator.on('interval-complete', intervalComplete);
+
+      const platesMap = makePlatesMap(['scanner-1']);
+      // Use very short intervals for test speed
+      const intervalPromise = coordinator.scanInterval(platesMap, 100, 500);
+
+      // Wait a bit for first cycle, then cancel
+      await new Promise((r) => setTimeout(r, 200));
+      coordinator.cancelAll();
+      await intervalPromise;
+
+      expect(intervalComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ cancelled: true })
+      );
+    }, 15000);
+  });
+
+  describe('shutdown()', () => {
+    it('shuts down all subprocesses and clears map', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(2));
+
+      await coordinator.shutdown();
+
+      expect(createdSubprocesses[0].shutdown).toHaveBeenCalled();
+      expect(createdSubprocesses[1].shutdown).toHaveBeenCalled();
+      expect(coordinator.isScanning).toBe(false);
+    });
+  });
+
+  describe('isScanning', () => {
+    it('returns false when idle', async () => {
+      const coordinator = await createCoordinator();
+      expect(coordinator.isScanning).toBe(false);
+    });
+
+    it('returns true during scanning', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      let scanCallCount = 0;
+      sub.scan.mockImplementation(() => {
+        scanCallCount++;
+        if (scanCallCount === 1) {
+          // First row: delay cycle-done so we can check isScanning
+          setTimeout(() => sub.emit('cycle-done', {}), 50);
+        } else {
+          // Subsequent rows: complete immediately
+          setImmediate(() => sub.emit('cycle-done', {}));
+        }
+      });
+
+      const platesMap = makePlatesMap(['scanner-1']);
+      const scanPromise = coordinator.scanOnce(platesMap);
+
+      // Give a tick for state transition
+      await new Promise((r) => setTimeout(r, 10));
+      expect(coordinator.isScanning).toBe(true);
+
+      await scanPromise;
+      expect(coordinator.isScanning).toBe(false);
+    });
+  });
+
+  describe('implements ScanCoordinatorLike', () => {
+    it('satisfies the interface contract at compile time', async () => {
+      // This is primarily a compile-time check — if ScanCoordinator
+      // doesn't implement ScanCoordinatorLike, tsc --noEmit will fail
+      const { ScanCoordinator } = await import(
+        '../../../src/main/graviscan/scan-coordinator'
+      );
+      const coordinator = new ScanCoordinator('/usr/bin/python3', false, false);
+
+      // Runtime checks for interface methods
+      expect(typeof coordinator.initialize).toBe('function');
+      expect(typeof coordinator.scanOnce).toBe('function');
+      expect(typeof coordinator.scanInterval).toBe('function');
+      expect(typeof coordinator.cancelAll).toBe('function');
+      expect(typeof coordinator.shutdown).toBe('function');
+      expect(typeof coordinator.on).toBe('function');
+      expect(typeof coordinator.isScanning).toBe('boolean');
+    });
+  });
+});

--- a/tests/unit/graviscan/scan-coordinator.test.ts
+++ b/tests/unit/graviscan/scan-coordinator.test.ts
@@ -210,6 +210,28 @@ describe('ScanCoordinator', () => {
       expect(sub1.shutdown).toHaveBeenCalled();
       expect(sub2.shutdown).toHaveBeenCalled();
     });
+
+    it('resets state to idle when spawn fails', async () => {
+      const coordinator = await createCoordinator();
+
+      // Make the first subprocess spawn fail
+      const failScanner = makeScanners(1);
+      vi.mocked(ScannerSubprocess).mockImplementationOnce(
+        (_pythonPath, _isPackaged, scannerId) => {
+          const mock = createMockSubprocess(scannerId as string);
+          mock.spawn.mockRejectedValue(new Error('SANE device not found'));
+          createdSubprocesses.push(mock);
+          return mock as unknown as ScannerSubprocess;
+        }
+      );
+
+      await expect(coordinator.initialize(failScanner)).rejects.toThrow(
+        'SANE device not found'
+      );
+
+      // State should be reset to idle, not stuck in 'initializing'
+      expect(coordinator.isScanning).toBe(false);
+    });
   });
 
   describe('scanOnce()', () => {
@@ -483,9 +505,10 @@ describe('ScanCoordinator', () => {
   });
 
   describe('implements ScanCoordinatorLike', () => {
-    it('satisfies the interface contract at compile time', async () => {
-      // This is primarily a compile-time check — if ScanCoordinator
-      // doesn't implement ScanCoordinatorLike, tsc --noEmit will fail
+    it('exposes all interface methods at runtime', async () => {
+      // The `implements ScanCoordinatorLike` on the class is enforced by
+      // tsc when compiling src/. This test verifies the methods exist at
+      // runtime as a safety net.
       const { ScanCoordinator } = await import(
         '../../../src/main/graviscan/scan-coordinator'
       );

--- a/tests/unit/graviscan/scan-coordinator.test.ts
+++ b/tests/unit/graviscan/scan-coordinator.test.ts
@@ -278,6 +278,34 @@ describe('ScanCoordinator', () => {
       expect(fs.existsSync).toHaveBeenCalled();
     });
 
+    it('emits scan-error when statSync throws (filesystem race)', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      sub.scan.mockImplementation(() => {
+        process.nextTick(() => sub.emit('cycle-done', {}));
+      });
+
+      // File exists but statSync throws (e.g., permissions, race condition)
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.statSync).mockImplementation(() => {
+        throw new Error('EACCES: permission denied');
+      });
+
+      const scanError = vi.fn();
+      coordinator.on('scan-error', scanError);
+
+      const platesMap = makePlatesMap(['scanner-1']);
+      await coordinator.scanOnce(platesMap);
+
+      expect(scanError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('Cannot stat'),
+        })
+      );
+    });
+
     it('emits rename-error when rename fails', async () => {
       const coordinator = await createCoordinator();
       await coordinator.initialize(makeScanners(1));

--- a/tests/unit/graviscan/scan-coordinator.test.ts
+++ b/tests/unit/graviscan/scan-coordinator.test.ts
@@ -262,7 +262,80 @@ describe('ScanCoordinator', () => {
       );
     });
 
+    it('regex path rewriting only affects filename, not directory', async () => {
+      vi.useFakeTimers();
+
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      let capturedPlates: PlateConfig[] = [];
+      sub.scan.mockImplementation((plates: PlateConfig[]) => {
+        capturedPlates = plates;
+        setImmediate(() => sub.emit('cycle-done', {}));
+      });
+
+      // Create plates with a date-like directory path
+      const platesMap = new Map<string, PlateConfig[]>();
+      platesMap.set('scanner-1', [
+        {
+          plate_index: '00',
+          grid_mode: '2grid' as const,
+          resolution: 600,
+          // Directory contains 20260410T000000 which matches \d{8}T\d{6}
+          output_path:
+            '/scans/20260410T000000/exp1_st_20260410T120000_cy1_S1_00.tif',
+        },
+      ]);
+
+      const scanPromise = coordinator.scanOnce(platesMap);
+      await vi.advanceTimersByTimeAsync(100_000);
+      await scanPromise;
+
+      // The directory portion should NOT have been modified
+      expect(capturedPlates[0].output_path).toContain(
+        '/scans/20260410T000000/'
+      );
+      // The filename portion SHOULD have the new timestamp
+      expect(capturedPlates[0].output_path).not.toContain('st_20260410T120000');
+
+      vi.useRealTimers();
+    });
+
+    it('forwarded scan-event does not include scan_ended_at before row completes', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      // Emit a scan-complete event BEFORE cycle-done
+      sub.scan.mockImplementation(() => {
+        // Emit scan-complete first (individual plate done)
+        sub.emit('event', {
+          type: 'scan-complete',
+          scanner_id: 'scanner-1',
+          plate_index: '00',
+          path: '/tmp/out.tif',
+        });
+        // Then cycle-done (all plates for this scanner done)
+        process.nextTick(() => sub.emit('cycle-done', {}));
+      });
+
+      const scanEvent = vi.fn();
+      coordinator.on('scan-event', scanEvent);
+
+      const platesMap = makePlatesMap(['scanner-1']);
+      await coordinator.scanOnce(platesMap);
+
+      // The forwarded scan-event should NOT have scan_ended_at
+      // (it's unknown until the row completes)
+      expect(scanEvent).toHaveBeenCalled();
+      const firstCall = scanEvent.mock.calls[0][0];
+      expect(firstCall).not.toHaveProperty('scan_ended_at');
+    });
+
     it('logs USB stagger delay between scanners', async () => {
+      vi.useFakeTimers();
+
       const coordinator = await createCoordinator();
       await coordinator.initialize(makeScanners(2));
 
@@ -278,11 +351,18 @@ describe('ScanCoordinator', () => {
       });
 
       const platesMap = makePlatesMap(['scanner-1', 'scanner-2']);
-      await coordinator.scanOnce(platesMap);
+      const scanPromise = coordinator.scanOnce(platesMap);
+
+      // Advance through stagger delays + row timeouts
+      await vi.advanceTimersByTimeAsync(100_000);
+      await vi.advanceTimersByTimeAsync(100_000);
+      await scanPromise;
 
       // scanLog should have been called for stagger delay
       expect(scanLog).toHaveBeenCalledWith(expect.stringContaining('stagger'));
-    }, 15000);
+
+      vi.useRealTimers();
+    });
 
     it('verifies file existence after scan-complete', async () => {
       const coordinator = await createCoordinator();
@@ -356,6 +436,8 @@ describe('ScanCoordinator', () => {
     });
 
     it('handles partial scanner failure mid-grid', async () => {
+      vi.useFakeTimers();
+
       const coordinator = await createCoordinator();
       await coordinator.initialize(makeScanners(2));
 
@@ -375,10 +457,84 @@ describe('ScanCoordinator', () => {
       coordinator.on('cycle-complete', cycleComplete);
 
       const platesMap = makePlatesMap(['scanner-1', 'scanner-2']);
-      await coordinator.scanOnce(platesMap);
+      const scanPromise = coordinator.scanOnce(platesMap);
+
+      // Advance through stagger delays + row timeouts
+      await vi.advanceTimersByTimeAsync(100_000);
+      await vi.advanceTimersByTimeAsync(100_000);
+      await scanPromise;
 
       // Should still complete the cycle
       expect(cycleComplete).toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('skips file verification after cancel during active row', async () => {
+      vi.useFakeTimers();
+
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      sub.scan.mockImplementation(() => {
+        // Cancel while the scan is "in progress" — then emit cycle-done
+        coordinator.cancelAll();
+        setImmediate(() => sub.emit('cycle-done', {}));
+      });
+
+      // Reset fs mocks to track calls during this specific test
+      vi.mocked(fs.existsSync).mockClear();
+
+      const platesMap = makePlatesMap(['scanner-1']);
+      const scanPromise = coordinator.scanOnce(platesMap);
+
+      await vi.advanceTimersByTimeAsync(100_000);
+      await scanPromise;
+
+      // After cancel, file verification (existsSync) should NOT run
+      // for the cancelled row
+      expect(fs.existsSync).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('emits scan-error and proceeds when subprocess does not respond within row timeout', async () => {
+      vi.useFakeTimers();
+
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      // Subprocess never emits cycle-done or exit — simulates a hang
+      sub.scan.mockImplementation(() => {
+        // intentionally do nothing
+      });
+
+      const scanError = vi.fn();
+      coordinator.on('scan-error', scanError);
+      const cycleComplete = vi.fn();
+      coordinator.on('cycle-complete', cycleComplete);
+
+      const platesMap = makePlatesMap(['scanner-1']);
+      const scanPromise = coordinator.scanOnce(platesMap);
+
+      // Advance past row timeouts for all row groups (2 rows for 2grid)
+      // Each row has a 90s timeout
+      await vi.advanceTimersByTimeAsync(100_000);
+      await vi.advanceTimersByTimeAsync(100_000);
+      await scanPromise;
+
+      // Should have emitted scan-error for the timed-out subprocess
+      expect(scanError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('timeout'),
+        })
+      );
+      // Should still complete the cycle (not hang forever)
+      expect(cycleComplete).toHaveBeenCalled();
+
+      vi.useRealTimers();
     }, 15000);
   });
 
@@ -430,6 +586,8 @@ describe('ScanCoordinator', () => {
     });
 
     it('cancels during interval wait', async () => {
+      vi.useFakeTimers();
+
       const coordinator = await createCoordinator();
       await coordinator.initialize(makeScanners(1));
 
@@ -442,18 +600,58 @@ describe('ScanCoordinator', () => {
       coordinator.on('interval-complete', intervalComplete);
 
       const platesMap = makePlatesMap(['scanner-1']);
-      // Use very short intervals for test speed
-      const intervalPromise = coordinator.scanInterval(platesMap, 100, 500);
+      const intervalPromise = coordinator.scanInterval(
+        platesMap,
+        60000, // 60s interval
+        300000 // 5 min duration = 5 cycles
+      );
 
-      // Wait a bit for first cycle, then cancel
-      await new Promise((r) => setTimeout(r, 200));
+      // Advance 1ms to let first scanOnce start, then advance through
+      // row timeouts for first cycle (2 rows × 90s each)
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(91_000); // first row done
+      await vi.advanceTimersByTimeAsync(91_000); // second row done
+      // Now scanOnce is complete, scanInterval enters sleep(remainingMs)
+      // Cancel during the sleep
       coordinator.cancelAll();
+      // Advance to let scanInterval exit
+      await vi.advanceTimersByTimeAsync(1000);
       await intervalPromise;
 
       expect(intervalComplete).toHaveBeenCalledWith(
         expect.objectContaining({ cancelled: true })
       );
-    }, 15000);
+
+      vi.useRealTimers();
+    });
+
+    it('isScanning returns false after cancelAll during interval wait', async () => {
+      vi.useFakeTimers();
+
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      sub.scan.mockImplementation(() => {
+        setImmediate(() => sub.emit('cycle-done', {}));
+      });
+
+      const platesMap = makePlatesMap(['scanner-1']);
+      const intervalPromise = coordinator.scanInterval(platesMap, 10000, 30000);
+
+      // Let first cycle complete, enter waiting phase
+      await vi.advanceTimersByTimeAsync(1000);
+      // Cancel during the wait
+      coordinator.cancelAll();
+      // Advance past the sleep
+      await vi.advanceTimersByTimeAsync(15000);
+      await intervalPromise;
+
+      // B1: isScanning MUST be false after interval completes
+      expect(coordinator.isScanning).toBe(false);
+
+      vi.useRealTimers();
+    });
   });
 
   describe('shutdown()', () => {

--- a/tests/unit/graviscan/scan-logger.test.ts
+++ b/tests/unit/graviscan/scan-logger.test.ts
@@ -1,0 +1,244 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+vi.mock('fs');
+vi.mock('os', async (importOriginal) => {
+  const original = await importOriginal<typeof import('os')>();
+  return {
+    ...original,
+    homedir: vi.fn().mockReturnValue('/mock-home'),
+  };
+});
+
+const LOGS_DIR = path.join('/mock-home', '.bloom', 'logs');
+
+describe('scan-logger', () => {
+  let mockStream: {
+    write: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+
+    // Re-mock after resetModules
+    vi.mocked(os.homedir).mockReturnValue('/mock-home');
+
+    mockStream = {
+      write: vi.fn(),
+      end: vi.fn(),
+    };
+    vi.mocked(fs.createWriteStream).mockReturnValue(
+      mockStream as unknown as fs.WriteStream
+    );
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readdirSync).mockReturnValue([]);
+    // Suppress console.log from scanLog
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('scanLog()', () => {
+    it('writes timestamped entry to daily log file', async () => {
+      const { scanLog } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+
+      scanLog('Scanner S1 started');
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(LOGS_DIR, {
+        recursive: true,
+      });
+      expect(fs.createWriteStream).toHaveBeenCalledWith(
+        expect.stringContaining('graviscan-'),
+        { flags: 'a' }
+      );
+      expect(mockStream.write).toHaveBeenCalledWith(
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}T.+Scanner S1 started\n$/)
+      );
+    });
+
+    it('creates log directory if it does not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      const { scanLog } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+
+      scanLog('test message');
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(LOGS_DIR, {
+        recursive: true,
+      });
+    });
+
+    it('reuses stream for same day', async () => {
+      const { scanLog } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+
+      scanLog('message 1');
+      scanLog('message 2');
+
+      // createWriteStream should only be called once for same day
+      expect(fs.createWriteStream).toHaveBeenCalledTimes(1);
+      expect(mockStream.write).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not crash if write throws', async () => {
+      mockStream.write.mockImplementation(() => {
+        throw new Error('disk full');
+      });
+      const { scanLog } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+
+      // Should not throw
+      expect(() => scanLog('test')).not.toThrow();
+    });
+  });
+
+  describe('cleanupOldLogs()', () => {
+    it('deletes files older than LOG_RETENTION_DAYS', async () => {
+      const now = Date.now();
+      const oldDate = now - 200 * 24 * 60 * 60 * 1000; // 200 days ago
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'graviscan-2025-01-01.log' as unknown as string,
+      ]);
+      vi.mocked(fs.statSync).mockReturnValue({
+        mtimeMs: oldDate,
+      } as fs.Stats);
+      vi.mocked(fs.unlinkSync).mockReturnValue(undefined);
+
+      const { cleanupOldLogs } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+      cleanupOldLogs();
+
+      expect(fs.unlinkSync).toHaveBeenCalledWith(
+        path.join(LOGS_DIR, 'graviscan-2025-01-01.log')
+      );
+    });
+
+    it('preserves recent log files', async () => {
+      const now = Date.now();
+      const recentDate = now - 10 * 24 * 60 * 60 * 1000; // 10 days ago
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'graviscan-2026-04-01.log' as unknown as string,
+      ]);
+      vi.mocked(fs.statSync).mockReturnValue({
+        mtimeMs: recentDate,
+      } as fs.Stats);
+
+      const { cleanupOldLogs } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+      cleanupOldLogs();
+
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it('skips non-graviscan files', async () => {
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'other-file.log' as unknown as string,
+        'graviscan-2025-01-01.log' as unknown as string,
+      ]);
+      vi.mocked(fs.statSync).mockReturnValue({
+        mtimeMs: 0,
+      } as fs.Stats);
+      vi.mocked(fs.unlinkSync).mockReturnValue(undefined);
+
+      const { cleanupOldLogs } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+      cleanupOldLogs();
+
+      // Should only try to unlink the graviscan file
+      expect(fs.unlinkSync).toHaveBeenCalledTimes(1);
+      expect(fs.unlinkSync).toHaveBeenCalledWith(
+        expect.stringContaining('graviscan-2025-01-01.log')
+      );
+    });
+
+    it('does nothing if logs directory does not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const { cleanupOldLogs } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+      cleanupOldLogs();
+
+      expect(fs.readdirSync).not.toHaveBeenCalled();
+    });
+
+    it('does not crash on error', async () => {
+      vi.mocked(fs.readdirSync).mockImplementation(() => {
+        throw new Error('permission denied');
+      });
+
+      const { cleanupOldLogs } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+
+      expect(() => cleanupOldLogs()).not.toThrow();
+    });
+  });
+
+  describe('closeScanLog()', () => {
+    it('flushes and closes the stream', async () => {
+      const { scanLog, closeScanLog } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+
+      // Open a stream first
+      scanLog('open stream');
+      expect(mockStream.write).toHaveBeenCalled();
+
+      closeScanLog();
+      expect(mockStream.end).toHaveBeenCalled();
+    });
+
+    it('subsequent scanLog after close opens a new stream', async () => {
+      const newStream = {
+        write: vi.fn(),
+        end: vi.fn(),
+      };
+      const { scanLog, closeScanLog } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+
+      // Open and close
+      scanLog('first');
+      closeScanLog();
+
+      // Now mock a new stream for the next call
+      vi.mocked(fs.createWriteStream).mockReturnValue(
+        newStream as unknown as fs.WriteStream
+      );
+
+      scanLog('second');
+
+      // createWriteStream should have been called again
+      expect(fs.createWriteStream).toHaveBeenCalledTimes(2);
+      expect(newStream.write).toHaveBeenCalledWith(
+        expect.stringContaining('second')
+      );
+    });
+
+    it('is safe to call when no stream is open', async () => {
+      const { closeScanLog } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+
+      // Should not throw
+      expect(() => closeScanLog()).not.toThrow();
+    });
+  });
+});

--- a/tests/unit/graviscan/scan-logger.test.ts
+++ b/tests/unit/graviscan/scan-logger.test.ts
@@ -249,5 +249,35 @@ describe('scan-logger', () => {
       );
       expect(LOG_RETENTION_DAYS).toBe(180);
     });
+
+    it('falls back to 180 for non-numeric env var value', async () => {
+      vi.resetModules();
+      process.env.GRAVISCAN_LOG_RETENTION_DAYS = 'abc';
+      const { LOG_RETENTION_DAYS } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+      expect(LOG_RETENTION_DAYS).toBe(180);
+      delete process.env.GRAVISCAN_LOG_RETENTION_DAYS;
+    });
+
+    it('falls back to 180 for negative env var value', async () => {
+      vi.resetModules();
+      process.env.GRAVISCAN_LOG_RETENTION_DAYS = '-5';
+      const { LOG_RETENTION_DAYS } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+      expect(LOG_RETENTION_DAYS).toBe(180);
+      delete process.env.GRAVISCAN_LOG_RETENTION_DAYS;
+    });
+
+    it('uses custom value when env var is valid', async () => {
+      vi.resetModules();
+      process.env.GRAVISCAN_LOG_RETENTION_DAYS = '90';
+      const { LOG_RETENTION_DAYS } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+      expect(LOG_RETENTION_DAYS).toBe(90);
+      delete process.env.GRAVISCAN_LOG_RETENTION_DAYS;
+    });
   });
 });

--- a/tests/unit/graviscan/scan-logger.test.ts
+++ b/tests/unit/graviscan/scan-logger.test.ts
@@ -241,4 +241,13 @@ describe('scan-logger', () => {
       expect(() => closeScanLog()).not.toThrow();
     });
   });
+
+  describe('LOG_RETENTION_DAYS', () => {
+    it('defaults to 180 when env var is not set', async () => {
+      const { LOG_RETENTION_DAYS } = await import(
+        '../../../src/main/graviscan/scan-logger'
+      );
+      expect(LOG_RETENTION_DAYS).toBe(180);
+    });
+  });
 });

--- a/tests/unit/graviscan/scanner-subprocess.test.ts
+++ b/tests/unit/graviscan/scanner-subprocess.test.ts
@@ -23,6 +23,9 @@ function createMockProcess() {
       // Store handlers so we can trigger them in tests
       mockProcessHandlers[event] = cb;
     }),
+    once: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      mockProcessHandlers[event] = cb;
+    }),
     kill: vi.fn(),
     killed: false,
     pid: 12345,

--- a/tests/unit/graviscan/scanner-subprocess.test.ts
+++ b/tests/unit/graviscan/scanner-subprocess.test.ts
@@ -1,0 +1,396 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Mock child_process with factory pattern (Pattern B from python-process.test.ts)
+// stdout/stderr need resume() for readline.createInterface compatibility
+function createMockReadable() {
+  const emitter = new EventEmitter();
+  (emitter as unknown as Record<string, unknown>).resume = vi.fn();
+  (emitter as unknown as Record<string, unknown>).pause = vi.fn();
+  (emitter as unknown as Record<string, unknown>).setEncoding = vi.fn();
+  return emitter;
+}
+
+function createMockProcess() {
+  const stdout = createMockReadable();
+  const stderr = createMockReadable();
+  return {
+    stdout,
+    stderr,
+    stdin: { write: vi.fn() },
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      // Store handlers so we can trigger them in tests
+      mockProcessHandlers[event] = cb;
+    }),
+    kill: vi.fn(),
+    killed: false,
+    pid: 12345,
+  };
+}
+
+let mockProc: ReturnType<typeof createMockProcess>;
+let mockProcessHandlers: Record<string, (...args: unknown[]) => void>;
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => {
+    mockProc = createMockProcess();
+    return mockProc;
+  }),
+}));
+
+vi.mock('../../../src/main/graviscan/scan-logger', () => ({
+  scanLog: vi.fn(),
+}));
+
+import { spawn } from 'child_process';
+import { ScannerSubprocess } from '../../../src/main/graviscan/scanner-subprocess';
+import { scanLog } from '../../../src/main/graviscan/scan-logger';
+
+/** Emit a line on mock stdout (readline needs data events with newlines) */
+function emitLine(line: string) {
+  mockProc.stdout.emit('data', line + '\n');
+}
+
+describe('ScannerSubprocess', () => {
+  let subprocess: ScannerSubprocess;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcessHandlers = {};
+    subprocess = new ScannerSubprocess(
+      '/usr/bin/python3',
+      false, // not packaged
+      'scanner-1',
+      'epkowa:interpreter:001:002',
+      false // not mock
+    );
+    // Suppress console output
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('spawn()', () => {
+    it('spawns process and resolves on EVENT:ready', async () => {
+      const spawnPromise = subprocess.spawn();
+
+      // Simulate EVENT:ready on stdout
+      emitLine('EVENT:{"type":"ready","scanner_id":"scanner-1"}');
+
+      await spawnPromise;
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/bin/python3',
+        expect.arrayContaining([
+          '-m',
+          'graviscan.scan_worker',
+          '--scanner-id',
+          'scanner-1',
+          '--device',
+          'epkowa:interpreter:001:002',
+        ]),
+        expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+      );
+      expect(subprocess.isReady).toBe(true);
+      expect(subprocess.isAlive).toBe(true);
+    });
+
+    it('uses bloom-hardware args in packaged mode', async () => {
+      subprocess = new ScannerSubprocess(
+        '/app/bloom-hardware',
+        true, // packaged
+        'scanner-1',
+        'epkowa:interpreter:001:002'
+      );
+
+      const spawnPromise = subprocess.spawn();
+      emitLine('EVENT:{"type":"ready","scanner_id":"scanner-1"}');
+      await spawnPromise;
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/app/bloom-hardware',
+        expect.arrayContaining([
+          '--scan-worker',
+          '--scanner-id',
+          'scanner-1',
+          '--device',
+          'epkowa:interpreter:001:002',
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    it('rejects on spawn error (ENOENT)', async () => {
+      // Add error listener to prevent unhandled EventEmitter error
+      subprocess.on('error', () => {});
+
+      const spawnPromise = subprocess.spawn();
+
+      // Simulate spawn error — triggers 'error' on proc which sets state=dead
+      const handler = mockProcessHandlers['error'];
+      if (handler) handler(new Error('spawn ENOENT'));
+      // Also trigger exit since that's what happens with ENOENT
+      const exitHandler = mockProcessHandlers['exit'];
+      if (exitHandler) exitHandler(null, null);
+
+      await expect(spawnPromise).rejects.toThrow();
+    });
+
+    it('rejects if process exits before ready', async () => {
+      const spawnPromise = subprocess.spawn();
+
+      // Simulate unexpected exit
+      const exitHandler = mockProcessHandlers['exit'];
+      if (exitHandler) exitHandler(1, null);
+
+      await expect(spawnPromise).rejects.toThrow('exited');
+    });
+
+    it('rejects on init-error event', async () => {
+      const spawnPromise = subprocess.spawn();
+
+      emitLine(
+        'EVENT:{"type":"error","scanner_id":"scanner-1","error":"SANE device not found"}'
+      );
+
+      await expect(spawnPromise).rejects.toThrow('SANE device not found');
+    });
+  });
+
+  describe('scan()', () => {
+    it('sends JSON scan command to stdin and transitions to scanning', async () => {
+      // Get to ready state
+      const spawnPromise = subprocess.spawn();
+      emitLine('EVENT:{"type":"ready","scanner_id":"scanner-1"}');
+      await spawnPromise;
+
+      const plates = [
+        {
+          plate_index: '00',
+          grid_mode: '2grid',
+          resolution: 600,
+          output_path: '/tmp/scan/plate00.tif',
+        },
+      ];
+
+      subprocess.scan(plates);
+
+      expect(mockProc.stdin.write).toHaveBeenCalledWith(
+        expect.stringContaining('"action":"scan"')
+      );
+      const written = mockProc.stdin.write.mock.calls[0][0];
+      const parsed = JSON.parse(written.replace('\n', ''));
+      expect(parsed.action).toBe('scan');
+      expect(parsed.plates).toEqual(plates);
+    });
+  });
+
+  describe('cancel()', () => {
+    it('sends cancel command to stdin', async () => {
+      const spawnPromise = subprocess.spawn();
+      emitLine('EVENT:{"type":"ready","scanner_id":"scanner-1"}');
+      await spawnPromise;
+
+      subprocess.cancel();
+
+      expect(mockProc.stdin.write).toHaveBeenCalledWith(
+        expect.stringContaining('"action":"cancel"')
+      );
+    });
+  });
+
+  describe('event parsing', () => {
+    beforeEach(async () => {
+      const spawnPromise = subprocess.spawn();
+      emitLine('EVENT:{"type":"ready","scanner_id":"scanner-1"}');
+      await spawnPromise;
+    });
+
+    it('emits typed events for scan-started', () => {
+      const handler = vi.fn();
+      subprocess.on('scan-started', handler);
+
+      emitLine(
+        'EVENT:{"type":"scan-started","scanner_id":"scanner-1","plate_index":"00"}'
+      );
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'scan-started',
+          scanner_id: 'scanner-1',
+          plate_index: '00',
+        })
+      );
+    });
+
+    it('emits typed events for scan-complete', () => {
+      const handler = vi.fn();
+      subprocess.on('scan-complete', handler);
+
+      emitLine(
+        'EVENT:{"type":"scan-complete","scanner_id":"scanner-1","path":"/tmp/out.tif","duration_ms":5000}'
+      );
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'scan-complete',
+          path: '/tmp/out.tif',
+          duration_ms: 5000,
+        })
+      );
+    });
+
+    it('emits typed events for scan-error', () => {
+      const handler = vi.fn();
+      subprocess.on('scan-error', handler);
+
+      emitLine(
+        'EVENT:{"type":"scan-error","scanner_id":"scanner-1","error":"SANE IO error"}'
+      );
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'scan-error',
+          error: 'SANE IO error',
+        })
+      );
+    });
+
+    it('emits typed events for scan-cancelled', () => {
+      const handler = vi.fn();
+      subprocess.on('scan-cancelled', handler);
+
+      emitLine('EVENT:{"type":"scan-cancelled","scanner_id":"scanner-1"}');
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'scan-cancelled' })
+      );
+    });
+
+    it('emits typed events for cycle-done and transitions back to ready', () => {
+      const handler = vi.fn();
+      subprocess.on('cycle-done', handler);
+
+      // Force state to scanning first
+      subprocess.scan([
+        {
+          plate_index: '00',
+          grid_mode: '2grid',
+          resolution: 600,
+          output_path: '/tmp/scan.tif',
+        },
+      ]);
+
+      emitLine('EVENT:{"type":"cycle-done","scanner_id":"scanner-1"}');
+
+      expect(handler).toHaveBeenCalled();
+      expect(subprocess.isReady).toBe(true);
+    });
+
+    it('emits generic event for coordinator forwarding', () => {
+      const handler = vi.fn();
+      subprocess.on('event', handler);
+
+      emitLine('EVENT:{"type":"scan-complete","scanner_id":"scanner-1"}');
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'scan-complete' })
+      );
+    });
+
+    it('logs malformed EVENT JSON as warning without crashing', () => {
+      emitLine('EVENT:not-valid-json');
+
+      // Should not throw, subprocess should still be alive
+      expect(subprocess.isReady).toBe(true);
+      // The malformed line should be logged
+      expect(scanLog).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid EVENT JSON')
+      );
+    });
+  });
+
+  describe('process exit with non-zero code', () => {
+    it('emits exit event and transitions to dead', async () => {
+      const spawnPromise = subprocess.spawn();
+      emitLine('EVENT:{"type":"ready","scanner_id":"scanner-1"}');
+      await spawnPromise;
+
+      const exitHandler = vi.fn();
+      subprocess.on('exit', exitHandler);
+
+      // Trigger exit
+      const procExitHandler = mockProcessHandlers['exit'];
+      if (procExitHandler) procExitHandler(1, 'SIGTERM');
+
+      expect(exitHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scannerId: 'scanner-1',
+          code: 1,
+          signal: 'SIGTERM',
+        })
+      );
+    });
+  });
+
+  describe('shutdown()', () => {
+    it('sends quit command and resolves on exit', async () => {
+      const spawnPromise = subprocess.spawn();
+      emitLine('EVENT:{"type":"ready","scanner_id":"scanner-1"}');
+      await spawnPromise;
+
+      const shutdownPromise = subprocess.shutdown(5000);
+
+      // Check quit command was sent
+      expect(mockProc.stdin.write).toHaveBeenCalledWith(
+        expect.stringContaining('"action":"quit"')
+      );
+
+      // Simulate clean exit
+      const procExitHandler = mockProcessHandlers['exit'];
+      if (procExitHandler) procExitHandler(0, null);
+
+      await shutdownPromise;
+    });
+
+    it('force-kills after timeout', async () => {
+      vi.useFakeTimers();
+
+      const spawnPromise = subprocess.spawn();
+      emitLine('EVENT:{"type":"ready","scanner_id":"scanner-1"}');
+      await spawnPromise;
+
+      const shutdownPromise = subprocess.shutdown(100);
+
+      // Advance past timeout without triggering exit
+      vi.advanceTimersByTime(150);
+
+      await shutdownPromise;
+
+      expect(mockProc.kill).toHaveBeenCalledWith('SIGKILL');
+
+      vi.useRealTimers();
+    });
+
+    it('resolves immediately if already dead', async () => {
+      // Never spawned — state is idle
+      await subprocess.shutdown();
+      // Should resolve without error
+    });
+  });
+
+  describe('sendCommand safety', () => {
+    it('warns if process is not running', () => {
+      // Not spawned yet — proc is null
+      subprocess.cancel();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Cannot send command')
+      );
+    });
+  });
+});

--- a/tests/unit/graviscan/scanner-subprocess.test.ts
+++ b/tests/unit/graviscan/scanner-subprocess.test.ts
@@ -126,19 +126,14 @@ describe('ScannerSubprocess', () => {
     });
 
     it('rejects on spawn error (ENOENT)', async () => {
-      // Add error listener to prevent unhandled EventEmitter error
-      subprocess.on('error', () => {});
-
       const spawnPromise = subprocess.spawn();
 
-      // Simulate spawn error — triggers 'error' on proc which sets state=dead
+      // Simulate spawn error — triggers 'process-error' (renamed from 'error'
+      // to avoid Node EventEmitter special behavior)
       const handler = mockProcessHandlers['error'];
       if (handler) handler(new Error('spawn ENOENT'));
-      // Also trigger exit since that's what happens with ENOENT
-      const exitHandler = mockProcessHandlers['exit'];
-      if (exitHandler) exitHandler(null, null);
 
-      await expect(spawnPromise).rejects.toThrow();
+      await expect(spawnPromise).rejects.toThrow('spawn failed');
     });
 
     it('rejects if process exits before ready', async () => {


### PR DESCRIPTION
## Summary

- Cherry-pick and adapt `scan-coordinator.ts`, `scanner-subprocess.ts`, and `scan-logger.ts` from PR #138 into `src/main/graviscan/`
- Move `PlateConfig` and `ScannerConfig` types from session-handlers.ts local definitions into `src/types/graviscan.ts` (shared IPC-facing types)
- `ScanCoordinator` explicitly `implements ScanCoordinatorLike` for compile-time contract enforcement
- 47 new unit tests across 3 test files (scan-coordinator, scanner-subprocess, scan-logger)
- No IPC wiring — modules are isolated and tested, ready for Increment 3c

### Adaptations from Ben's branch (not cherry-picked as-is)

- Rename failures surface as `rename-error` events instead of silent `console.error`
- File existence + non-zero size verification after `scan-complete`
- USB stagger delay logged via `scanLog()` with scanner ID and delay duration
- Log retention configurable via `GRAVISCAN_LOG_RETENTION_DAYS` env var (default 180 days)
- Sleep/cancel race condition fixed — `cancelAll()` resolves pending sleep promise
- Dead `CoordinatorEvent` type removed
- `USB_STAGGER_DELAY_MS` extracted as named module-level constant

### Related issues

- Part of GraviScan integration epic #126
- Source: PR #138 (branch `origin/graviscan/4-main-process`), issue #130
- Filed #185 for deferred parallel subprocess initialization (#144)

### OpenSpec proposal

`openspec/changes/add-graviscan-coordinator-subprocess/` — reviewed by 5 specialized subagents

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx eslint` on all changed files — zero errors
- [x] `npx prettier --check` — all files formatted
- [x] `npm run test:unit` — 631 passed, 9 skipped (0 regressions)
- [ ] CI: lint, compilation, unit tests, Python tests
- [ ] E2E: N/A (no IPC wiring or UI changes in this increment)
- [ ] Packaging: N/A (modules not yet reachable from app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)