### PR TITLE
refactor: extract GraviScan wiring from main.ts into testable module

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -324,9 +324,13 @@ After ALL subagents return:
 4. **Post the review to GitHub**:
 
 > **Note:** GitHub does not allow requesting changes or approving your own PRs.
-> Always attempt the desired action first; if it fails with "Can not request changes on your own pull request"
-> or "Can not approve your own pull request", automatically fall back to `--comment` with the same body
-> and a note at the top indicating the intended verdict.
+> **Do NOT use the try-then-fallback pattern** (`gh pr review --approve || gh pr review --comment`),
+> because `--approve` posts the comment body before the approval step fails, causing a duplicate.
+> Instead, check authorship first:
+> `PR_AUTHOR=$(gh pr view $PR_NUMBER --json author --jq '.author.login')`
+> `GH_USER=$(gh api user --jq '.login')`
+> If they match, go directly to `--comment` with a verdict note. Only attempt `--approve` or
+> `--request-changes` on someone else's PR.
 
 For REQUEST_CHANGES (attempt first, fall back to --comment on own-PR error):
 
@@ -353,8 +357,11 @@ BODY="$(cat <<'EOF'
 EOF
 )"
 
-gh pr review $PR_NUMBER --request-changes -b "$BODY" 2>&1 || \
-gh pr review $PR_NUMBER --comment -b "$(printf '> **Verdict: REQUEST\_CHANGES** (posted as comment — GitHub does not allow requesting changes on your own PR)\n\n%s' "$BODY")"
+if [ "$IS_OWN_PR" = "true" ]; then
+  gh pr review $PR_NUMBER --comment -b "$(printf '> **Verdict: REQUEST_CHANGES** (posted as comment — cannot request changes on own PR)\n\n%s' "$BODY")"
+else
+  gh pr review $PR_NUMBER --request-changes -b "$BODY"
+fi
 ```
 
 For APPROVE (attempt first, fall back to --comment on own-PR error):
@@ -374,8 +381,11 @@ BODY="$(cat <<'EOF'
 EOF
 )"
 
-gh pr review $PR_NUMBER --approve -b "$BODY" 2>&1 || \
-gh pr review $PR_NUMBER --comment -b "$(printf '> **Verdict: APPROVE** (posted as comment — GitHub does not allow approving your own PR)\n\n%s' "$BODY")"
+if [ "$IS_OWN_PR" = "true" ]; then
+  gh pr review $PR_NUMBER --comment -b "$(printf '> **Verdict: APPROVE** (posted as comment — cannot approve own PR)\n\n%s' "$BODY")"
+else
+  gh pr review $PR_NUMBER --approve -b "$BODY"
+fi
 ```
 
 For COMMENT (no fallback needed):

--- a/openspec/changes/refactor-extract-graviscan-wiring/design.md
+++ b/openspec/changes/refactor-extract-graviscan-wiring/design.md
@@ -113,14 +113,15 @@ if (_coordinatorCreating) {
 
 Resets all 4 pieces of module-level state to initial values AND calls `_resetRegistration()` from `register-handlers.ts` to clear the `registered` boolean guard. Without this, tests calling `initGraviScan()` after reset would throw `"GraviScan IPC handlers are already registered"`.
 
-```typescript
-import { _resetRegistration } from './register-handlers';
+The `_resetRegistration` import is **dynamic** (not static) to avoid pulling in `register-handlers.ts` and its transitive dependencies (`scanner-handlers` → `image-handlers` → `sharp`) at module load time. A static import would defeat the lazy-loading strategy and cause the packaged app to load `sharp` even in cylinderscan mode.
 
-export function _resetWiringState(): void {
+```typescript
+export async function _resetWiringState(): Promise<void> {
   scanSession = null;
   scanCoordinator = null;
   _getMainWindow = null;
   _coordinatorCreating = null;
+  const { _resetRegistration } = await import('./register-handlers');
   _resetRegistration();
 }
 ```

--- a/openspec/changes/refactor-extract-graviscan-wiring/design.md
+++ b/openspec/changes/refactor-extract-graviscan-wiring/design.md
@@ -1,0 +1,136 @@
+# Design: Extract GraviScan Wiring
+
+## Module Boundary
+
+### New file: `src/main/graviscan/wiring.ts`
+
+This module owns all GraviScan wiring state and orchestration. It is **side-effect-free** at load time — no code runs on import, only declarations and type-only imports.
+
+#### State (module-level, not exported)
+
+| Variable               | Type                                    | Purpose                                   |
+| ---------------------- | --------------------------------------- | ----------------------------------------- |
+| `scanSession`          | `ScanSessionState \| null`              | Current scan session                      |
+| `scanCoordinator`      | `ScanCoordinator \| null`               | Lazy-created coordinator singleton        |
+| `_getMainWindow`       | `(() => BrowserWindow \| null) \| null` | Cached window getter for event forwarding |
+| `_coordinatorCreating` | `Promise<ScanCoordinator> \| null`      | Race guard for concurrent creation        |
+
+#### Exports
+
+| Export                              | Type                 | Purpose                                                         |
+| ----------------------------------- | -------------------- | --------------------------------------------------------------- |
+| `graviSessionFns`                   | `SessionFns` (const) | Session state getter/setter/marker                              |
+| `setupCoordinatorEventForwarding()` | function             | Wires coordinator events to renderer IPC                        |
+| `getOrCreateCoordinator()`          | async function       | Lazy singleton with promise memoization                         |
+| `initGraviScan()`                   | async function       | Conditional init: mode check, handler registration, log cleanup |
+| `shutdownGraviScan()`               | async function       | **NEW** — coordinator shutdown + scan log close                 |
+| `_resetWiringState()`               | function             | Test-only: reset all module state for clean test isolation      |
+
+### Dependencies
+
+`wiring.ts` uses only type-only imports at module level — no runtime Electron imports:
+
+```typescript
+// Type-only (no side effects, erased at compile time)
+import type { SessionFns } from './session-handlers';
+import type { ScanSessionState } from '../../types/graviscan';
+import type { ScanCoordinator } from './scan-coordinator';
+import type { BrowserWindow } from 'electron';
+```
+
+The `app.isPackaged` value needed by `getOrCreateCoordinator()` is obtained via a dynamic import inside the function body:
+
+```typescript
+const { app } = await import('electron');
+const isPackaged = app.isPackaged;
+```
+
+This keeps the module free of runtime Electron imports at the top level, meaning it can be imported in a Node test environment with only `vi.mock('electron')` intercepting the dynamic import inside `getOrCreateCoordinator()`. The dynamic import is already in an async function that does other dynamic imports (`scan-coordinator`, `python-paths`), so this adds no architectural overhead.
+
+## Changes to main.ts
+
+After extraction, main.ts:
+
+1. **Removes**: Lines 102-240 (GraviScan state + 4 functions + type imports for `SessionFns`, `ScanSessionState`, `ScanCoordinator`), lines 1383-1406 (shutdown logic)
+2. **Adds**: `import { initGraviScan, shutdownGraviScan } from './graviscan/wiring';`
+3. **Replaces** shutdown block with: `await shutdownGraviScan();`
+4. **Keeps**: The `initGraviScan(...)` call site unchanged (same arguments)
+
+## Changes to barrel (index.ts)
+
+Add re-exports for the public API consumed by main.ts:
+
+```typescript
+export { initGraviScan, shutdownGraviScan } from './wiring';
+```
+
+Note: `graviSessionFns`, `setupCoordinatorEventForwarding`, and `getOrCreateCoordinator` are **not** re-exported from the barrel. They are internal to the graviscan module — consumed only by `wiring.ts` itself and directly imported in tests. This keeps the barrel surface area minimal.
+
+## Shutdown Ordering
+
+### Current sequence (main.ts before-quit handler)
+
+1. Coordinator shutdown (`scanCoordinator.shutdown()`) — lines 1383-1393
+2. Database close (`closeDatabase()`) — lines 1396-1398
+3. Scan log close (`closeScanLog()`) — lines 1401-1406
+
+### New sequence
+
+1. `await shutdownGraviScan()` — coordinator shutdown + scan log close
+2. `await closeDatabase()`
+
+`closeScanLog()` moves from after database close to before it. **This is safe** because `closeScanLog()` closes a filesystem write stream (`~/.bloom/logs/graviscan-YYYY-MM-DD.log`) with no database dependency. The database close has no dependency on the scan log either. The coordinator shutdown still happens before database close, preserving the critical ordering (coordinator may flush events that trigger database writes).
+
+### Shutdown during in-flight coordinator creation
+
+If `shutdownGraviScan()` is called while `_coordinatorCreating` is pending, the function awaits the pending creation, then shuts down the resulting coordinator. This prevents orphaned coordinator instances.
+
+The await must be wrapped in try/catch — if `_coordinatorCreating` rejects (coordinator creation failed), the error is caught and logged, and shutdown proceeds to `closeScanLog()`. A bare `await _coordinatorCreating` would propagate the rejection and skip remaining cleanup:
+
+```typescript
+if (_coordinatorCreating) {
+  try {
+    scanCoordinator = await _coordinatorCreating;
+  } catch {
+    // Creation failed — nothing to shut down, proceed to closeScanLog
+  }
+  _coordinatorCreating = null;
+}
+```
+
+## Test Strategy
+
+`main-wiring.test.ts` is rewritten to:
+
+1. Import `graviSessionFns`, `setupCoordinatorEventForwarding`, `getOrCreateCoordinator`, `initGraviScan`, `shutdownGraviScan`, `_resetWiringState` from `../../../src/main/graviscan/wiring`.
+2. Call `_resetWiringState()` in `beforeEach` for test isolation.
+3. Mock only external dependencies (`electron`, `./scan-coordinator`, `../python-paths`, `./register-handlers`, `./scan-logger`).
+4. Test the **real** exported functions instead of inline reimplementations.
+5. Add tests for the new `shutdownGraviScan()` function (3 scenarios: active, no-op, error handling).
+6. Add explicit test for side-effect-free import.
+
+### `_resetWiringState()` specification
+
+Resets all 4 pieces of module-level state to initial values AND calls `_resetRegistration()` from `register-handlers.ts` to clear the `registered` boolean guard. Without this, tests calling `initGraviScan()` after reset would throw `"GraviScan IPC handlers are already registered"`.
+
+```typescript
+import { _resetRegistration } from './register-handlers';
+
+export function _resetWiringState(): void {
+  scanSession = null;
+  scanCoordinator = null;
+  _getMainWindow = null;
+  _coordinatorCreating = null;
+  _resetRegistration();
+}
+```
+
+## Decisions
+
+1. **`_resetWiringState()` for tests**: Prefixed with underscore to signal test-only usage. Resets all module-level variables to their initial values. This is the standard pattern in this codebase (see `_resetRegistration` in register-handlers).
+
+2. **`shutdownGraviScan()` encapsulation**: The shutdown logic in main.ts directly accesses `scanCoordinator` and calls `closeScanLog()`. After extraction, main.ts cannot access `scanCoordinator` (it's private to wiring.ts), so shutdown must be exposed as a function. This is a minor API addition, not a pure move.
+
+3. **No runtime `app` import at module level**: `getOrCreateCoordinator()` uses `app.isPackaged`. Rather than importing `app` at module level (which would couple the module to Electron at import time), we use a dynamic `await import('electron')` inside the function. This keeps `wiring.ts` genuinely importable in Node test environments — tests only need to mock `electron` for the dynamic import inside `getOrCreateCoordinator()`, not at module load time.
+
+4. **Minimal barrel re-exports**: Only `initGraviScan` and `shutdownGraviScan` are re-exported from the barrel. Internal wiring functions are available via direct import from `wiring.ts` when needed (e.g., in tests).

--- a/openspec/changes/refactor-extract-graviscan-wiring/proposal.md
+++ b/openspec/changes/refactor-extract-graviscan-wiring/proposal.md
@@ -1,0 +1,56 @@
+# Proposal: Extract GraviScan Wiring Logic from main.ts
+
+**Change ID:** `refactor-extract-graviscan-wiring`
+**Status:** Draft
+**Issue:** #190
+**Related:** #181 (increase test coverage thresholds / make main process testable), #130 (GraviScan integration epic)
+**Type:** Refactor
+
+## Why
+
+`src/main/main.ts` contains GraviScan wiring logic — module-level state, orchestration functions, and shutdown code — that should live in a side-effect-free module. The test file `tests/unit/graviscan/main-wiring.test.ts` re-implements all this logic inline because importing from `main.ts` triggers Electron side effects that crash the Node test environment. This means tests verify hand-copied logic rather than the real production code.
+
+## What Changes
+
+Extract all GraviScan wiring into `src/main/graviscan/wiring.ts`:
+
+1. Move state variables, `graviSessionFns`, `setupCoordinatorEventForwarding()`, `getOrCreateCoordinator()`, and `initGraviScan()` into the new module.
+2. Add a new `shutdownGraviScan()` function that encapsulates the coordinator shutdown + log close logic currently inline in main.ts's `before-quit` handler. This is a minor API addition (not a pure move) required because the extracted module's state is private.
+3. Update `main.ts` to import from `./graviscan/wiring` and call the extracted functions.
+4. Update `src/main/graviscan/index.ts` barrel to add re-exports of `initGraviScan` and `shutdownGraviScan` from `./wiring`, in addition to all existing handler exports. Internal functions (`graviSessionFns`, `setupCoordinatorEventForwarding`, `getOrCreateCoordinator`) are importable directly from `wiring.ts` but not added to the barrel.
+5. Rewrite `main-wiring.test.ts` to import and test the **real** extracted functions instead of inline reimplementations.
+6. Fix pre-existing spec gap: add `rename-error` to the Coordinator Event Forwarding events list (the code already forwards it but the spec omitted it).
+
+## Impact
+
+**Affected specs:**
+
+- `scanning` — MODIFIED requirements for session state management, coordinator instantiation, event forwarding, conditional mode registration, and barrel exports. ADDED requirements for graceful shutdown and side-effect-free module.
+
+**Affected code files:**
+
+- `src/main/graviscan/wiring.ts` — NEW
+- `src/main/main.ts` — MODIFIED (remove ~140 lines of GraviScan wiring, add imports)
+- `src/main/graviscan/index.ts` — MODIFIED (add barrel re-exports)
+- `tests/unit/graviscan/main-wiring.test.ts` — REWRITTEN (import real exports)
+
+## Constraints
+
+- All 706 existing tests must continue passing.
+- Preserve lazy dynamic imports (no heavy modules loaded in cylinderscan mode).
+- Preserve promise memoization pattern for coordinator creation.
+- `wiring.ts` must be side-effect-free at module load time (no top-level code that runs on import).
+
+## Known Behavior Change
+
+`closeScanLog()` moves from after `closeDatabase()` to before it (both are now inside `shutdownGraviScan()` which runs before database close). This is safe because `closeScanLog()` closes a filesystem write stream with no database dependency. See design.md for details.
+
+## Risk Assessment
+
+**Low risk.** This is a mechanical extraction with one minor ordering change (closeScanLog). The primary risk is import path errors, mitigated by running the full test suite after each step.
+
+## Known Limitations (Out of Scope)
+
+- `setupCoordinatorEventForwarding()` does not remove listeners if a new coordinator is created later (duplicate-listener risk). Pre-existing; tracked separately.
+- `initGraviScan()` may not be awaited correctly at the call site in main.ts (race condition). Pre-existing; tracked separately.
+- Copilot review comments from PR #189 (11 items) remain untracked beyond #190.

--- a/openspec/changes/refactor-extract-graviscan-wiring/specs/scanning/spec.md
+++ b/openspec/changes/refactor-extract-graviscan-wiring/specs/scanning/spec.md
@@ -1,0 +1,222 @@
+# Spec Deltas: scanning
+
+## MODIFIED Requirements
+
+### Requirement: GraviScan Session State Management
+
+The system SHALL maintain scan session state at module level in `src/main/graviscan/wiring.ts` and expose it via getter/setter functions passed to handler modules through dependency injection. The session state type `ScanSessionState` SHALL be defined in `src/types/graviscan.ts`.
+
+> **Delta:** Changed location from `main.ts` to `src/main/graviscan/wiring.ts`. Added scenario for markScanJobRecorded when session is null. All other scenarios unchanged.
+
+#### Scenario: Session state accessible via getters
+
+- **GIVEN** the GraviScan session state is initialized in `src/main/graviscan/wiring.ts`
+- **WHEN** `sessionFns.getScanSession()` is called
+- **THEN** it SHALL return the current `ScanSessionState` or `null` if no scan is active
+
+#### Scenario: Session state updated by handlers
+
+- **GIVEN** a scan is started via `graviscan:start-scan`
+- **WHEN** `startScan()` calls `sessionFns.setScanSession(newState)`
+- **THEN** `sessionFns.getScanSession()` SHALL return the updated state
+- **AND** the state SHALL include `isActive`, `isContinuous`, `experimentId`, `phenotyperId`, `resolution`, `sessionId`, `jobs`, `currentCycle`, `totalCycles`, `intervalMs`, `scanStartedAt`, `scanEndedAt`, `scanDurationMs`, `coordinatorState`, `nextScanAt`, and `waveNumber` fields
+
+#### Scenario: Session state cleared on cancel
+
+- **GIVEN** an active scan session exists
+- **WHEN** `graviscan:cancel-scan` is invoked
+- **THEN** `cancelScan()` SHALL call `sessionFns.setScanSession(null)`
+- **AND** `sessionFns.getScanSession()` SHALL return `null`
+
+#### Scenario: Concurrent start-scan rejected when session active
+
+- **GIVEN** an active scan session exists (`getScanSession()` returns non-null with `isActive: true`)
+- **WHEN** the renderer invokes `graviscan:start-scan`
+- **THEN** the handler SHALL return `{ success: false, error: 'Scan already in progress' }`
+- **AND** the existing session SHALL NOT be modified
+
+#### Scenario: markScanJobRecorded updates job status
+
+- **GIVEN** an active scan session exists with a job keyed by `scannerId:plateIndex`
+- **WHEN** `sessionFns.markScanJobRecorded('scanner1:00')` is called
+- **THEN** the job's `status` field SHALL be set to `'recorded'`
+
+#### Scenario: markScanJobRecorded ignores unknown job key
+
+- **GIVEN** an active scan session exists
+- **WHEN** `sessionFns.markScanJobRecorded('nonexistent:99')` is called
+- **THEN** the session state SHALL NOT be modified
+- **AND** no error SHALL be thrown
+
+#### Scenario: markScanJobRecorded no-ops when session is null
+
+- **GIVEN** no scan session is active (`getScanSession()` returns `null`)
+- **WHEN** `sessionFns.markScanJobRecorded('scanner1:00')` is called
+- **THEN** no error SHALL be thrown
+- **AND** `getScanSession()` SHALL still return `null`
+
+### Requirement: GraviScan Conditional Mode Registration
+
+The system SHALL register GraviScan IPC handlers only when the configured scanner mode is `graviscan`. When mode is `cylinderscan` or empty, no GraviScan handlers SHALL be registered. The `initGraviScan()` function SHALL be exported from `src/main/graviscan/wiring.ts`.
+
+> **Delta:** Changed source location from `main.ts` to `src/main/graviscan/wiring.ts`. All scenarios unchanged.
+
+#### Scenario: GraviScan handlers registered in graviscan mode
+
+- **GIVEN** `SCANNER_MODE=graviscan` in the `.env` config
+- **WHEN** the app starts and `initGraviScan()` is called
+- **THEN** `registerGraviScanHandlers` SHALL be called
+- **AND** all 15 `graviscan:*` IPC channels SHALL be available
+
+#### Scenario: GraviScan handlers not registered in cylinderscan mode
+
+- **GIVEN** `SCANNER_MODE=cylinderscan` in the `.env` config
+- **WHEN** the app starts
+- **THEN** `registerGraviScanHandlers` SHALL NOT be called
+- **AND** invoking any `graviscan:*` IPC channel SHALL result in an unhandled channel error
+
+#### Scenario: GraviScan handlers not registered when mode is empty
+
+- **GIVEN** `SCANNER_MODE` is not set or is an empty string in the `.env` config
+- **WHEN** the app starts
+- **THEN** `registerGraviScanHandlers` SHALL NOT be called
+
+### Requirement: GraviScan Coordinator Lazy Instantiation
+
+The `ScanCoordinator` SHALL be instantiated lazily — created only when `graviscan:start-scan` is invoked, not at app startup. The `getOrCreateCoordinator()` function SHALL be exported from `src/main/graviscan/wiring.ts`. This matches the CylinderScan pattern where `ScannerProcess` is created in the `scanner:initialize` handler.
+
+> **Delta:** Changed source location from `main.ts` to `src/main/graviscan/wiring.ts`. Updated shutdown scenario to reference `shutdownGraviScan()`. All other scenarios unchanged.
+
+#### Scenario: No coordinator at startup
+
+- **GIVEN** the app starts in `graviscan` mode
+- **WHEN** no scan has been initiated
+- **THEN** no `ScanCoordinator` instance SHALL exist
+- **AND** no Python subprocesses SHALL be spawned
+
+#### Scenario: Coordinator created on first call
+
+- **GIVEN** the app is in `graviscan` mode
+- **AND** no `ScanCoordinator` instance exists
+- **WHEN** `getOrCreateCoordinator()` is called
+- **THEN** a new `ScanCoordinator` SHALL be instantiated
+- **AND** its events SHALL be wired to the renderer via `setupCoordinatorEventForwarding()`
+
+#### Scenario: Coordinator returned from cache on subsequent calls
+
+- **GIVEN** a `ScanCoordinator` instance already exists
+- **WHEN** `getOrCreateCoordinator()` is called
+- **THEN** the existing instance SHALL be returned
+- **AND** no new `ScanCoordinator` SHALL be created
+
+#### Scenario: Concurrent calls return same instance
+
+- **GIVEN** `getOrCreateCoordinator()` is called concurrently from multiple callers
+- **WHEN** both calls resolve
+- **THEN** both SHALL return the same `ScanCoordinator` instance
+- **AND** only one `ScanCoordinator` SHALL have been created (promise memoization)
+
+#### Scenario: Coordinator shutdown on app quit
+
+- **GIVEN** a `ScanCoordinator` instance exists (scan was started)
+- **WHEN** the app is quitting
+- **THEN** `shutdownGraviScan()` SHALL be called
+- **AND** the coordinator SHALL be shut down gracefully via `coordinator.shutdown()`
+- **AND** `closeScanLog()` SHALL be called
+
+### Requirement: GraviScan Coordinator Event Forwarding
+
+The system SHALL forward `ScanCoordinator` events to the renderer process via IPC. The `setupCoordinatorEventForwarding()` function SHALL be exported from `src/main/graviscan/wiring.ts`. All forwarding SHALL use the `if (mainWindow && !mainWindow.isDestroyed())` guard pattern.
+
+> **Delta:** Changed source location from `main.ts` to `src/main/graviscan/wiring.ts`. Fixed pre-existing gap: added `rename-error` to the forwarded events list.
+
+#### Scenario: Scan events forwarded to renderer
+
+- **GIVEN** a `ScanCoordinator` is active and `mainWindow` exists
+- **WHEN** the coordinator emits `scan-event`, `grid-start`, `grid-complete`, `cycle-complete`, `interval-start`, `interval-waiting`, `interval-complete`, `overtime`, `cancelled`, `scan-error`, or `rename-error`
+- **THEN** the event SHALL be forwarded to the renderer via `mainWindow.webContents.send('graviscan:<event-name>', payload)`
+
+#### Scenario: No crash when mainWindow is null
+
+- **GIVEN** a `ScanCoordinator` is active
+- **AND** `mainWindow` is `null`
+- **WHEN** the coordinator emits an event
+- **THEN** the event SHALL be silently dropped (no crash, no error log)
+
+#### Scenario: No crash when mainWindow is destroyed
+
+- **GIVEN** a `ScanCoordinator` is active
+- **AND** `mainWindow.isDestroyed()` returns `true`
+- **WHEN** the coordinator emits an event
+- **THEN** the event SHALL be silently dropped (no crash, no error log)
+
+### Requirement: GraviScan Barrel Exports
+
+The `src/main/graviscan/index.ts` barrel SHALL export all existing handler exports unchanged, plus `initGraviScan` and `shutdownGraviScan` from `wiring`. The full barrel export list SHALL include: `registerGraviScanHandlers` from `register-handlers`, `ScanCoordinator` from `scan-coordinator`, `ScannerSubprocess` from `scanner-subprocess`, `scanLog`, `cleanupOldLogs`, `closeScanLog` from `scan-logger`, `initGraviScan` and `shutdownGraviScan` from `wiring`, in addition to all existing handler module re-exports.
+
+> **Delta:** Added re-exports of `initGraviScan` and `shutdownGraviScan` from `./wiring`. All existing exports are preserved unchanged. Internal wiring functions (`graviSessionFns`, `setupCoordinatorEventForwarding`, `getOrCreateCoordinator`) are not barrel-exported — they are importable directly from `wiring.ts` when needed.
+
+#### Scenario: All public symbols exported
+
+- **GIVEN** a TypeScript file imports from `./graviscan`
+- **WHEN** it references `registerGraviScanHandlers`, `ScanCoordinator`, `ScannerSubprocess`, `scanLog`, `cleanupOldLogs`, `closeScanLog`, `initGraviScan`, or `shutdownGraviScan`
+- **THEN** the imports SHALL resolve without TypeScript compilation errors
+
+## ADDED Requirements
+
+### Requirement: GraviScan Graceful Shutdown
+
+The system SHALL provide a `shutdownGraviScan()` function in `src/main/graviscan/wiring.ts` that encapsulates all GraviScan cleanup: coordinator shutdown and scan log closing. This function SHALL be called from `main.ts` during the `before-quit` handler.
+
+#### Scenario: Coordinator shutdown when active
+
+- **GIVEN** a `ScanCoordinator` instance exists
+- **WHEN** `shutdownGraviScan()` is called
+- **THEN** `coordinator.shutdown()` SHALL be called
+- **AND** the internal coordinator reference SHALL be set to `null`
+- **AND** `closeScanLog()` SHALL be called
+
+#### Scenario: No-op when no coordinator exists
+
+- **GIVEN** no `ScanCoordinator` instance exists (no scan was started)
+- **WHEN** `shutdownGraviScan()` is called
+- **THEN** no error SHALL be thrown
+- **AND** `closeScanLog()` SHALL still be called (safe to call even if not opened)
+
+#### Scenario: Coordinator shutdown error handled gracefully
+
+- **GIVEN** a `ScanCoordinator` instance exists
+- **AND** `coordinator.shutdown()` throws an error
+- **WHEN** `shutdownGraviScan()` is called
+- **THEN** the error SHALL be caught and logged via `console.error`
+- **AND** the coordinator reference SHALL still be set to `null`
+- **AND** `closeScanLog()` SHALL still be called
+
+#### Scenario: Shutdown awaits in-flight coordinator creation
+
+- **GIVEN** `getOrCreateCoordinator()` has been called and its creation promise is pending
+- **WHEN** `shutdownGraviScan()` is called before creation completes
+- **THEN** the function SHALL await the pending creation
+- **AND** shut down the resulting coordinator
+- **AND** no orphaned coordinator instance SHALL remain
+
+#### Scenario: Shutdown handles rejected coordinator creation
+
+- **GIVEN** `getOrCreateCoordinator()` has been called and its creation promise is pending
+- **AND** the creation promise will reject (e.g., Python executable not found)
+- **WHEN** `shutdownGraviScan()` is called
+- **THEN** the rejection SHALL be caught and logged via `console.error`
+- **AND** the coordinator reference SHALL remain `null`
+- **AND** `closeScanLog()` SHALL still be called
+
+### Requirement: GraviScan Wiring Module Side-Effect-Free
+
+The `src/main/graviscan/wiring.ts` module SHALL be side-effect-free at load time. Importing the module SHALL NOT execute any code beyond variable declarations and function definitions. The module SHALL use only `import type` at the top level — no runtime Electron imports.
+
+#### Scenario: Module importable in Node test environment
+
+- **GIVEN** a Node.js test environment without Electron
+- **AND** the `electron` module is mocked (intercepting dynamic imports inside functions)
+- **WHEN** `wiring.ts` is imported
+- **THEN** no side effects SHALL occur (no IPC registration, no subprocess spawning, no file I/O)
+- **AND** all exported functions (`initGraviScan`, `shutdownGraviScan`, `getOrCreateCoordinator`, `setupCoordinatorEventForwarding`, `graviSessionFns`, `_resetWiringState`) SHALL be defined and callable

--- a/openspec/changes/refactor-extract-graviscan-wiring/tasks.md
+++ b/openspec/changes/refactor-extract-graviscan-wiring/tasks.md
@@ -1,0 +1,70 @@
+# Tasks: Extract GraviScan Wiring
+
+## Task 1: Extract wiring module and update main.ts (with tests) ✅
+
+This task is atomic — tests, `wiring.ts` creation, and `main.ts` update happen together to avoid a duplicate-export state where both modules own the same state.
+
+### Tests first
+
+Rewrite `tests/unit/graviscan/main-wiring.test.ts` to:
+
+1. Import `graviSessionFns`, `setupCoordinatorEventForwarding`, `getOrCreateCoordinator`, `initGraviScan`, `shutdownGraviScan`, `_resetWiringState` from the real `../../../src/main/graviscan/wiring` module.
+2. Mock `electron` (dynamic import in `getOrCreateCoordinator`), `./scan-coordinator`, `../python-paths`, `./register-handlers`, `./scan-logger`.
+3. Call `_resetWiringState()` in `beforeEach` to reset all 4 state variables (`scanSession`, `scanCoordinator`, `_getMainWindow`, `_coordinatorCreating`) plus the `registered` guard in register-handlers.
+4. Rewrite all 14 existing tests to use real exports instead of inline reimplementations:
+   - `initGraviScan`: registers handlers in graviscan mode, skips in cylinderscan mode, skips when mode is empty, calls `cleanupOldLogs`.
+   - Session state lifecycle: `getScanSession` returns null initially, `setScanSession` updates state, `markScanJobRecorded` updates job status, `markScanJobRecorded` ignores unknown key, `setScanSession(null)` clears state.
+   - Event forwarding: all 11 events forwarded, null window no-crash, destroyed window no-crash, rename-error forwarded.
+   - Coordinator race protection: concurrent calls return same instance.
+   - Session completion: session cleared after scan completes.
+5. Add new tests:
+   - `shutdownGraviScan`: shuts down active coordinator, sets reference to null, calls `closeScanLog()`.
+   - `shutdownGraviScan`: no-ops when no coordinator exists, still calls `closeScanLog()`.
+   - `shutdownGraviScan`: catches `coordinator.shutdown()` error, logs it, still nulls coordinator, still calls `closeScanLog()`.
+   - `shutdownGraviScan`: awaits in-flight `_coordinatorCreating` before shutting down. (Use a deferred promise mock for `scan-coordinator` to keep creation pending, call `shutdownGraviScan()` concurrently, then resolve the deferred, and verify the resulting coordinator is shut down.)
+   - `shutdownGraviScan`: handles rejected `_coordinatorCreating` gracefully (creation promise rejects, error caught, `closeScanLog()` still called).
+   - `markScanJobRecorded`: no-ops when `scanSession` is null (no error thrown).
+   - Side-effect-free: module imports successfully in Node test environment, all exports are defined.
+   - Coordinator lazy instantiation: first call creates coordinator, second call returns cached instance.
+   - `initGraviScan` wires arguments correctly: after calling `initGraviScan('graviscan', ...)`, verify `registerGraviScanHandlers` was called with `graviSessionFns` and `getOrCreateCoordinator` as arguments, and that the stored `_getMainWindow` is used by `getOrCreateCoordinator` for event forwarding.
+
+### Implementation
+
+1. Create `src/main/graviscan/wiring.ts` containing:
+   - Module-level state: `scanSession`, `scanCoordinator`, `_getMainWindow`, `_coordinatorCreating` (all type-only imports at top, no runtime Electron import).
+   - `graviSessionFns` const.
+   - `setupCoordinatorEventForwarding()` — moved from main.ts lines 128-154.
+   - `getOrCreateCoordinator()` — moved from main.ts lines 165-201, with `app` obtained via dynamic `await import('electron')` instead of top-level import.
+   - `initGraviScan()` — moved from main.ts lines 207-240.
+   - `shutdownGraviScan()` — new, encapsulates main.ts lines 1383-1393 + 1401-1406, awaits `_coordinatorCreating` if pending (with try/catch for rejected creation promises).
+   - `_resetWiringState()` — resets all 4 state variables to null and calls `_resetRegistration()` from register-handlers.
+2. Remove from main.ts: GraviScan state block (lines 102-122), `setupCoordinatorEventForwarding` (lines 128-154), `_coordinatorCreating` (line 157), `getOrCreateCoordinator` (lines 165-201), `initGraviScan` (lines 207-240), type imports (`SessionFns`, `ScanSessionState`, `ScanCoordinator`), shutdown block (lines 1383-1406).
+3. Add to main.ts: `import { initGraviScan, shutdownGraviScan } from './graviscan/wiring';`
+4. Replace shutdown block in main.ts with: `await shutdownGraviScan();`
+
+### Validation
+
+- `npx vitest run tests/unit/graviscan/main-wiring.test.ts`
+- `npx vitest run` (all 706 tests pass)
+- `npx tsc --noEmit`
+- `npm run lint`
+
+---
+
+## Task 2: Update barrel exports and spec deltas ✅
+
+### Tests first
+
+No new tests — barrel export correctness verified by TypeScript compilation (`npx tsc --noEmit`). Existing barrel consumers are unaffected since this is additive (no exports removed).
+
+### Implementation
+
+1. Update `src/main/graviscan/index.ts` to add re-exports of `initGraviScan` and `shutdownGraviScan` from `./wiring` (in addition to all existing handler exports).
+2. Apply spec deltas to `openspec/specs/scanning/spec.md`.
+
+### Validation
+
+- `npx vitest run` (all 706 tests pass)
+- `npx tsc --noEmit`
+- `npm run lint`
+- `npx openspec validate refactor-extract-graviscan-wiring --strict`

--- a/openspec/specs/scanning/spec.md
+++ b/openspec/specs/scanning/spec.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 TBD - created by archiving change fix-scanner-event-listener-leak. Update Purpose after archive.
+
 ## Requirements
+
 ### Requirement: Scanner Event Listener Lifecycle
 
 Scanner event listeners SHALL be properly cleaned up when component unmounts or dependencies change to prevent memory leaks and duplicate event handling.
@@ -1721,12 +1723,12 @@ The system SHALL provide a `registerGraviScanHandlers` function in `src/main/gra
 
 ### Requirement: GraviScan Conditional Mode Registration
 
-The system SHALL register GraviScan IPC handlers only when the configured scanner mode is `graviscan`. When mode is `cylinderscan` or empty, no GraviScan handlers SHALL be registered.
+The system SHALL register GraviScan IPC handlers only when the configured scanner mode is `graviscan`. When mode is `cylinderscan` or empty, no GraviScan handlers SHALL be registered. The `initGraviScan()` function SHALL be exported from `src/main/graviscan/wiring.ts`.
 
 #### Scenario: GraviScan handlers registered in graviscan mode
 
 - **GIVEN** `SCANNER_MODE=graviscan` in the `.env` config
-- **WHEN** the app starts and `main.ts` initializes IPC handlers
+- **WHEN** the app starts and `initGraviScan()` is called
 - **THEN** `registerGraviScanHandlers` SHALL be called
 - **AND** all 15 `graviscan:*` IPC channels SHALL be available
 
@@ -1745,11 +1747,11 @@ The system SHALL register GraviScan IPC handlers only when the configured scanne
 
 ### Requirement: GraviScan Session State Management
 
-The system SHALL maintain scan session state at module level in `main.ts` and expose it via getter/setter functions passed to handler modules through dependency injection. The session state type `ScanSessionState` SHALL be defined in `src/types/graviscan.ts`.
+The system SHALL maintain scan session state at module level in `src/main/graviscan/wiring.ts` and expose it via getter/setter functions passed to handler modules through dependency injection. The session state type `ScanSessionState` SHALL be defined in `src/types/graviscan.ts`.
 
 #### Scenario: Session state accessible via getters
 
-- **GIVEN** the GraviScan session state is initialized in `main.ts`
+- **GIVEN** the GraviScan session state is initialized in `src/main/graviscan/wiring.ts`
 - **WHEN** `sessionFns.getScanSession()` is called
 - **THEN** it SHALL return the current `ScanSessionState` or `null` if no scan is active
 
@@ -1787,9 +1789,16 @@ The system SHALL maintain scan session state at module level in `main.ts` and ex
 - **THEN** the session state SHALL NOT be modified
 - **AND** no error SHALL be thrown
 
+#### Scenario: markScanJobRecorded no-ops when session is null
+
+- **GIVEN** no scan session is active (`getScanSession()` returns `null`)
+- **WHEN** `sessionFns.markScanJobRecorded('scanner1:00')` is called
+- **THEN** no error SHALL be thrown
+- **AND** `getScanSession()` SHALL still return `null`
+
 ### Requirement: GraviScan Coordinator Lazy Instantiation
 
-The `ScanCoordinator` SHALL be instantiated lazily — created only when `graviscan:start-scan` is invoked, not at app startup. This matches the CylinderScan pattern where `ScannerProcess` is created in the `scanner:initialize` handler.
+The `ScanCoordinator` SHALL be instantiated lazily — created only when `graviscan:start-scan` is invoked, not at app startup. The `getOrCreateCoordinator()` function SHALL be exported from `src/main/graviscan/wiring.ts`. This matches the CylinderScan pattern where `ScannerProcess` is created in the `scanner:initialize` handler.
 
 #### Scenario: No coordinator at startup
 
@@ -1798,28 +1807,44 @@ The `ScanCoordinator` SHALL be instantiated lazily — created only when `gravis
 - **THEN** no `ScanCoordinator` instance SHALL exist
 - **AND** no Python subprocesses SHALL be spawned
 
-#### Scenario: Coordinator created on start-scan
+#### Scenario: Coordinator created on first call
 
 - **GIVEN** the app is in `graviscan` mode
-- **WHEN** the renderer invokes `graviscan:start-scan` with valid parameters
+- **AND** no `ScanCoordinator` instance exists
+- **WHEN** `getOrCreateCoordinator()` is called
 - **THEN** a new `ScanCoordinator` SHALL be instantiated
-- **AND** its events SHALL be wired to the renderer via `mainWindow.webContents.send()`
+- **AND** its events SHALL be wired to the renderer via `setupCoordinatorEventForwarding()`
+
+#### Scenario: Coordinator returned from cache on subsequent calls
+
+- **GIVEN** a `ScanCoordinator` instance already exists
+- **WHEN** `getOrCreateCoordinator()` is called
+- **THEN** the existing instance SHALL be returned
+- **AND** no new `ScanCoordinator` SHALL be created
+
+#### Scenario: Concurrent calls return same instance
+
+- **GIVEN** `getOrCreateCoordinator()` is called concurrently from multiple callers
+- **WHEN** both calls resolve
+- **THEN** both SHALL return the same `ScanCoordinator` instance
+- **AND** only one `ScanCoordinator` SHALL have been created (promise memoization)
 
 #### Scenario: Coordinator shutdown on app quit
 
 - **GIVEN** a `ScanCoordinator` instance exists (scan was started)
 - **WHEN** the app is quitting
-- **THEN** the coordinator SHALL be shut down gracefully via `coordinator.shutdown()`
+- **THEN** `shutdownGraviScan()` SHALL be called
+- **AND** the coordinator SHALL be shut down gracefully via `coordinator.shutdown()`
 - **AND** `closeScanLog()` SHALL be called
 
 ### Requirement: GraviScan Coordinator Event Forwarding
 
-The system SHALL forward `ScanCoordinator` events to the renderer process via IPC. All forwarding SHALL use the `if (mainWindow && !mainWindow.isDestroyed())` guard pattern.
+The system SHALL forward `ScanCoordinator` events to the renderer process via IPC. The `setupCoordinatorEventForwarding()` function SHALL be exported from `src/main/graviscan/wiring.ts`. All forwarding SHALL use the `if (mainWindow && !mainWindow.isDestroyed())` guard pattern.
 
 #### Scenario: Scan events forwarded to renderer
 
 - **GIVEN** a `ScanCoordinator` is active and `mainWindow` exists
-- **WHEN** the coordinator emits `scan-event`, `grid-start`, `grid-complete`, `cycle-complete`, `interval-start`, `interval-waiting`, `interval-complete`, `overtime`, `cancelled`, or `scan-error`
+- **WHEN** the coordinator emits `scan-event`, `grid-start`, `grid-complete`, `cycle-complete`, `interval-start`, `interval-waiting`, `interval-complete`, `overtime`, `cancelled`, `scan-error`, or `rename-error`
 - **THEN** the event SHALL be forwarded to the renderer via `mainWindow.webContents.send('graviscan:<event-name>', payload)`
 
 #### Scenario: No crash when mainWindow is null
@@ -1864,13 +1889,70 @@ The preload script SHALL expose a `gravi` namespace on `window.electron` with me
 
 ### Requirement: GraviScan Barrel Exports
 
-The `src/main/graviscan/index.ts` barrel SHALL export `registerGraviScanHandlers` from `register-handlers`, `ScanCoordinator` from `scan-coordinator`, `ScannerSubprocess` from `scanner-subprocess`, and `scanLog`, `cleanupOldLogs`, `closeScanLog` from `scan-logger`, in addition to existing handler exports.
+The `src/main/graviscan/index.ts` barrel SHALL export all existing handler exports unchanged, plus `initGraviScan` and `shutdownGraviScan` from `wiring`. The full barrel export list SHALL include: `registerGraviScanHandlers` from `register-handlers`, `ScanCoordinator` from `scan-coordinator`, `ScannerSubprocess` from `scanner-subprocess`, `scanLog`, `cleanupOldLogs`, `closeScanLog` from `scan-logger`, `initGraviScan` and `shutdownGraviScan` from `wiring`, in addition to all existing handler module re-exports.
 
 #### Scenario: All public symbols exported
 
 - **GIVEN** a TypeScript file imports from `./graviscan`
-- **WHEN** it references `registerGraviScanHandlers`, `ScanCoordinator`, `ScannerSubprocess`, `scanLog`, `cleanupOldLogs`, or `closeScanLog`
+- **WHEN** it references `registerGraviScanHandlers`, `ScanCoordinator`, `ScannerSubprocess`, `scanLog`, `cleanupOldLogs`, `closeScanLog`, `initGraviScan`, or `shutdownGraviScan`
 - **THEN** the imports SHALL resolve without TypeScript compilation errors
+
+### Requirement: GraviScan Graceful Shutdown
+
+The system SHALL provide a `shutdownGraviScan()` function in `src/main/graviscan/wiring.ts` that encapsulates all GraviScan cleanup: coordinator shutdown and scan log closing. This function SHALL be called from `main.ts` during the `before-quit` handler.
+
+#### Scenario: Coordinator shutdown when active
+
+- **GIVEN** a `ScanCoordinator` instance exists
+- **WHEN** `shutdownGraviScan()` is called
+- **THEN** `coordinator.shutdown()` SHALL be called
+- **AND** the internal coordinator reference SHALL be set to `null`
+- **AND** `closeScanLog()` SHALL be called
+
+#### Scenario: No-op when no coordinator exists
+
+- **GIVEN** no `ScanCoordinator` instance exists (no scan was started)
+- **WHEN** `shutdownGraviScan()` is called
+- **THEN** no error SHALL be thrown
+- **AND** `closeScanLog()` SHALL still be called (safe to call even if not opened)
+
+#### Scenario: Coordinator shutdown error handled gracefully
+
+- **GIVEN** a `ScanCoordinator` instance exists
+- **AND** `coordinator.shutdown()` throws an error
+- **WHEN** `shutdownGraviScan()` is called
+- **THEN** the error SHALL be caught and logged via `console.error`
+- **AND** the coordinator reference SHALL still be set to `null`
+- **AND** `closeScanLog()` SHALL still be called
+
+#### Scenario: Shutdown awaits in-flight coordinator creation
+
+- **GIVEN** `getOrCreateCoordinator()` has been called and its creation promise is pending
+- **WHEN** `shutdownGraviScan()` is called before creation completes
+- **THEN** the function SHALL await the pending creation
+- **AND** shut down the resulting coordinator
+- **AND** no orphaned coordinator instance SHALL remain
+
+#### Scenario: Shutdown handles rejected coordinator creation
+
+- **GIVEN** `getOrCreateCoordinator()` has been called and its creation promise is pending
+- **AND** the creation promise will reject (e.g., Python executable not found)
+- **WHEN** `shutdownGraviScan()` is called
+- **THEN** the rejection SHALL be caught and logged via `console.error`
+- **AND** the coordinator reference SHALL remain `null`
+- **AND** `closeScanLog()` SHALL still be called
+
+### Requirement: GraviScan Wiring Module Side-Effect-Free
+
+The `src/main/graviscan/wiring.ts` module SHALL be side-effect-free at load time. Importing the module SHALL NOT execute any code beyond variable declarations and function definitions. The module SHALL use only `import type` at the top level — no runtime Electron imports.
+
+#### Scenario: Module importable in Node test environment
+
+- **GIVEN** a Node.js test environment without Electron
+- **AND** the `electron` module is mocked (intercepting dynamic imports inside functions)
+- **WHEN** `wiring.ts` is imported
+- **THEN** no side effects SHALL occur (no IPC registration, no subprocess spawning, no file I/O)
+- **AND** all exported functions (`initGraviScan`, `shutdownGraviScan`, `getOrCreateCoordinator`, `setupCoordinatorEventForwarding`, `graviSessionFns`, `_resetWiringState`) SHALL be defined and callable
 
 ### Requirement: GraviScan Scan Log Lifecycle
 
@@ -1968,4 +2050,3 @@ The system SHALL include integration tests verifying the full IPC round-trip for
 - **WHEN** renderer code calls `window.electron.gravi.onScanEvent(callback)`
 - **THEN** it SHALL return a function (cleanup)
 - **AND** the cleanup function SHALL be callable without error
-

--- a/src/main/graviscan/index.ts
+++ b/src/main/graviscan/index.ts
@@ -36,3 +36,4 @@ export { registerGraviScanHandlers } from './register-handlers';
 export { ScanCoordinator } from './scan-coordinator';
 export { ScannerSubprocess } from './scanner-subprocess';
 export { scanLog, cleanupOldLogs, closeScanLog } from './scan-logger';
+export { initGraviScan, shutdownGraviScan } from './wiring';

--- a/src/main/graviscan/wiring.ts
+++ b/src/main/graviscan/wiring.ts
@@ -12,7 +12,6 @@ import type { SessionFns } from './session-handlers';
 import type { ScanSessionState } from '../../types/graviscan';
 import type { ScanCoordinator } from './scan-coordinator';
 import type { BrowserWindow } from 'electron';
-import { _resetRegistration } from './register-handlers';
 
 // =============================================================================
 // Module-level state (not exported — accessed via functions)
@@ -212,10 +211,13 @@ export async function shutdownGraviScan(): Promise<void> {
  * Reset all module state for test isolation.
  * @internal Test-only — prefixed with underscore by convention.
  */
-export function _resetWiringState(): void {
+export async function _resetWiringState(): Promise<void> {
   scanSession = null;
   scanCoordinator = null;
   _getMainWindow = null;
   _coordinatorCreating = null;
+  // Dynamic import to avoid pulling in register-handlers (and its transitive
+  // sharp/native dependencies) at module load time.
+  const { _resetRegistration } = await import('./register-handlers');
   _resetRegistration();
 }

--- a/src/main/graviscan/wiring.ts
+++ b/src/main/graviscan/wiring.ts
@@ -176,7 +176,8 @@ export async function shutdownGraviScan(): Promise<void> {
   if (_coordinatorCreating) {
     try {
       scanCoordinator = await _coordinatorCreating;
-    } catch {
+    } catch (err) {
+      console.error('Error during in-flight coordinator creation:', err);
       // Creation failed — nothing to shut down
     }
     _coordinatorCreating = null;

--- a/src/main/graviscan/wiring.ts
+++ b/src/main/graviscan/wiring.ts
@@ -4,7 +4,7 @@
  * Owns all GraviScan wiring state and orchestration. Side-effect-free at
  * load time — no code runs on import, only declarations and type-only imports.
  *
- * Extracted from main.ts (PR #190) so that tests can import and exercise the
+ * Extracted from main.ts (#190, PR #191) so that tests can import and exercise the
  * real production code without triggering Electron side effects.
  */
 

--- a/src/main/graviscan/wiring.ts
+++ b/src/main/graviscan/wiring.ts
@@ -1,0 +1,221 @@
+/**
+ * GraviScan Wiring Module
+ *
+ * Owns all GraviScan wiring state and orchestration. Side-effect-free at
+ * load time — no code runs on import, only declarations and type-only imports.
+ *
+ * Extracted from main.ts (PR #190) so that tests can import and exercise the
+ * real production code without triggering Electron side effects.
+ */
+
+import type { SessionFns } from './session-handlers';
+import type { ScanSessionState } from '../../types/graviscan';
+import type { ScanCoordinator } from './scan-coordinator';
+import type { BrowserWindow } from 'electron';
+import { _resetRegistration } from './register-handlers';
+
+// =============================================================================
+// Module-level state (not exported — accessed via functions)
+// =============================================================================
+
+let scanSession: ScanSessionState | null = null;
+let scanCoordinator: ScanCoordinator | null = null;
+let _getMainWindow: (() => BrowserWindow | null) | null = null;
+let _coordinatorCreating: Promise<ScanCoordinator> | null = null;
+
+// =============================================================================
+// Session state management
+// =============================================================================
+
+export const graviSessionFns: SessionFns = {
+  getScanSession: () => scanSession,
+  setScanSession: (s: ScanSessionState | null) => {
+    scanSession = s;
+  },
+  markScanJobRecorded: (key: string) => {
+    if (scanSession?.jobs[key]) {
+      scanSession.jobs[key].status = 'recorded';
+    }
+  },
+};
+
+// =============================================================================
+// Coordinator event forwarding
+// =============================================================================
+
+/**
+ * Set up coordinator event forwarding to renderer.
+ * Called when a new ScanCoordinator is created.
+ */
+export function setupCoordinatorEventForwarding(
+  coordinator: ScanCoordinator,
+  getMainWindow: () => BrowserWindow | null
+): void {
+  const events = [
+    'scan-event',
+    'grid-start',
+    'grid-complete',
+    'cycle-complete',
+    'interval-start',
+    'interval-waiting',
+    'interval-complete',
+    'overtime',
+    'cancelled',
+    'scan-error',
+    'rename-error',
+  ];
+
+  for (const eventName of events) {
+    coordinator.on(eventName, (payload: unknown) => {
+      const win = getMainWindow();
+      if (win && !win.isDestroyed()) {
+        win.webContents.send(`graviscan:${eventName}`, payload);
+      }
+    });
+  }
+}
+
+// =============================================================================
+// Coordinator lazy instantiation
+// =============================================================================
+
+/**
+ * Get or create the ScanCoordinator (lazy instantiation).
+ * Creates the coordinator on first call and wires event forwarding.
+ * Uses promise memoization to prevent duplicate creation from concurrent calls.
+ * Matches the CylinderScan pattern where ScannerProcess is created on demand.
+ */
+export async function getOrCreateCoordinator(): Promise<ScanCoordinator> {
+  if (scanCoordinator) return scanCoordinator;
+  if (_coordinatorCreating) return _coordinatorCreating;
+
+  _coordinatorCreating = (async () => {
+    // Lazy imports to avoid loading subprocess modules in cylinderscan mode
+    const { ScanCoordinator: ScanCoordinatorClass } = await import(
+      './scan-coordinator'
+    );
+    const { getPythonExecutablePath } = await import('../python-paths');
+    const { app } = await import('electron');
+
+    const pythonPath = getPythonExecutablePath();
+    const isPackaged = app.isPackaged;
+
+    const mockMode =
+      process.env.GRAVISCAN_MOCK?.trim().toLowerCase() === 'true';
+    scanCoordinator = new ScanCoordinatorClass(
+      pythonPath,
+      isPackaged,
+      mockMode
+    );
+    console.log(`[Main] ScanCoordinator created (lazy, mock=${mockMode})`);
+
+    // Wire event forwarding to renderer
+    if (_getMainWindow) {
+      setupCoordinatorEventForwarding(scanCoordinator, _getMainWindow);
+    }
+
+    return scanCoordinator;
+  })();
+
+  try {
+    return await _coordinatorCreating;
+  } finally {
+    _coordinatorCreating = null;
+  }
+}
+
+// =============================================================================
+// Initialization
+// =============================================================================
+
+/**
+ * Initialize GraviScan IPC handlers conditionally based on scanner mode.
+ */
+export async function initGraviScan(
+  scannerMode: string,
+  ipcMainRef: Electron.IpcMain,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: any,
+  getMainWindow: () => BrowserWindow | null
+): Promise<void> {
+  if (scannerMode !== 'graviscan') return;
+
+  console.log('[Main] GraviScan mode detected, registering handlers...');
+
+  // Cache for coordinator event forwarding
+  _getMainWindow = getMainWindow;
+
+  // Lazy import to avoid loading sharp/native modules in cylinderscan mode
+  const { registerGraviScanHandlers } = await import('./register-handlers');
+  const { cleanupOldLogs } = await import('./scan-logger');
+
+  // Clean up old scan logs on startup
+  cleanupOldLogs();
+
+  registerGraviScanHandlers(
+    ipcMainRef,
+    db,
+    getMainWindow,
+    graviSessionFns,
+    () => scanCoordinator,
+    getOrCreateCoordinator
+  );
+
+  console.log('[Main] GraviScan handlers registered');
+}
+
+// =============================================================================
+// Shutdown
+// =============================================================================
+
+/**
+ * Shut down GraviScan gracefully: coordinator shutdown + scan log close.
+ * Called from main.ts during the before-quit handler.
+ */
+export async function shutdownGraviScan(): Promise<void> {
+  // Await in-flight coordinator creation if pending
+  if (_coordinatorCreating) {
+    try {
+      scanCoordinator = await _coordinatorCreating;
+    } catch {
+      // Creation failed — nothing to shut down
+    }
+    _coordinatorCreating = null;
+  }
+
+  // Shut down coordinator if active
+  if (scanCoordinator) {
+    console.log('Shutting down GraviScan coordinator...');
+    try {
+      await scanCoordinator.shutdown();
+    } catch (coordErr) {
+      console.error('Error shutting down coordinator:', coordErr);
+    }
+    scanCoordinator = null;
+    console.log('GraviScan coordinator shut down');
+  }
+
+  // Close scan log stream
+  try {
+    const { closeScanLog } = await import('./scan-logger');
+    closeScanLog();
+  } catch {
+    // scan-logger not loaded — nothing to close
+  }
+}
+
+// =============================================================================
+// Test helper
+// =============================================================================
+
+/**
+ * Reset all module state for test isolation.
+ * @internal Test-only — prefixed with underscore by convention.
+ */
+export function _resetWiringState(): void {
+  scanSession = null;
+  scanCoordinator = null;
+  _getMainWindow = null;
+  _coordinatorCreating = null;
+  _resetRegistration();
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -47,11 +47,8 @@ import {
 } from './session-store';
 import { IdleTimer } from './idle-timer';
 import { createFrameForwarder } from './frame-forwarder';
-// GraviScan imports are lazy (dynamic import) to avoid loading sharp/native
-// modules in cylinderscan mode. Only type imports are static.
-import type { SessionFns } from './graviscan/session-handlers';
-import type { ScanSessionState } from '../types/graviscan';
-import type { ScanCoordinator } from './graviscan/scan-coordinator';
+// GraviScan wiring is in a side-effect-free module for testability.
+import { initGraviScan, shutdownGraviScan } from './graviscan/wiring';
 
 // Config file paths
 const BLOOM_DIR = path.join(os.homedir(), '.bloom');
@@ -98,146 +95,6 @@ let currentCameraSettings: CameraSettings | null = null;
 
 // Idle timer — resets session after inactivity to prevent scan misattribution
 let idleTimer: IdleTimer | null = null;
-
-// =============================================================================
-// GraviScan State
-// =============================================================================
-
-let scanSession: ScanSessionState | null = null;
-let scanCoordinator: ScanCoordinator | null = null;
-
-// Cached getMainWindow reference for coordinator event forwarding
-let _getMainWindow: (() => BrowserWindow | null) | null = null;
-
-const graviSessionFns: SessionFns = {
-  getScanSession: () => scanSession,
-  setScanSession: (s: ScanSessionState | null) => {
-    scanSession = s;
-  },
-  markScanJobRecorded: (key: string) => {
-    if (scanSession?.jobs[key]) {
-      scanSession.jobs[key].status = 'recorded';
-    }
-  },
-};
-
-/**
- * Set up coordinator event forwarding to renderer.
- * Called when a new ScanCoordinator is created.
- */
-export function setupCoordinatorEventForwarding(
-  coordinator: ScanCoordinator,
-  getMainWindow: () => BrowserWindow | null
-): void {
-  const events = [
-    'scan-event',
-    'grid-start',
-    'grid-complete',
-    'cycle-complete',
-    'interval-start',
-    'interval-waiting',
-    'interval-complete',
-    'overtime',
-    'cancelled',
-    'scan-error',
-    'rename-error',
-  ];
-
-  for (const eventName of events) {
-    coordinator.on(eventName, (payload: unknown) => {
-      const win = getMainWindow();
-      if (win && !win.isDestroyed()) {
-        win.webContents.send(`graviscan:${eventName}`, payload);
-      }
-    });
-  }
-}
-
-// Guard against concurrent coordinator creation (promise memoization)
-let _coordinatorCreating: Promise<ScanCoordinator> | null = null;
-
-/**
- * Get or create the ScanCoordinator (lazy instantiation).
- * Creates the coordinator on first call and wires event forwarding.
- * Uses promise memoization to prevent duplicate creation from concurrent calls.
- * Matches the CylinderScan pattern where ScannerProcess is created on demand.
- */
-export async function getOrCreateCoordinator(): Promise<ScanCoordinator> {
-  if (scanCoordinator) return scanCoordinator;
-  if (_coordinatorCreating) return _coordinatorCreating;
-
-  _coordinatorCreating = (async () => {
-    // Lazy import to avoid loading subprocess modules in cylinderscan mode
-    const { ScanCoordinator: ScanCoordinatorClass } = await import(
-      './graviscan/scan-coordinator'
-    );
-    const { getPythonExecutablePath } = await import('./python-paths');
-
-    const pythonPath = getPythonExecutablePath();
-    const isPackaged = app.isPackaged;
-
-    const mockMode =
-      process.env.GRAVISCAN_MOCK?.trim().toLowerCase() === 'true';
-    scanCoordinator = new ScanCoordinatorClass(
-      pythonPath,
-      isPackaged,
-      mockMode
-    );
-    console.log(`[Main] ScanCoordinator created (lazy, mock=${mockMode})`);
-
-    // Wire event forwarding to renderer
-    if (_getMainWindow) {
-      setupCoordinatorEventForwarding(scanCoordinator, _getMainWindow);
-    }
-
-    return scanCoordinator;
-  })();
-
-  try {
-    return await _coordinatorCreating;
-  } finally {
-    _coordinatorCreating = null;
-  }
-}
-
-/**
- * Initialize GraviScan IPC handlers conditionally based on scanner mode.
- * Extracted for testability.
- */
-export async function initGraviScan(
-  scannerMode: string,
-  ipcMainRef: Electron.IpcMain,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  db: any,
-  getMainWindow: () => BrowserWindow | null
-): Promise<void> {
-  if (scannerMode !== 'graviscan') return;
-
-  console.log('[Main] GraviScan mode detected, registering handlers...');
-
-  // Cache for coordinator event forwarding
-  _getMainWindow = getMainWindow;
-
-  // Lazy import to avoid loading sharp/native modules in cylinderscan mode
-  const { registerGraviScanHandlers } = await import(
-    './graviscan/register-handlers'
-  );
-  const { cleanupOldLogs } = await import('./graviscan/scan-logger');
-
-  // Clean up old scan logs on startup
-  cleanupOldLogs();
-
-  registerGraviScanHandlers(
-    ipcMainRef,
-    db,
-    getMainWindow,
-    graviSessionFns,
-    () => scanCoordinator,
-    getOrCreateCoordinator
-  );
-
-  console.log('[Main] GraviScan handlers registered');
-}
 
 /**
  * Scanner identity (runtime state)
@@ -1380,30 +1237,13 @@ app.on('before-quit', async (event) => {
       console.log('DAQ process stopped');
     }
 
-    // Shut down GraviScan coordinator if active
-    if (scanCoordinator) {
-      console.log('Shutting down GraviScan coordinator...');
-      try {
-        await scanCoordinator.shutdown();
-      } catch (coordErr) {
-        console.error('Error shutting down coordinator:', coordErr);
-      }
-      scanCoordinator = null;
-      console.log('GraviScan coordinator shut down');
-    }
+    // Shut down GraviScan coordinator and close scan log
+    await shutdownGraviScan();
 
     // Close database connection
     console.log('Closing database connection...');
     await closeDatabase();
     console.log('Database connection closed');
-
-    // Close scan log stream (lazy import — module may not be loaded in cylinderscan mode)
-    try {
-      const { closeScanLog } = await import('./graviscan/scan-logger');
-      closeScanLog();
-    } catch {
-      // scan-logger not loaded (cylinderscan mode) — nothing to close
-    }
 
     // Give processes a moment to clean up
     console.log('Waiting 500ms for processes to clean up...');

--- a/tests/unit/graviscan/main-wiring.test.ts
+++ b/tests/unit/graviscan/main-wiring.test.ts
@@ -264,11 +264,6 @@ describe('GraviScan wiring module', () => {
 
   describe('coordinator lazy instantiation', () => {
     it('first call creates coordinator', async () => {
-      // Set up _getMainWindow by calling initGraviScan
-      await initGraviScan('graviscan', {} as any, {} as any, () => null);
-      await _resetWiringState();
-      vi.mocked(registerGraviScanHandlers).mockClear();
-
       const coordinator = await getOrCreateCoordinator();
       expect(coordinator).toBeDefined();
       expect(ScanCoordinator).toHaveBeenCalledTimes(1);

--- a/tests/unit/graviscan/main-wiring.test.ts
+++ b/tests/unit/graviscan/main-wiring.test.ts
@@ -3,7 +3,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 
+// Mock electron (dynamic import inside getOrCreateCoordinator)
+vi.mock('electron', () => ({
+  app: { isPackaged: false },
+}));
+
 // Mock graviscan modules
+vi.mock('../../../src/main/graviscan/scan-coordinator', () => {
+  const MockCoordinator = vi.fn().mockImplementation(() => {
+    const emitter = new EventEmitter();
+    return Object.assign(emitter, {
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+  return { ScanCoordinator: MockCoordinator };
+});
+
+vi.mock('../../../src/main/python-paths', () => ({
+  getPythonExecutablePath: vi.fn().mockReturnValue('/usr/bin/python3'),
+}));
+
 vi.mock('../../../src/main/graviscan/register-handlers', () => ({
   registerGraviScanHandlers: vi.fn(),
   _resetRegistration: vi.fn(),
@@ -15,19 +34,25 @@ vi.mock('../../../src/main/graviscan/scan-logger', () => ({
   closeScanLog: vi.fn(),
 }));
 
-vi.mock('../../../src/main/graviscan/scan-coordinator', () => ({
-  ScanCoordinator: vi.fn(),
-}));
-
+import {
+  graviSessionFns,
+  setupCoordinatorEventForwarding,
+  getOrCreateCoordinator,
+  initGraviScan,
+  shutdownGraviScan,
+  _resetWiringState,
+} from '../../../src/main/graviscan/wiring';
 import { registerGraviScanHandlers } from '../../../src/main/graviscan/register-handlers';
-import { cleanupOldLogs } from '../../../src/main/graviscan/scan-logger';
+import {
+  cleanupOldLogs,
+  closeScanLog,
+} from '../../../src/main/graviscan/scan-logger';
+import { ScanCoordinator } from '../../../src/main/graviscan/scan-coordinator';
 
-// We test the extracted patterns directly rather than importing from main.ts
-// (which has Electron side effects that cannot run in a Node test environment)
-
-describe('GraviScan main.ts wiring', () => {
+describe('GraviScan wiring module', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetWiringState();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });
@@ -36,195 +61,117 @@ describe('GraviScan main.ts wiring', () => {
     vi.restoreAllMocks();
   });
 
+  describe('side-effect-free import', () => {
+    it('module imports successfully and all exports are defined', () => {
+      expect(graviSessionFns).toBeDefined();
+      expect(setupCoordinatorEventForwarding).toBeDefined();
+      expect(getOrCreateCoordinator).toBeDefined();
+      expect(initGraviScan).toBeDefined();
+      expect(shutdownGraviScan).toBeDefined();
+      expect(_resetWiringState).toBeDefined();
+      expect(typeof graviSessionFns.getScanSession).toBe('function');
+      expect(typeof graviSessionFns.setScanSession).toBe('function');
+      expect(typeof graviSessionFns.markScanJobRecorded).toBe('function');
+    });
+  });
+
   describe('initGraviScan', () => {
-    it('registers handlers when mode is graviscan', () => {
-      const mode = 'graviscan';
-      if (mode === 'graviscan') {
-        cleanupOldLogs();
-        registerGraviScanHandlers(
-          {} as any,
-          {} as any,
-          () => null,
-          {
-            getScanSession: () => null,
-            setScanSession: () => {},
-            markScanJobRecorded: () => {},
-          },
-          () => null
-        );
-      }
+    it('registers handlers when mode is graviscan', async () => {
+      await initGraviScan('graviscan', {} as any, {} as any, () => null);
 
       expect(cleanupOldLogs).toHaveBeenCalled();
       expect(registerGraviScanHandlers).toHaveBeenCalled();
     });
 
-    it('does NOT register handlers when mode is cylinderscan', () => {
-      const mode = 'cylinderscan';
-      if (mode === 'graviscan') {
-        registerGraviScanHandlers(
-          {} as any,
-          {} as any,
-          () => null,
-          {
-            getScanSession: () => null,
-            setScanSession: () => {},
-            markScanJobRecorded: () => {},
-          },
-          () => null
-        );
-      }
+    it('does NOT register handlers when mode is cylinderscan', async () => {
+      await initGraviScan('cylinderscan', {} as any, {} as any, () => null);
 
       expect(registerGraviScanHandlers).not.toHaveBeenCalled();
     });
 
-    it('does NOT register handlers when mode is empty', () => {
-      const mode = '';
-      if (mode === 'graviscan') {
-        registerGraviScanHandlers(
-          {} as any,
-          {} as any,
-          () => null,
-          {
-            getScanSession: () => null,
-            setScanSession: () => {},
-            markScanJobRecorded: () => {},
-          },
-          () => null
-        );
-      }
+    it('does NOT register handlers when mode is empty', async () => {
+      await initGraviScan('', {} as any, {} as any, () => null);
 
       expect(registerGraviScanHandlers).not.toHaveBeenCalled();
+    });
+
+    it('calls cleanupOldLogs on startup', async () => {
+      await initGraviScan('graviscan', {} as any, {} as any, () => null);
+
+      expect(cleanupOldLogs).toHaveBeenCalled();
+    });
+
+    it('wires arguments correctly to registerGraviScanHandlers', async () => {
+      const mockIpc = {} as any;
+      const mockDb = {} as any;
+      const mockGetWindow = () => null;
+
+      await initGraviScan('graviscan', mockIpc, mockDb, mockGetWindow);
+
+      expect(registerGraviScanHandlers).toHaveBeenCalledWith(
+        mockIpc,
+        mockDb,
+        mockGetWindow,
+        graviSessionFns,
+        expect.any(Function), // () => scanCoordinator
+        getOrCreateCoordinator
+      );
     });
   });
 
   describe('session state lifecycle', () => {
     it('getScanSession returns null initially', () => {
-      let scanSession: any = null;
-      const sessionFns = {
-        getScanSession: () => scanSession,
-        setScanSession: (s: any) => {
-          scanSession = s;
-        },
-        markScanJobRecorded: (key: string) => {
-          if (scanSession?.jobs[key]) {
-            scanSession.jobs[key].status = 'recorded';
-          }
-        },
-      };
-
-      expect(sessionFns.getScanSession()).toBeNull();
+      expect(graviSessionFns.getScanSession()).toBeNull();
     });
 
     it('setScanSession updates state', () => {
-      let scanSession: any = null;
-      const sessionFns = {
-        getScanSession: () => scanSession,
-        setScanSession: (s: any) => {
-          scanSession = s;
-        },
-        markScanJobRecorded: (key: string) => {
-          if (scanSession?.jobs[key]) {
-            scanSession.jobs[key].status = 'recorded';
-          }
-        },
-      };
-
-      sessionFns.setScanSession({ isActive: true, jobs: {} });
-      expect(sessionFns.getScanSession()).toEqual({
+      graviSessionFns.setScanSession({ isActive: true, jobs: {} } as any);
+      expect(graviSessionFns.getScanSession()).toEqual({
         isActive: true,
         jobs: {},
       });
     });
 
     it('markScanJobRecorded updates job status', () => {
-      let scanSession: any = {
+      graviSessionFns.setScanSession({
         isActive: true,
         jobs: { 'scanner1:00': { status: 'complete' } },
-      };
-      const sessionFns = {
-        getScanSession: () => scanSession,
-        setScanSession: (s: any) => {
-          scanSession = s;
-        },
-        markScanJobRecorded: (key: string) => {
-          if (scanSession?.jobs[key]) {
-            scanSession.jobs[key].status = 'recorded';
-          }
-        },
-      };
+      } as any);
 
-      sessionFns.markScanJobRecorded('scanner1:00');
-      expect(scanSession.jobs['scanner1:00'].status).toBe('recorded');
+      graviSessionFns.markScanJobRecorded('scanner1:00');
+      expect(
+        (graviSessionFns.getScanSession() as any).jobs['scanner1:00'].status
+      ).toBe('recorded');
     });
 
     it('markScanJobRecorded ignores unknown key', () => {
-      let scanSession: any = {
+      graviSessionFns.setScanSession({
         isActive: true,
         jobs: { 'scanner1:00': { status: 'complete' } },
-      };
-      const sessionFns = {
-        getScanSession: () => scanSession,
-        setScanSession: (s: any) => {
-          scanSession = s;
-        },
-        markScanJobRecorded: (key: string) => {
-          if (scanSession?.jobs[key]) {
-            scanSession.jobs[key].status = 'recorded';
-          }
-        },
-      };
+      } as any);
 
-      // Should not throw
-      sessionFns.markScanJobRecorded('nonexistent:99');
-      expect(scanSession.jobs['scanner1:00'].status).toBe('complete');
+      graviSessionFns.markScanJobRecorded('nonexistent:99');
+      expect(
+        (graviSessionFns.getScanSession() as any).jobs['scanner1:00'].status
+      ).toBe('complete');
+    });
+
+    it('markScanJobRecorded no-ops when scanSession is null', () => {
+      expect(graviSessionFns.getScanSession()).toBeNull();
+      expect(() =>
+        graviSessionFns.markScanJobRecorded('scanner1:00')
+      ).not.toThrow();
+      expect(graviSessionFns.getScanSession()).toBeNull();
     });
 
     it('setScanSession(null) clears state', () => {
-      let scanSession: any = { isActive: true };
-      const sessionFns = {
-        getScanSession: () => scanSession,
-        setScanSession: (s: any) => {
-          scanSession = s;
-        },
-        markScanJobRecorded: () => {},
-      };
-
-      sessionFns.setScanSession(null);
-      expect(sessionFns.getScanSession()).toBeNull();
+      graviSessionFns.setScanSession({ isActive: true } as any);
+      graviSessionFns.setScanSession(null);
+      expect(graviSessionFns.getScanSession()).toBeNull();
     });
   });
 
   describe('coordinator event forwarding', () => {
-    function setupCoordinatorEventForwarding(
-      coordinator: EventEmitter,
-      getMainWindow: () => {
-        isDestroyed: () => boolean;
-        webContents: { send: (...args: any[]) => void };
-      } | null
-    ): void {
-      const events = [
-        'scan-event',
-        'grid-start',
-        'grid-complete',
-        'cycle-complete',
-        'interval-start',
-        'interval-waiting',
-        'interval-complete',
-        'overtime',
-        'cancelled',
-        'scan-error',
-        'rename-error',
-      ];
-      for (const eventName of events) {
-        coordinator.on(eventName, (payload: unknown) => {
-          const win = getMainWindow();
-          if (win && !win.isDestroyed()) {
-            win.webContents.send(`graviscan:${eventName}`, payload);
-          }
-        });
-      }
-    }
-
     it('forwards all 11 coordinator events to renderer', () => {
       const coordinator = new EventEmitter();
       const send = vi.fn();
@@ -233,7 +180,10 @@ describe('GraviScan main.ts wiring', () => {
         webContents: { send },
       };
 
-      setupCoordinatorEventForwarding(coordinator, () => mockWindow);
+      setupCoordinatorEventForwarding(
+        coordinator as any,
+        () => mockWindow as any
+      );
 
       const events = [
         'scan-event',
@@ -260,7 +210,7 @@ describe('GraviScan main.ts wiring', () => {
 
     it('does not crash when mainWindow is null', () => {
       const coordinator = new EventEmitter();
-      setupCoordinatorEventForwarding(coordinator, () => null);
+      setupCoordinatorEventForwarding(coordinator as any, () => null);
 
       expect(() =>
         coordinator.emit('scan-event', { test: true })
@@ -274,7 +224,10 @@ describe('GraviScan main.ts wiring', () => {
         webContents: { send: vi.fn() },
       };
 
-      setupCoordinatorEventForwarding(coordinator, () => mockWindow);
+      setupCoordinatorEventForwarding(
+        coordinator as any,
+        () => mockWindow as any
+      );
 
       expect(() =>
         coordinator.emit('scan-event', { test: true })
@@ -290,7 +243,10 @@ describe('GraviScan main.ts wiring', () => {
         webContents: { send },
       };
 
-      setupCoordinatorEventForwarding(coordinator, () => mockWindow);
+      setupCoordinatorEventForwarding(
+        coordinator as any,
+        () => mockWindow as any
+      );
 
       coordinator.emit('rename-error', {
         scannerId: 'scanner-1',
@@ -306,62 +262,127 @@ describe('GraviScan main.ts wiring', () => {
     });
   });
 
-  describe('coordinator creation race protection', () => {
-    it('concurrent getOrCreateCoordinator calls return same instance', async () => {
-      // Simulate the coordinator factory with promise memoization guard
-      const mockCoordinator = new EventEmitter();
-      let instance: EventEmitter | null = null;
-      let creating: Promise<EventEmitter> | null = null;
+  describe('coordinator lazy instantiation', () => {
+    it('first call creates coordinator', async () => {
+      // Set up _getMainWindow by calling initGraviScan
+      await initGraviScan('graviscan', {} as any, {} as any, () => null);
+      _resetWiringState();
+      vi.mocked(registerGraviScanHandlers).mockClear();
 
-      async function getOrCreateCoordinator() {
-        if (instance) return instance;
-        if (creating) return creating;
-        creating = (async () => {
-          await new Promise((r) => setTimeout(r, 10));
-          instance = mockCoordinator;
-          return instance;
-        })();
-        try {
-          return await creating;
-        } finally {
-          creating = null;
-        }
-      }
+      const coordinator = await getOrCreateCoordinator();
+      expect(coordinator).toBeDefined();
+      expect(ScanCoordinator).toHaveBeenCalledTimes(1);
+    });
 
-      // Call twice concurrently
+    it('second call returns cached instance', async () => {
+      const c1 = await getOrCreateCoordinator();
+      const c2 = await getOrCreateCoordinator();
+      expect(c1).toBe(c2);
+      expect(ScanCoordinator).toHaveBeenCalledTimes(1);
+    });
+
+    it('concurrent calls return same instance', async () => {
       const [c1, c2] = await Promise.all([
         getOrCreateCoordinator(),
         getOrCreateCoordinator(),
       ]);
 
-      // Both should return the same instance (when properly guarded)
-      // With the bug, createCount would be 2 and they'd be different objects
-      // This test documents the DESIRED behavior — the fix should make createCount === 1
       expect(c1).toBe(c2);
+      expect(ScanCoordinator).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('shutdownGraviScan', () => {
+    it('shuts down active coordinator and calls closeScanLog', async () => {
+      // Create a coordinator with a trackable shutdown spy
+      const shutdownFn = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(ScanCoordinator).mockImplementationOnce(() => {
+        const emitter = new EventEmitter();
+        return Object.assign(emitter, { shutdown: shutdownFn }) as any;
+      });
+
+      await getOrCreateCoordinator();
+      await shutdownGraviScan();
+
+      expect(shutdownFn).toHaveBeenCalled();
+      expect(closeScanLog).toHaveBeenCalled();
+    });
+
+    it('no-ops when no coordinator exists, still calls closeScanLog', async () => {
+      await shutdownGraviScan();
+
+      expect(closeScanLog).toHaveBeenCalled();
+    });
+
+    it('catches coordinator.shutdown() error and still calls closeScanLog', async () => {
+      // Create a coordinator with a failing shutdown
+      const shutdownFn = vi
+        .fn()
+        .mockRejectedValue(new Error('shutdown failed'));
+      vi.mocked(ScanCoordinator).mockImplementationOnce(() => {
+        const emitter = new EventEmitter();
+        return Object.assign(emitter, { shutdown: shutdownFn }) as any;
+      });
+
+      await getOrCreateCoordinator();
+      await shutdownGraviScan();
+
+      expect(shutdownFn).toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error shutting down'),
+        expect.any(Error)
+      );
+      expect(closeScanLog).toHaveBeenCalled();
+    });
+
+    it('awaits in-flight _coordinatorCreating before shutting down', async () => {
+      // Verify the promise memoization pattern works with shutdown.
+      // We simulate concurrent create + shutdown by calling both without awaiting.
+      const shutdownFn = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(ScanCoordinator).mockImplementationOnce(() => {
+        const emitter = new EventEmitter();
+        return Object.assign(emitter, { shutdown: shutdownFn }) as any;
+      });
+
+      // Start creation (sets _coordinatorCreating) and shutdown concurrently
+      const createPromise = getOrCreateCoordinator();
+      const shutdownPromise = shutdownGraviScan();
+
+      // Both should resolve without error
+      await createPromise;
+      await shutdownPromise;
+
+      expect(shutdownFn).toHaveBeenCalled();
+      expect(closeScanLog).toHaveBeenCalled();
+    });
+
+    it('handles rejected _coordinatorCreating gracefully', async () => {
+      // Make coordinator creation fail
+      vi.mocked(ScanCoordinator).mockImplementationOnce(() => {
+        throw new Error('Python not found');
+      });
+
+      // Start creation — will reject
+      const createPromise = getOrCreateCoordinator();
+      await createPromise.catch(() => {});
+
+      // Shutdown should handle this gracefully
+      await shutdownGraviScan();
+
+      expect(closeScanLog).toHaveBeenCalled();
     });
   });
 
   describe('session completion', () => {
     it('session is cleared after scan completes successfully', () => {
-      let scanSession: any = {
+      graviSessionFns.setScanSession({
         isActive: true,
         experimentId: 'exp1',
         jobs: {},
-      };
+      } as any);
 
-      const sessionFns = {
-        getScanSession: () => scanSession,
-        setScanSession: (s: any) => {
-          scanSession = s;
-        },
-        markScanJobRecorded: () => {},
-      };
-
-      // Simulate scan completion: session should be cleared or marked inactive
-      // The coordinator emits interval-complete or cycle-complete,
-      // and the session should transition to inactive
-      sessionFns.setScanSession(null);
-      expect(sessionFns.getScanSession()).toBeNull();
+      graviSessionFns.setScanSession(null);
+      expect(graviSessionFns.getScanSession()).toBeNull();
     });
   });
 });

--- a/tests/unit/graviscan/main-wiring.test.ts
+++ b/tests/unit/graviscan/main-wiring.test.ts
@@ -50,9 +50,9 @@ import {
 import { ScanCoordinator } from '../../../src/main/graviscan/scan-coordinator';
 
 describe('GraviScan wiring module', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
-    _resetWiringState();
+    await _resetWiringState();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });
@@ -266,7 +266,7 @@ describe('GraviScan wiring module', () => {
     it('first call creates coordinator', async () => {
       // Set up _getMainWindow by calling initGraviScan
       await initGraviScan('graviscan', {} as any, {} as any, () => null);
-      _resetWiringState();
+      await _resetWiringState();
       vi.mocked(registerGraviScanHandlers).mockClear();
 
       const coordinator = await getOrCreateCoordinator();


### PR DESCRIPTION
## Summary

- Extract GraviScan wiring logic (state, orchestration, shutdown) from `main.ts` into `src/main/graviscan/wiring.ts` — a side-effect-free module importable in Node test environments
- Add `shutdownGraviScan()` to encapsulate coordinator shutdown + scan log close (required since extracted state is module-private)
- Rewrite `main-wiring.test.ts` to test real exported functions instead of inline reimplementations (25 tests, up from 14)
- Fix pre-existing spec gap: add `rename-error` to Coordinator Event Forwarding events list

Closes #190
Related: #181 (make main process testable), #130 (GraviScan integration epic)

## Details

**Why:** Tests previously re-implemented wiring logic inline because importing `main.ts` triggers Electron side effects. Now tests import and exercise the real production code.

**Known behavior change:** `closeScanLog()` now runs before `closeDatabase()` instead of after. Safe because the scan log is a filesystem write stream with no database dependency (see design.md).

**OpenSpec:** `refactor-extract-graviscan-wiring` — proposal, design, tasks, and spec deltas included.

## Test plan

- [x] 25 unit tests in `main-wiring.test.ts` (14 rewritten + 11 new)
- [x] Full suite: 717 passed, 9 skipped (706 original + 11 new)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Lint clean (`npm run lint`)
- [x] OpenSpec validates (`npx openspec validate --strict`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)