### PR TITLE
fix: add .gitattributes to normalize line endings (CRLF/LF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Normalize all text files to LF line endings on checkin, regardless of a
+# contributor's local core.autocrlf setting. This matches what Prettier
+# writes by default and what the Linux CI runners already use, avoiding
+# the CRLF/LF "noise" that made git status report hundreds of unmodified
+# files as changed on Windows checkouts (see issue #253).
+* text=auto eol=lf
+
+# Explicit binary overrides for tracked binary assets. git's text=auto
+# heuristic (NUL-byte detection) would likely classify these correctly on
+# its own, but pinning them avoids any risk of accidental normalization.
+*.png binary
+*.db binary
+*.xlsx binary


### PR DESCRIPTION
## Summary

Add `.gitattributes` to normalize line endings to LF, eliminating the CRLF/LF `git status` noise that Windows checkouts with `core.autocrlf=true` produce.

## Changes

- Add `.gitattributes` at repo root with `* text=auto eol=lf` to pin all text files to LF regardless of a contributor's local `core.autocrlf` setting
- Add explicit `binary` overrides for tracked binary assets that are actually in the repo: `*.png`, `*.db`, `*.xlsx` (test fixtures, sample scan images, SQLite databases, Excel fixtures)
- No other files touched — this does **not** run `git add --renormalize .`; any bulk re-normalization of already-committed file contents is intentionally left as a separate follow-up PR

## OpenSpec Change

No OpenSpec change: small, low-risk infra/config fix (repo-root `.gitattributes` only), no behavior or capability change.

## Testing

Verification performed (see issue #253 for the exact repro this fixes):

- [x] Fresh clone of this branch + `npm install` + `npm run format`: `git status --short` initially shows a batch of files flagged "modified" — this is a pre-existing git-for-windows stat-cache display quirk unrelated to `.gitattributes` (confirmed to occur identically with `.gitattributes` absent). `git add -A && git diff --cached --stat` shows this conclusively: **only `.gitattributes` has a real content change** (13 insertions, the new file itself) — zero other files have any actual diff.
- [x] Confirmed via four independent methods that no tracked file's content changes as a result of this PR: `git diff`, `git diff --numstat`, `git hash-object` (filtered and `--no-filters`) against the index/HEAD blob hash, and raw byte-level CR/LF counts read via .NET (bypassing any shell text-mode translation).
- [x] `git status --short` on a clean checkout of this branch (no formatter run) shows no unexpected modifications.
- [ ] Full test suite / lint / build — not run; this change touches no source, tests, or build config, only adds a root-level git metadata file with no runtime effect.

## Cross-Platform Compatibility

- [x] This is the fix for a Windows-specific issue; verified on Windows (the platform where the noise occurs). Linux/macOS CI runners already produce LF, so this is a no-op for them.

## Related Issues

Fixes #253

## Reviewer Notes

- The `binary` overrides list (`*.png`, `*.db`, `*.xlsx`) was derived by tallying all tracked file extensions (`git ls-files` + extension histogram) rather than assumed — these are the only binary-ish assets actually committed to the repo (test fixture images/dbs/excel files). No fonts, icons, or PyInstaller build outputs are currently tracked, so no overrides were needed for those.
- Deliberately did **not** run `git add --renormalize .` — per the issue, that bulk line-ending cleanup of already-committed files is a separate, clearly-labeled follow-up PR if the team wants it.
