### PR TITLE
feat(graviscan): re-enable Bloom upload, parallel per-image + alongside Box

### DIFF
--- a/src/main/graviscan-handlers.ts
+++ b/src/main/graviscan-handlers.ts
@@ -18,8 +18,7 @@ import { resolveGraviScanPath } from './graviscan-path-utils';
 import type { ScanCoordinator, ScannerConfig } from './scan-coordinator';
 import type { PlateConfig } from './scanner-subprocess';
 import { getScanSession, setScanSession, markScanJobRecorded } from './main';
-// Bloom upload temporarily disabled (proxy size limit) — re-enable when fixed
-// import { uploadAllPendingScans } from './graviscan-upload';
+import { uploadAllPendingScans } from './graviscan-upload';
 import { runBoxBackup } from './box-backup';
 import { readQrCodes } from './qr-reader';
 import type {
@@ -1894,9 +1893,10 @@ export function registerGraviscanHandlers(
   // ==========================================================================
 
   /**
-   * Upload all pending/failed scans to Box backup.
-   * Bloom (Supabase) upload is temporarily disabled due to proxy size limit.
-   * Sends progress events to the renderer via 'graviscan:box-backup-progress'.
+   * Upload all pending/failed scans to Bloom (Supabase) and Box (rclone).
+   * Both run in parallel; their results are merged. Progress events:
+   *   'graviscan:upload-progress'      — Bloom per-image progress
+   *   'graviscan:box-backup-progress'  — Box per-file progress
    */
   let uploadInProgress = false;
   ipcMain.handle('graviscan:upload-all-scans', async () => {
@@ -1912,28 +1912,60 @@ export function registerGraviscanHandlers(
     }
     uploadInProgress = true;
     try {
-      console.log(
-        '[GraviScan:UPLOAD] Bloom upload disabled (proxy size limit) — Box backup only'
-      );
+      console.log('[GraviScan:UPLOAD] Starting Bloom + Box upload in parallel');
 
       const mainWindow = getMainWindow?.();
 
-      // Bloom upload temporarily disabled — proxy at api.bloom.salk.edu
-      // rejects files >50MB. Re-enable by restoring uploadAllPendingScans
-      // to a Promise.allSettled alongside runBoxBackup.
+      const [bloomSettled, boxSettled] = await Promise.allSettled([
+        uploadAllPendingScans(db, (progress) => {
+          mainWindow?.webContents.send('graviscan:upload-progress', progress);
+        }),
+        runBoxBackup(db, (progress) => {
+          mainWindow?.webContents.send('graviscan:box-backup-progress', progress);
+        }),
+      ]);
 
-      const boxResult = await runBoxBackup(db, (progress) => {
-        mainWindow?.webContents.send('graviscan:box-backup-progress', progress);
-      });
+      const bloomResult =
+        bloomSettled.status === 'fulfilled'
+          ? bloomSettled.value
+          : {
+              success: false,
+              uploaded: 0,
+              skipped: 0,
+              failed: 0,
+              errors: [
+                `Bloom upload threw: ${
+                  bloomSettled.reason instanceof Error
+                    ? bloomSettled.reason.message
+                    : String(bloomSettled.reason)
+                }`,
+              ],
+            };
+      const boxResult =
+        boxSettled.status === 'fulfilled'
+          ? boxSettled.value
+          : {
+              success: false,
+              experiments: 0,
+              filesCopied: 0,
+              errors: [
+                `Box backup threw: ${
+                  boxSettled.reason instanceof Error
+                    ? boxSettled.reason.message
+                    : String(boxSettled.reason)
+                }`,
+              ],
+            };
 
-      console.log('[GraviScan:UPLOAD] Box backup result:', boxResult);
+      console.log('[GraviScan:UPLOAD] Bloom result:', bloomResult);
+      console.log('[GraviScan:UPLOAD] Box result:', boxResult);
 
       return {
-        success: boxResult.success,
-        uploaded: boxResult.filesCopied,
-        skipped: 0,
-        failed: boxResult.errors.length,
-        errors: boxResult.errors,
+        success: bloomResult.success && boxResult.success,
+        uploaded: bloomResult.uploaded + boxResult.filesCopied,
+        skipped: bloomResult.skipped,
+        failed: bloomResult.failed + boxResult.errors.length,
+        errors: [...bloomResult.errors, ...boxResult.errors],
       };
     } catch (error) {
       console.error('[GraviScan:UPLOAD] Error:', error);

--- a/src/main/graviscan-upload.ts
+++ b/src/main/graviscan-upload.ts
@@ -159,20 +159,22 @@ async function processImageJobs(
   metadataIdMap: Map<string, number>,
   onProgress?: (progress: UploadProgress) => void
 ): Promise<UploadResult> {
+  // Bounded concurrency for Bloom uploads. Each image is 3 round-trips
+  // (insert RPC → file upload → update RPC); 4 workers keeps HTTPS pipes
+  // saturated without overwhelming Bloom's API or the local network when
+  // running alongside rclone's Box backup.
+  const UPLOAD_CONCURRENCY = 4;
+
   const errors: string[] = [];
   const total = imageJobs.length;
   let uploaded = 0;
   let skipped = 0;
   let failed = 0;
 
-  for (const { scan, image } of imageJobs) {
-    onProgress?.({
-      total,
-      completed: uploaded + skipped + failed,
-      failed,
-      currentFile: path.basename(image.path),
-    });
+  type Job = (typeof imageJobs)[number];
 
+  const processOne = async (job: Job): Promise<void> => {
+    const { scan, image } = job;
     try {
       // Resolve stale paths (DB may have _st_ only, disk file renamed with _et_)
       const resolvedPath = resolveGraviScanPath(image.path);
@@ -183,7 +185,7 @@ async function processImageJobs(
           data: { status: 'failed' },
         });
         failed++;
-        continue;
+        return;
       }
       if (resolvedPath !== image.path) {
         console.log(
@@ -248,7 +250,7 @@ async function processImageJobs(
           data: { status: 'failed' },
         });
         failed++;
-        continue;
+        return;
       }
 
       if (scanId === null) {
@@ -257,7 +259,7 @@ async function processImageJobs(
           data: { status: 'uploaded' },
         });
         skipped++;
-        continue;
+        return;
       }
 
       const ext = path.extname(image.path);
@@ -279,7 +281,7 @@ async function processImageJobs(
           data: { status: 'failed' },
         });
         failed++;
-        continue;
+        return;
       }
 
       const { error: imageError } = await (
@@ -299,7 +301,7 @@ async function processImageJobs(
           data: { status: 'failed' },
         });
         failed++;
-        continue;
+        return;
       }
 
       await db.graviImage.update({
@@ -316,7 +318,29 @@ async function processImageJobs(
       });
       failed++;
     }
-  }
+  };
+
+  // Worker-pool pattern: N workers share a single index cursor and pull
+  // from `imageJobs` until the queue is exhausted. Counter mutations are
+  // safe because JS is single-threaded between awaits.
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= imageJobs.length) return;
+      const job = imageJobs[idx];
+      await processOne(job);
+      onProgress?.({
+        total,
+        completed: uploaded + skipped + failed,
+        failed,
+        currentFile: path.basename(job.image.path),
+      });
+    }
+  };
+
+  const workerCount = Math.min(UPLOAD_CONCURRENCY, imageJobs.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
 
   onProgress?.({
     total,


### PR DESCRIPTION
## Why

The Bloom upload path was disabled in [graviscan-handlers.ts:1916](src/main/graviscan-handlers.ts#L1916) because the proxy at api.bloom.salk.edu rejected files >50MB. That limit is now lifted, so it's safe to re-enable. Two changes in one PR:

1. **Re-enable the path.** Restore `uploadAllPendingScans` import and call it alongside `runBoxBackup` via `Promise.allSettled` so the two destinations don't block each other.
2. **Parallelize per-image uploads.** `processImageJobs` was a strict sequential `for...of await` loop — every image was 3 round-trips (insert RPC → file upload → update RPC) one after another. With 200 plates that's ~10 minutes serialized. Replaced with a 4-worker pool over a shared cursor.

## What changes

- [src/main/graviscan-handlers.ts](src/main/graviscan-handlers.ts) — uncomment import; restore Bloom call alongside Box backup via `Promise.allSettled`; merge result counters; a thrown rejection on either side becomes a structured error in the response (no swallowing).
- [src/main/graviscan-upload.ts](src/main/graviscan-upload.ts) — extract the per-image body to `processOne(job)`; run `UPLOAD_CONCURRENCY = 4` workers over a shared `cursor` index; counters mutate from concurrent tasks (safe — JS is single-threaded between awaits). Progress callback fires on each completion with the just-finished file name.

## Concurrency choice

`UPLOAD_CONCURRENCY = 4` matches rclone's default `--transfers` so total network parallelism stays bounded when both run together (Bloom × 4 + Box × 4 = 8 in flight, system-wide). Tunable as a single named constant.