### PR TITLE
fix(graviscan): auto-populate transplant_date + custom_note on barcode pick

### DIFF
--- a/src/renderer/hooks/usePlateAssignments.ts
+++ b/src/renderer/hooks/usePlateAssignments.ts
@@ -202,6 +202,9 @@ export function usePlateAssignments({
                   id: plate.id,
                   plate_id: plate.plate_id,
                   accession: plate.accession,
+                  transplant_date: plate.transplant_date
+                    ? new Date(plate.transplant_date).toISOString().split('T')[0]
+                    : null,
                   custom_note: plate.custom_note ?? null,
                   sectionCount: new Set(
                     (plate.sections || []).map((s) => s.plate_section_id)
@@ -485,10 +488,28 @@ export function usePlateAssignments({
         }
       }
 
+      // Pull transplant_date + custom_note from the matching metadata row so
+      // they flow through the assignment → scan → DB → both upload paths.
+      // Without this copy, GraviScan rows are written with null on these
+      // fields and the Box CSV ends up empty even though the metadata sheet
+      // has the values.
+      const matchedPlate = barcode
+        ? availablePlates.find((p) => p.plate_id === barcode)
+        : undefined;
+      const transplantDate = matchedPlate?.transplant_date ?? null;
+      const customNote = matchedPlate?.custom_note ?? null;
+
       setScannerPlateAssignments((prev) => {
         const assignments = prev[scannerId] || [];
         const updated = assignments.map((p) =>
-          p.plateIndex === plateIndex ? { ...p, plantBarcode: barcode } : p
+          p.plateIndex === plateIndex
+            ? {
+                ...p,
+                plantBarcode: barcode,
+                transplantDate,
+                customNote,
+              }
+            : p
         );
 
         // Save to database if experiment is selected
@@ -496,6 +517,8 @@ export function usePlateAssignments({
           window.electron.database.graviscanPlateAssignments
             .upsert(selectedExperiment, scannerId, plateIndex, {
               plate_barcode: barcode,
+              transplant_date: transplantDate,
+              custom_note: customNote,
             })
             .then((result) => {
               console.log('[GraviScan] Upsert response:', result);
@@ -508,7 +531,7 @@ export function usePlateAssignments({
         return { ...prev, [scannerId]: updated };
       });
     },
-    [selectedExperiment, scannerPlateAssignments, setScanError]
+    [selectedExperiment, scannerPlateAssignments, availablePlates, setScanError]
   );
 
   return {

--- a/src/types/graviscan.ts
+++ b/src/types/graviscan.ts
@@ -236,6 +236,7 @@ export interface AvailablePlate {
   id: string; // GraviPlateAccession database ID
   plate_id: string; // Human-readable plate identifier (e.g., "PLATE_001")
   accession: string; // Accession/genotype line (e.g., "Ara-1")
+  transplant_date: string | null; // ISO date from metadata CSV; copied to assignment on barcode pick
   custom_note: string | null; // User-defined note from metadata CSV
   sectionCount: number; // Number of sections on this plate
   plantQrCodes: string[]; // All plant QR codes from sections


### PR DESCRIPTION
## Why

Box CSV showed empty `accession` and `transplant_date` even when the metadata sheet had the values. Bloom upload had them. Same source data, different output — root cause is the renderer drops them silently.

When a user picks a barcode in Capture Scan, only `plate_barcode` was being copied into `GraviScanPlateAssignment` — `transplant_date` and `custom_note` from the matching `GraviPlateAccession` (the metadata sheet) were dropped on the floor. Downstream:

- `GraviScan.transplant_date` and `GraviScan.custom_note` are written as null
- Box CSV reads `scan.transplant_date` → empty
- Bloom upload happened to read `matchedPlate.transplant_date` directly via a redundant lookup, so it had the right value
- Local SQLite is incomplete, capture-scan UI fields show blank

This was the band-aid territory: any consumer that read off `GraviScan` directly was wrong. The right fix is to make the data flow correctly once.

## What changes

- **[src/types/graviscan.ts](src/types/graviscan.ts)** — `AvailablePlate` gains `transplant_date: string | null` so the dropdown carries it through.
- **[src/renderer/hooks/usePlateAssignments.ts](src/renderer/hooks/usePlateAssignments.ts)**
  - When loading available plates from `GraviPlateAccession`, populate `transplant_date` (ISO date string).
  - In `handlePlateBarcode`, after the barcode-uniqueness check, look up the matching plate by `plate_id === barcode`, pull `transplant_date` and `custom_note`, and include them in:
    - the local `scannerPlateAssignments` state, and
    - the `graviscanPlateAssignments.upsert` IPC payload.
  - The IPC handler and DB schema already support both fields (no main-process / Prisma changes needed).