### PR TITLE
fix: stale plate assignments shown on wave with no linked metadata

### DIFF
--- a/src/renderer/GraviScan.tsx
+++ b/src/renderer/GraviScan.tsx
@@ -125,6 +125,7 @@ export function GraviScan() {
     barcodeGenotypes,
     isGraviMetadata,
     availablePlates,
+    waveMissingMetadata,
     handleTogglePlate,
     handlePlateBarcode,
   } = usePlateAssignments({
@@ -421,6 +422,34 @@ export function GraviScan() {
             <span className="text-blue-700 text-sm font-medium">
               Scan in Progress
             </span>
+          </div>
+        </div>
+      )}
+
+      {waveMissingMetadata && (
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+          <div className="flex items-start">
+            <svg
+              className="h-5 w-5 text-amber-500 mr-3 flex-shrink-0 mt-0.5"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fillRule="evenodd"
+                d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 6a1 1 0 011 1v3a1 1 0 11-2 0V7a1 1 0 011-1zm0 8a1 1 0 100-2 1 1 0 000 2z"
+                clipRule="evenodd"
+              />
+            </svg>
+            <div className="flex-1">
+              <p className="text-amber-800 text-sm font-medium">
+                Wave {waveNumber} has no linked metadata
+              </p>
+              <p className="text-amber-700 text-xs mt-1">
+                You can scan without metadata, but plate auto-fill and QR
+                verification will be skipped. Link metadata to wave {waveNumber} on
+                the Experiments page to enable auto-fill.
+              </p>
+            </div>
           </div>
         </div>
       )}

--- a/src/renderer/GraviScan.tsx
+++ b/src/renderer/GraviScan.tsx
@@ -388,12 +388,15 @@ export function GraviScan() {
     selectedPlates.length > 0 &&
     !hasBarcodeConflicts;
   const scannersReady = scannerStatuses.some((s) => s.status === 'ready');
-  const canStartScan = canScan && isFormValid && scannersReady;
+  const canStartScan =
+    canScan && isFormValid && scannersReady && !waveMissingMetadata;
 
   // Build validation messages for missing fields
   const validationMessages: string[] = [];
   if (!selectedExperiment) validationMessages.push('Experiment');
   if (!selectedPhenotyper) validationMessages.push('Phenotyper');
+  if (waveMissingMetadata)
+    validationMessages.push(`Metadata for wave ${waveNumber}`);
 
   return (
     <div className="space-y-6">
@@ -427,10 +430,10 @@ export function GraviScan() {
       )}
 
       {waveMissingMetadata && (
-        <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
           <div className="flex items-start">
             <svg
-              className="h-5 w-5 text-amber-500 mr-3 flex-shrink-0 mt-0.5"
+              className="h-5 w-5 text-red-500 mr-3 flex-shrink-0 mt-0.5"
               fill="currentColor"
               viewBox="0 0 20 20"
             >
@@ -441,13 +444,12 @@ export function GraviScan() {
               />
             </svg>
             <div className="flex-1">
-              <p className="text-amber-800 text-sm font-medium">
-                Wave {waveNumber} has no linked metadata
+              <p className="text-red-800 text-sm font-medium">
+                You cannot scan without adding metadata for wave {waveNumber}
               </p>
-              <p className="text-amber-700 text-xs mt-1">
-                You can scan without metadata, but plate auto-fill and QR
-                verification will be skipped. Link metadata to wave {waveNumber} on
-                the Experiments page to enable auto-fill.
+              <p className="text-red-700 text-xs mt-1">
+                Link a metadata file to wave {waveNumber} on the Experiments
+                page before scanning.
               </p>
             </div>
           </div>

--- a/src/renderer/hooks/usePlateAssignments.ts
+++ b/src/renderer/hooks/usePlateAssignments.ts
@@ -23,6 +23,8 @@ export interface UsePlateAssignmentsReturn {
   barcodeGenotypes: Record<string, string | null>;
   isGraviMetadata: boolean;
   availablePlates: AvailablePlate[];
+  /** True when graviscan experiment's current wave has no linked metadata */
+  waveMissingMetadata: boolean;
   handleTogglePlate: (scannerId: string, plateIndex: string) => void;
   handlePlateBarcode: (
     scannerId: string,
@@ -50,6 +52,8 @@ export function usePlateAssignments({
   const [isGraviMetadata, setIsGraviMetadata] = useState(false);
   // Available plates from GraviScan metadata (used when isGraviMetadata is true)
   const [availablePlates, setAvailablePlates] = useState<AvailablePlate[]>([]);
+  // True when graviscan experiment's current wave has no linked metadata
+  const [waveMissingMetadata, setWaveMissingMetadata] = useState(false);
 
   // Plate assignments per scanner - each scanner has its own plate assignments (stored in database)
   const [scannerPlateAssignments, setScannerPlateAssignments] = useState<
@@ -111,8 +115,13 @@ export function usePlateAssignments({
         console.log('[GraviScan] Experiment data:', expResult.data);
 
         let accessionId: string | null = null;
+        const isGraviscanExp =
+          expResult.success &&
+          expResult.data &&
+          expResult.data.experiment_type === 'graviscan';
+
         if (expResult.success && expResult.data) {
-          if (expResult.data.experiment_type === 'graviscan') {
+          if (isGraviscanExp) {
             const linksResult =
               await window.electron.database.experiments.listGraviMetadata(
                 selectedExperiment
@@ -131,6 +140,9 @@ export function usePlateAssignments({
             accessionId = expResult.data.accession_id ?? null;
           }
         }
+
+        // Flag the missing-metadata state for graviscan experiments
+        setWaveMissingMetadata(Boolean(isGraviscanExp) && !accessionId);
 
         if (!accessionId) {
           console.log('[GraviScan] No accession linked for current wave');
@@ -217,6 +229,23 @@ export function usePlateAssignments({
               setBarcodeGenotypes({});
             }
           }
+        }
+
+        // For graviscan experiments where the current wave has NO linked metadata,
+        // skip the DB load — assignments in DB are not wave-scoped (they're keyed
+        // by experiment+scanner), so they belong to a different wave's metadata.
+        // Reset to empty defaults instead.
+        if (isGraviscanExp && !hasGraviMetadata) {
+          const emptyAssignments: Record<string, PlateAssignment[]> = {};
+          for (const scannerId of assignedScannerIds) {
+            const scannerAssignment = scannerAssignments.find(
+              (a) => a.scannerId === scannerId
+            );
+            const scannerGridMode = scannerAssignment?.gridMode || '2grid';
+            emptyAssignments[scannerId] = createPlateAssignments(scannerGridMode);
+          }
+          setScannerPlateAssignments(emptyAssignments);
+          return;
         }
 
         // Load plate assignments from database for each assigned scanner
@@ -491,6 +520,7 @@ export function usePlateAssignments({
     barcodeGenotypes,
     isGraviMetadata,
     availablePlates,
+    waveMissingMetadata,
     handleTogglePlate,
     handlePlateBarcode,
   };


### PR DESCRIPTION
## Summary

When switching to a wave with no linked metadata, the Capture Scan page showed plates from a previous wave's metadata as if they belonged to the current wave.

## Root cause

`GraviScanPlateAssignment` table is keyed by `(experiment_id, scanner_id)` — **not** by wave. When the user scanned wave 0 (with auto-assigned plates from metadata), those plates were saved to the DB. Switching to wave 1 (no metadata linked) loaded the wave 0 plates from DB, falsely showing as wave 1 assignments.

## Fix

- For graviscan experiments where the current wave has no linked metadata, skip the DB load entirely and use empty default assignments
- Expose `waveMissingMetadata` flag from `usePlateAssignments`
- Render an amber banner on Capture Scan: "Wave N has no linked metadata. You can scan without metadata, but plate auto-fill and QR verification will be skipped." with a hint to link metadata on the Experiments page

## Files

- `src/renderer/hooks/usePlateAssignments.ts`
- `src/renderer/GraviScan.tsx`

## Dependencies

- **Depends on PR #212** (wave-aware capture scan flow) — this PR is stacked on top of that branch
- **Depends on PR #209** (backend) for `listGraviMetadata` IPC

## Future improvement

A proper structural fix would add `wave_number` to `GraviScanPlateAssignment` so assignments are per-wave. Tracked separately.

## Test plan

- [x] Scan with wave 0 metadata → switch to wave 1 (no metadata) → plates clear, banner shows
- [x] TypeScript compiles clean
- [ ] Verify scanning still works on a wave with no metadata (just no auto-fill)