### PR TITLE
fix: skip fetch-scanners E2E tests when live Bloom API creds unavailable

### DIFF
--- a/tests/e2e/machine-config-fetch-scanners.e2e.ts
+++ b/tests/e2e/machine-config-fetch-scanners.e2e.ts
@@ -253,7 +253,9 @@ test.describe('Machine Configuration - Fetch Scanners Button', () => {
     // guaranteed path to reach api.bloom.salk.edu. Skip unless a developer
     // has configured real credentials locally. See GH issue #254.
     test.skip(
-      !process.env.BLOOM_TEST_USERNAME,
+      !process.env.BLOOM_TEST_USERNAME ||
+        !process.env.BLOOM_TEST_PASSWORD ||
+        !process.env.BLOOM_ANON_KEY,
       'Requires live Bloom API credentials - set BLOOM_TEST_USERNAME/BLOOM_TEST_PASSWORD/BLOOM_ANON_KEY locally to run this test'
     );
 
@@ -293,7 +295,9 @@ test.describe('Machine Configuration - Fetch Scanners Button', () => {
   test('should not require full form completion to fetch scanners', async () => {
     // Requires a live round-trip to the real Bloom API - see comment above.
     test.skip(
-      !process.env.BLOOM_TEST_USERNAME,
+      !process.env.BLOOM_TEST_USERNAME ||
+        !process.env.BLOOM_TEST_PASSWORD ||
+        !process.env.BLOOM_ANON_KEY,
       'Requires live Bloom API credentials - set BLOOM_TEST_USERNAME/BLOOM_TEST_PASSWORD/BLOOM_ANON_KEY locally to run this test'
     );
 

--- a/tests/e2e/machine-config-fetch-scanners.e2e.ts
+++ b/tests/e2e/machine-config-fetch-scanners.e2e.ts
@@ -246,19 +246,29 @@ test.describe('Machine Configuration - Fetch Scanners Button', () => {
   });
 
   test('should populate scanner dropdown after successful fetch', async () => {
+    // Requires a live round-trip to the real Bloom API with a real test
+    // account. BLOOM_TEST_USERNAME/PASSWORD/ANON_KEY are documented in
+    // .env.example as being for manual testing - they are not (and should
+    // not be) wired up as CI secrets, since GitHub-hosted runners have no
+    // guaranteed path to reach api.bloom.salk.edu. Skip unless a developer
+    // has configured real credentials locally. See GH issue #254.
+    test.skip(
+      !process.env.BLOOM_TEST_USERNAME,
+      'Requires live Bloom API credentials - set BLOOM_TEST_USERNAME/BLOOM_TEST_PASSWORD/BLOOM_ANON_KEY locally to run this test'
+    );
+
     // Fill in VALID test credentials (from .env)
     await window.fill(
       'input[id*="creds-username"]',
-      process.env.BLOOM_TEST_USERNAME || 'bloom_desktop_test@salk.edu'
+      process.env.BLOOM_TEST_USERNAME || 'your-test-username@salk.edu'
     );
     await window.fill(
       'input[id*="creds-password"]',
-      process.env.BLOOM_TEST_PASSWORD || 'bloom_desktop_test_123'
+      process.env.BLOOM_TEST_PASSWORD || 'your-test-password'
     );
     await window.fill(
       'input[id*="creds-anonkey"]',
-      process.env.BLOOM_ANON_KEY ||
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICAgInJvbGUiOiAiYW5vbiIsCiAgICAiaXNzIjogInN1cGFiYXNlIiwKICAgICJpYXQiOiAxNjg3NTkwMDAwLAogICAgImV4cCI6IDE4NDU0NDI4MDAKfQ.ev7gXAhB8Uv6pgRF9B5oEpmlYI6l15DUIlAQBWSGxPU'
+      process.env.BLOOM_ANON_KEY || 'your-anon-key-here'
     );
 
     // Click the fetch button
@@ -281,19 +291,24 @@ test.describe('Machine Configuration - Fetch Scanners Button', () => {
   });
 
   test('should not require full form completion to fetch scanners', async () => {
+    // Requires a live round-trip to the real Bloom API - see comment above.
+    test.skip(
+      !process.env.BLOOM_TEST_USERNAME,
+      'Requires live Bloom API credentials - set BLOOM_TEST_USERNAME/BLOOM_TEST_PASSWORD/BLOOM_ANON_KEY locally to run this test'
+    );
+
     // Fill ONLY credentials (not camera IP or scans directory)
     await window.fill(
       'input[id*="creds-username"]',
-      process.env.BLOOM_TEST_USERNAME || 'bloom_desktop_test@salk.edu'
+      process.env.BLOOM_TEST_USERNAME || 'your-test-username@salk.edu'
     );
     await window.fill(
       'input[id*="creds-password"]',
-      process.env.BLOOM_TEST_PASSWORD || 'bloom_desktop_test_123'
+      process.env.BLOOM_TEST_PASSWORD || 'your-test-password'
     );
     await window.fill(
       'input[id*="creds-anonkey"]',
-      process.env.BLOOM_ANON_KEY ||
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICAgInJvbGUiOiAiYW5vbiIsCiAgICAiaXNzIjogInN1cGFiYXNlIiwKICAgICJpYXQiOiAxNjg3NTkwMDAwLAogICAgImV4cCI6IDE4NDU0NDI4MDAKfQ.ev7gXAhB8Uv6pgRF9B5oEpmlYI6l15DUIlAQBWSGxPU'
+      process.env.BLOOM_ANON_KEY || 'your-anon-key-here'
     );
 
     // Click fetch button - should work without filling other fields


### PR DESCRIPTION
## Summary

Fixes the two E2E tests in `tests/e2e/machine-config-fetch-scanners.e2e.ts` that consistently time out on all 3 CI platforms (#254) by skipping them in CI, where they can never actually succeed.

## Root Cause

These two tests (`should populate scanner dropdown after successful fetch`, `should not require full form completion to fetch scanners`) fill in credentials and click "Fetch Scanners," which triggers a **real network call** (`src/main/config-store.ts` → `supabase.auth.signInWithPassword`) to the live production endpoint `https://api.bloom.salk.edu/proxy`. This isn't mocked — it's a genuine integration test against a real backend.

I confirmed via the actual Playwright trace artifacts from PR #252's CI run (downloaded from GitHub Actions, ubuntu-latest + macos-latest) that the UI shows:

```
⚠️ Authentication failed: fetch failed
```

`fetch failed` is Node's network-layer error (DNS/connection failure), not Supabase's "Invalid login credentials" — so the request never completes; it's not resolving late, it fails outright. Bumping the 10s timeout would not have fixed this.

Supporting evidence this is a pre-existing design gap, not a regression:
- No GitHub Actions secrets are configured for this repo (`gh secret list` is empty), so CI has only ever used the hardcoded fallback credentials in the test file.
- `.env.example` itself documents `BLOOM_TEST_USERNAME`/`PASSWORD`/`BLOOM_ANON_KEY` as being "Used for **manual testing** of Bloom API integration" — this was written for local/manual verification, not unattended public CI runners.
- The issue notes this same job also failed back on PR #191 (April), consistent with it being broken since these tests were added to the CI matrix rather than a recent regression.

The two *other* credential-related tests in the file (loading state, invalid credentials) pass only because their assertions accept `Authentication failed|Failed to fetch` as valid outcomes — they don't require a real successful round-trip.

## Changes

- Add `test.skip(...)` guarding on all three required env vars (`BLOOM_TEST_USERNAME`/`PASSWORD`/`BLOOM_ANON_KEY`), so the two tests are skipped automatically in CI (no secrets configured) but still run for real local/manual verification when a developer sets up `.env.e2e` with real credentials — matching the documented intent of those env vars.
- Replace the hardcoded fallback credentials (a real test account, `bloom_desktop_test@salk.edu`) with generic placeholders consistent with `.env.example`'s style. That account has separately been deleted from the Bloom auth backend.

## OpenSpec Change

No OpenSpec change: this is a test-only fix that restores intended CI behavior (per `openspec/AGENTS.md`, bug fixes and "tests for existing behavior" skip the proposal process). The `fetch-scanners` production capability and its spec (`openspec/specs/ui-management-pages/spec.md`) are unchanged — only how these two tests execute in CI vs. locally.

## Testing

### Linting

- [x] `npx eslint tests/e2e/machine-config-fetch-scanners.e2e.ts` passes
- [x] `npx tsc --noEmit` reports no errors for this file

### E2E Tests

- [!] Could not run `npm run test:e2e -- machine-config-fetch-scanners` in this dev sandbox — local Electron binary is broken/uninstalled (`Error: Electron failed to install correctly`), a pre-existing environment issue unrelated to this change. Webpack dev build itself compiled successfully.
- [ ] Please confirm locally or via CI that the two tests now report as **skipped** (not failed) and the rest of the suite is unaffected.

### Code Review

This PR went through a 5-agent adversarial review (code quality, testing/TDD, scientific rigor, security/cross-platform, behavioral correctness). No blocking issues found. One real issue surfaced independently by 3 of the 5 agents was fixed in a follow-up commit: the `test.skip()` condition originally only checked `BLOOM_TEST_USERNAME`, not all three required vars, which could produce a confusing local failure instead of a clean skip if only one var was set.

## Related Issues

Fixes #254

## Reviewer Notes

The `test.skip` guard only applies to the 2 tests that need a real network round-trip — the other 5 tests in this file (button visibility/disabled/enabled state, loading state, invalid-credential error) intentionally use fake credentials and don't need this guard, so they still run unconditionally in CI.