### PR TITLE
feat(graviscan): embed exp_name, wave_number, start time, phenotyper_name in TIFF

### DIFF
--- a/python/graviscan/scan_worker.py
+++ b/python/graviscan/scan_worker.py
@@ -54,22 +54,23 @@ _BLOOM_VERSION = "0.1.0"
 
 def _build_tiff_metadata(
     scanner_id: str,
-    grid_mode: str,
-    plate_index: str,
-    resolution: int,
+    plate: dict,
     region,
 ) -> ImageFileDirectory_v2:
     """Build TIFF metadata tags for a scan image.
 
     Embeds scan provenance into standard TIFF tags so files are self-describing.
-    Structured metadata goes into ImageDescription as JSON.
+    Structured metadata (incl. experiment + phenotyper attribution) goes into
+    ImageDescription as JSON so the .tif is portable to Box, downstream
+    pipelines, or scientists' laptops without the local DB.
     """
+    resolution = plate["resolution"]
     ifd = ImageFileDirectory_v2()
     ifd[270] = json.dumps(
         {  # ImageDescription
             "scanner_id": scanner_id,
-            "grid_mode": grid_mode,
-            "plate_index": plate_index,
+            "grid_mode": plate["grid_mode"],
+            "plate_index": plate["plate_index"],
             "resolution_dpi": resolution,
             "scan_region_mm": {
                 "top": region.top,
@@ -77,6 +78,10 @@ def _build_tiff_metadata(
                 "width": region.width,
                 "height": region.height,
             },
+            "exp_name": plate["exp_name"],
+            "wave_number": plate["wave_number"],
+            "st_timestamp": plate["st_timestamp"],
+            "phenotyper_name": plate.get("phenotyper_name") or "",
             "capture_timestamp": datetime.now(timezone.utc).isoformat(),
             "bloom_version": _BLOOM_VERSION,
         }
@@ -410,9 +415,7 @@ class ScanWorker:
                 # Save as TIFF with LZW compression and metadata.
                 # Compose the final filename here so `_et_` reflects the
                 # actual save moment, not the scan-start moment.
-                tiff_meta = _build_tiff_metadata(
-                    self.scanner_id, grid_mode, plate_index, resolution, region
-                )
+                tiff_meta = _build_tiff_metadata(self.scanner_id, plate, region)
                 et = datetime.now().strftime("%Y%m%dT%H%M%S")
                 final_path = compose_output_path(plate, et)
                 image.save(
@@ -594,9 +597,7 @@ class ScanWorker:
         image = Image.fromarray(img_array, mode="RGB")
 
         os.makedirs(plate["output_dir"], exist_ok=True)
-        tiff_meta = _build_tiff_metadata(
-            self.scanner_id, grid_mode, plate_index, resolution, region
-        )
+        tiff_meta = _build_tiff_metadata(self.scanner_id, plate, region)
         et = datetime.now().strftime("%Y%m%dT%H%M%S")
         final_path = compose_output_path(plate, et)
         image.save(final_path, "TIFF", compression="tiff_lzw", tiffinfo=tiff_meta)

--- a/python/tests/test_scan_worker.py
+++ b/python/tests/test_scan_worker.py
@@ -66,6 +66,7 @@ def _make_plate(
     scanner_tag="Sc1",
     system_prefix="",
     cycle=1,
+    phenotyper_name="",
 ):
     """Build a component-shaped plate dict for the worker's scan command."""
     return {
@@ -79,6 +80,7 @@ def _make_plate(
         "scanner_tag": scanner_tag,
         "system_prefix": system_prefix,
         "cycle": cycle,
+        "phenotyper_name": phenotyper_name,
     }
 
 
@@ -947,7 +949,9 @@ class TestBuildTiffMetadata:
 
     def test_returns_ifd(self):
         region = get_scan_region("2grid", "00")
-        ifd = _build_tiff_metadata("scanner-1", "2grid", "00", 300, region)
+        ifd = _build_tiff_metadata(
+            "scanner-1", _make_plate("/tmp", plate_index="00"), region
+        )
         # 270 = ImageDescription
         desc = json.loads(ifd[270])
         assert desc["scanner_id"] == "scanner-1"
@@ -957,10 +961,35 @@ class TestBuildTiffMetadata:
 
     def test_software_tag(self):
         region = get_scan_region("4grid", "10")
-        ifd = _build_tiff_metadata("s1", "4grid", "10", 600, region)
+        ifd = _build_tiff_metadata(
+            "s1",
+            _make_plate(
+                "/tmp", plate_index="10", grid_mode="4grid", resolution=600
+            ),
+            region,
+        )
         assert ifd[305] == "Bloom Desktop / GraviScan"
 
     def test_resolution_unit(self):
         region = get_scan_region("2grid", "01")
-        ifd = _build_tiff_metadata("s1", "2grid", "01", 300, region)
+        ifd = _build_tiff_metadata(
+            "s1", _make_plate("/tmp", plate_index="01"), region
+        )
         assert ifd[296] == 2  # inches
+
+    def test_embeds_exp_wave_st_phenotyper(self):
+        region = get_scan_region("2grid", "00")
+        plate = _make_plate(
+            "/tmp",
+            plate_index="00",
+            exp_name="myexp",
+            wave_number=3,
+            st_timestamp="20260502T101530",
+        )
+        plate["phenotyper_name"] = "Alice"
+        ifd = _build_tiff_metadata("scanner-1", plate, region)
+        desc = json.loads(ifd[270])
+        assert desc["exp_name"] == "myexp"
+        assert desc["wave_number"] == 3
+        assert desc["st_timestamp"] == "20260502T101530"
+        assert desc["phenotyper_name"] == "Alice"

--- a/python/tests/test_tiff_metadata.py
+++ b/python/tests/test_tiff_metadata.py
@@ -10,12 +10,38 @@ from python.graviscan.scan_worker import ScanWorker, _build_tiff_metadata
 from python.graviscan.scan_regions import get_scan_region
 
 
+def _make_plate_for_metadata(
+    plate_index="00",
+    grid_mode="2grid",
+    resolution=300,
+    exp_name="exp",
+    st_timestamp="20260301T120000",
+    wave_number=1,
+    phenotyper_name="",
+):
+    return {
+        "plate_index": plate_index,
+        "grid_mode": grid_mode,
+        "resolution": resolution,
+        "output_dir": "/tmp",
+        "exp_name": exp_name,
+        "st_timestamp": st_timestamp,
+        "wave_number": wave_number,
+        "scanner_tag": "Sc1",
+        "system_prefix": "",
+        "cycle": 1,
+        "phenotyper_name": phenotyper_name,
+    }
+
+
 class TestBuildTiffMetadata:
     """Test the _build_tiff_metadata helper."""
 
     def test_returns_ifd_with_standard_tags(self):
         region = get_scan_region("2grid", "00")
-        ifd = _build_tiff_metadata("scanner-001", "2grid", "00", 300, region)
+        ifd = _build_tiff_metadata(
+            "scanner-001", _make_plate_for_metadata(plate_index="00"), region
+        )
 
         # ImageDescription (270) — JSON string
         desc = json.loads(ifd[270])
@@ -30,6 +56,12 @@ class TestBuildTiffMetadata:
         assert desc["scan_region_mm"]["height"] == region.height
         assert "capture_timestamp" in desc
         assert "bloom_version" in desc
+
+        # New embedded fields
+        assert desc["exp_name"] == "exp"
+        assert desc["wave_number"] == 1
+        assert desc["st_timestamp"] == "20260301T120000"
+        assert desc["phenotyper_name"] == ""
 
         # Software (305)
         assert ifd[305] == "Bloom Desktop / GraviScan"
@@ -60,6 +92,7 @@ class TestMockScanTiffMetadata:
             "scanner_tag": "Sc1",
             "system_prefix": "",
             "cycle": 1,
+            "phenotyper_name": "",
         }
 
     def test_mock_scan_embeds_metadata(self):

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -483,6 +483,7 @@ const graviscanAPI = {
         wave_number: number;
         scanner_tag: string;
         system_prefix: string;
+        phenotyper_name: string;
         plate_barcode?: string | null;
       }>;
     }>;

--- a/src/main/scan-coordinator.ts
+++ b/src/main/scan-coordinator.ts
@@ -349,6 +349,7 @@ export class ScanCoordinator extends EventEmitter {
           scanner_tag: plate.scanner_tag,
           system_prefix: plate.system_prefix,
           cycle: this.currentCycle,
+          phenotyper_name: plate.phenotyper_name,
         }));
 
         const promise = new Promise<void>((resolve) => {

--- a/src/main/scanner-subprocess.ts
+++ b/src/main/scanner-subprocess.ts
@@ -36,6 +36,7 @@ export interface PlateConfig {
   wave_number: number;
   scanner_tag: string; // e.g. "Sc1"
   system_prefix: string; // e.g. "" or "GS1_"
+  phenotyper_name: string; // embedded in TIFF ImageDescription JSON
 }
 
 /**
@@ -55,6 +56,7 @@ export interface ScanWorkerPlate {
   scanner_tag: string;
   system_prefix: string;
   cycle: number;
+  phenotyper_name: string;
 }
 
 export interface ScanWorkerEvent {

--- a/src/renderer/GraviScan.tsx
+++ b/src/renderer/GraviScan.tsx
@@ -210,6 +210,7 @@ export function GraviScan() {
     selectedPhenotyper,
     setSelectedPhenotyper,
     experiments,
+    phenotypers,
     assignedScannerIds,
     selectedPlates,
   });

--- a/src/renderer/hooks/useScanSession.ts
+++ b/src/renderer/hooks/useScanSession.ts
@@ -105,6 +105,7 @@ export interface UseScanSessionParams {
   selectedPhenotyper: string;
   setSelectedPhenotyper: React.Dispatch<React.SetStateAction<string>>;
   experiments: ListItem[];
+  phenotypers: ListItem[];
 
   // Derived
   assignedScannerIds: string[];
@@ -180,6 +181,7 @@ export function useScanSession({
   selectedPhenotyper,
   setSelectedPhenotyper,
   experiments,
+  phenotypers,
   assignedScannerIds,
   selectedPlates,
 }: UseScanSessionParams): UseScanSessionReturn {
@@ -1248,6 +1250,8 @@ export function useScanSession({
       const systemPrefix = platformInfo?.system_name
         ? `${platformInfo.system_name}_`
         : '';
+      const phenotyperName =
+        phenotypers.find((p) => p.id === selectedPhenotyper)?.name || '';
 
       // Build scan config for each scanner — pass components, never a
       // pre-baked output_path. Coordinator composes per-cycle paths.
@@ -1292,6 +1296,7 @@ export function useScanSession({
             wave_number: waveNumber,
             scanner_tag: scannerTag,
             system_prefix: systemPrefix,
+            phenotyper_name: phenotyperName,
             plate_barcode: plate.plantBarcode || null,
           };
         });

--- a/src/renderer/hooks/useTestScan.ts
+++ b/src/renderer/hooks/useTestScan.ts
@@ -224,6 +224,7 @@ export function useTestScan({
             wave_number: 0,
             scanner_tag: scannerTag,
             system_prefix: '',
+            phenotyper_name: '',
           })),
         };
       });

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -756,6 +756,7 @@ export interface GraviScanAPI {
         wave_number: number;
         scanner_tag: string;
         system_prefix: string;
+        phenotyper_name: string;
         plate_barcode?: string | null;
       }>;
     }>;


### PR DESCRIPTION
## Why

The TIFF `ImageDescription` JSON now includes:

| Field | Source |
|---|---|
| `exp_name` | already on `PlateConfig`, just added to JSON |
| `wave_number` | already on `PlateConfig`, just added to JSON |
| `st_timestamp` | already on `ScanWorkerPlate`, just added to JSON |
| `phenotyper_name` | new — derived in renderer, plumbed through |