### PR TITLE
feat(graviscan): permanent elapsed-time counter in top banner

### DIFF
--- a/src/renderer/Layout.tsx
+++ b/src/renderer/Layout.tsx
@@ -225,7 +225,9 @@ export function Layout() {
     totalCycles?: number;
     coordinatorState?: string;
     isContinuous?: boolean;
+    scanStartedAt?: number | null;
   } | null>(null);
+  const [nowMs, setNowMs] = useState(() => Date.now());
 
   // Load scanner name from scanner identity service
   useEffect(() => {
@@ -297,6 +299,26 @@ export function Layout() {
     const interval = setInterval(poll, 3000);
     return () => clearInterval(interval);
   }, []);
+
+  // Tick once a second so the banner's elapsed counter updates between polls.
+  useEffect(() => {
+    if (!scanStatus?.isActive || !scanStatus.scanStartedAt) return;
+    setNowMs(Date.now());
+    const interval = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, [scanStatus?.isActive, scanStatus?.scanStartedAt]);
+
+  const elapsedSec =
+    scanStatus?.scanStartedAt != null
+      ? Math.max(0, Math.floor((nowMs - scanStatus.scanStartedAt) / 1000))
+      : null;
+
+  const formatHMS = (totalSec: number): string => {
+    const hh = String(Math.floor(totalSec / 3600)).padStart(2, '0');
+    const mm = String(Math.floor((totalSec % 3600) / 60)).padStart(2, '0');
+    const ss = String(totalSec % 60).padStart(2, '0');
+    return `${hh}:${mm}:${ss}`;
+  };
 
   return (
     <div className="flex flex-col h-screen bg-gray-50">
@@ -469,6 +491,11 @@ export function Layout() {
                     ? ' (waiting for next cycle)'
                     : ''}
                 </span>
+                {elapsedSec !== null && (
+                  <span className="text-xs font-mono bg-blue-700/40 px-2 py-0.5 rounded">
+                    {formatHMS(elapsedSec)}
+                  </span>
+                )}
               </div>
               <span className="text-xs opacity-80">Click to view</span>
             </div>

--- a/src/renderer/components/graviscan/ScanControlSection.tsx
+++ b/src/renderer/components/graviscan/ScanControlSection.tsx
@@ -249,31 +249,30 @@ export function ScanControlSection({
                   : 'Scanning plates...'}
               </span>
             </div>
-            {/* Elapsed time and estimated remaining — only shown between scans */}
-            {intervalCountdown !== null && intervalCountdown > 0 && (
-              <div className="flex items-center justify-between text-xs text-indigo-500">
-                <span>
-                  Elapsed:{' '}
-                  {String(Math.floor(elapsedSeconds / 3600)).padStart(2, '0')}:
-                  {String(Math.floor((elapsedSeconds % 3600) / 60)).padStart(
-                    2,
-                    '0'
-                  )}
-                  :{String(elapsedSeconds % 60).padStart(2, '0')}
-                </span>
-                {currentCycle > 0 && totalCycles > currentCycle && (
-                  <span>
-                    {(() => {
-                      const avgCycleSeconds = elapsedSeconds / currentCycle;
-                      const remainingSeconds = Math.round(
-                        (totalCycles - currentCycle) * avgCycleSeconds
-                      );
-                      return `~${String(Math.floor(remainingSeconds / 3600)).padStart(2, '0')}:${String(Math.floor((remainingSeconds % 3600) / 60)).padStart(2, '0')}:${String(remainingSeconds % 60).padStart(2, '0')} remaining`;
-                    })()}
-                  </span>
+            {/* Elapsed time + estimated remaining — visible throughout the
+                whole continuous run, including while a scan is in progress. */}
+            <div className="flex items-center justify-between text-xs text-indigo-500">
+              <span>
+                Elapsed:{' '}
+                {String(Math.floor(elapsedSeconds / 3600)).padStart(2, '0')}:
+                {String(Math.floor((elapsedSeconds % 3600) / 60)).padStart(
+                  2,
+                  '0'
                 )}
-              </div>
-            )}
+                :{String(elapsedSeconds % 60).padStart(2, '0')}
+              </span>
+              {currentCycle > 0 && totalCycles > currentCycle && (
+                <span>
+                  {(() => {
+                    const avgCycleSeconds = elapsedSeconds / currentCycle;
+                    const remainingSeconds = Math.round(
+                      (totalCycles - currentCycle) * avgCycleSeconds
+                    );
+                    return `~${String(Math.floor(remainingSeconds / 3600)).padStart(2, '0')}:${String(Math.floor((remainingSeconds % 3600) / 60)).padStart(2, '0')}:${String(remainingSeconds % 60).padStart(2, '0')} remaining`;
+                  })()}
+                </span>
+              )}
+            </div>
             {/* Overtime banner */}
             {overtimeMs !== null && (
               <div className="mt-2 p-2 bg-amber-50 border border-amber-300 rounded text-sm text-amber-800">


### PR DESCRIPTION
## Why

The elapsed-time line on the scanning page was gated on `intervalCountdown > 0`, so it disappeared while a scan was actually running and only reappeared between cycles. There's also no global indicator on other pages.

## What changes

- **Top banner** (`Layout.tsx`): adds a 1Hz-ticked elapsed counter (`HH:MM:SS`) computed from `scanStatus.scanStartedAt`. Visible across all non-`/scanning` pages while a scan is in progress, never depends on poll timing for accuracy.
- **Scanning page** (`ScanControlSection.tsx`): elapsed + estimated-remaining row in continuous mode is no longer hidden during the actual scan portion of each cycle. Always visible while the continuous run is going.