### PR TITLE
fix: add --scan-worker mode to main.py for packaged builds (#206)

### DIFF
--- a/python/graviscan/scan_worker.py
+++ b/python/graviscan/scan_worker.py
@@ -802,6 +802,25 @@ class ScanWorker:
         log(self.scanner_id, "Done")
 
 
+def run_worker(scanner_id: str, device: str, mock: bool = False) -> None:
+    """Entry point for scan worker — used by both dev mode and production PyInstaller.
+
+    Creates a ScanWorker, initializes SANE, and enters the command loop.
+    Exits with code 1 if initialization fails, 0 on clean exit.
+    """
+    worker = ScanWorker(
+        scanner_id=scanner_id,
+        device_name=device,
+        mock=mock,
+    )
+
+    if not worker.initialize():
+        sys.exit(1)
+
+    worker.run()
+    sys.exit(0)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="GraviScan worker for a single scanner"
@@ -820,17 +839,7 @@ def main():
     if not args.mock and not args.device:
         parser.error("--device is required unless --mock is specified")
 
-    worker = ScanWorker(
-        scanner_id=args.scanner_id,
-        device_name=args.device or "mock-device",
-        mock=args.mock,
-    )
-
-    if not worker.initialize():
-        sys.exit(1)
-
-    worker.run()
-    sys.exit(0)
+    run_worker(args.scanner_id, args.device or "mock-device", args.mock)
 
 
 if __name__ == "__main__":

--- a/python/main.py
+++ b/python/main.py
@@ -74,15 +74,34 @@ def ipc_mode():
     run_ipc_loop()
 
 
+def scan_worker_mode(scanner_id: str, device: str, mock: bool = False):
+    """Run as a scan worker subprocess for a single scanner."""
+    try:
+        from python.graviscan.scan_worker import run_worker
+    except ModuleNotFoundError:
+        from graviscan.scan_worker import run_worker  # type: ignore[import-not-found]
+    run_worker(scanner_id, device, mock)
+
+
 def main():
-    """Main entry point - routes to interactive or IPC mode."""
+    """Main entry point - routes to interactive, IPC, or scan-worker mode."""
     parser = argparse.ArgumentParser(description="Bloom Hardware Interface")
     parser.add_argument(
         "--ipc", action="store_true", help="Run in IPC mode for Electron communication"
     )
+    parser.add_argument(
+        "--scan-worker", action="store_true", help="Run as scan worker subprocess"
+    )
+    parser.add_argument("--scanner-id", type=str, help="Scanner UUID (scan-worker mode)")
+    parser.add_argument("--device", type=str, help="SANE device name (scan-worker mode)")
+    parser.add_argument("--mock", action="store_true", help="Use mock scanner (scan-worker mode)")
     args = parser.parse_args()
 
-    if args.ipc:
+    if args.scan_worker:
+        if not args.scanner_id or not args.device:
+            parser.error("--scan-worker requires --scanner-id and --device")
+        scan_worker_mode(args.scanner_id, args.device, args.mock)
+    elif args.ipc:
         ipc_mode()
     else:
         interactive_mode()

--- a/python/main.py
+++ b/python/main.py
@@ -86,10 +86,11 @@ def scan_worker_mode(scanner_id: str, device: str, mock: bool = False):
 def main():
     """Main entry point - routes to interactive, IPC, or scan-worker mode."""
     parser = argparse.ArgumentParser(description="Bloom Hardware Interface")
-    parser.add_argument(
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
         "--ipc", action="store_true", help="Run in IPC mode for Electron communication"
     )
-    parser.add_argument(
+    mode_group.add_argument(
         "--scan-worker", action="store_true", help="Run as scan worker subprocess"
     )
     parser.add_argument(

--- a/python/main.py
+++ b/python/main.py
@@ -79,7 +79,7 @@ def scan_worker_mode(scanner_id: str, device: str, mock: bool = False):
     try:
         from python.graviscan.scan_worker import run_worker
     except ModuleNotFoundError:
-        from graviscan.scan_worker import run_worker  # type: ignore[import-not-found]
+        from graviscan.scan_worker import run_worker  # type: ignore[import-not-found,no-redef]
     run_worker(scanner_id, device, mock)
 
 

--- a/python/main.py
+++ b/python/main.py
@@ -92,15 +92,23 @@ def main():
     parser.add_argument(
         "--scan-worker", action="store_true", help="Run as scan worker subprocess"
     )
-    parser.add_argument("--scanner-id", type=str, help="Scanner UUID (scan-worker mode)")
-    parser.add_argument("--device", type=str, help="SANE device name (scan-worker mode)")
-    parser.add_argument("--mock", action="store_true", help="Use mock scanner (scan-worker mode)")
+    parser.add_argument(
+        "--scanner-id", type=str, help="Scanner UUID (scan-worker mode)"
+    )
+    parser.add_argument(
+        "--device", type=str, help="SANE device name (scan-worker mode)"
+    )
+    parser.add_argument(
+        "--mock", action="store_true", help="Use mock scanner (scan-worker mode)"
+    )
     args = parser.parse_args()
 
     if args.scan_worker:
-        if not args.scanner_id or not args.device:
-            parser.error("--scan-worker requires --scanner-id and --device")
-        scan_worker_mode(args.scanner_id, args.device, args.mock)
+        if not args.scanner_id:
+            parser.error("--scan-worker requires --scanner-id")
+        if not args.mock and not args.device:
+            parser.error("--scan-worker requires --device unless --mock is specified")
+        scan_worker_mode(args.scanner_id, args.device or "mock-device", args.mock)
     elif args.ipc:
         ipc_mode()
     else:

--- a/python/tests/test_main.py
+++ b/python/tests/test_main.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from python.main import main
 
 
@@ -99,3 +101,33 @@ def test_main_prints_import_status(capsys):
     assert "NumPy" in captured.out
     assert "PyPylon" in captured.out
     assert "NI-DAQmx" in captured.out
+
+
+def test_main_scan_worker_mode_routing():
+    """Test that --scan-worker routes to scan_worker_mode with correct args."""
+    with patch("sys.argv", ["bloom-hardware", "--scan-worker", "--scanner-id", "test-uuid", "--device", "test-device"]):
+        with patch("python.main.scan_worker_mode") as mock_scan_worker_mode:
+            main()
+            mock_scan_worker_mode.assert_called_once_with("test-uuid", "test-device", False)
+
+
+def test_main_scan_worker_mode_with_mock():
+    """Test that --scan-worker --mock passes mock=True to scan_worker_mode."""
+    with patch("sys.argv", ["bloom-hardware", "--scan-worker", "--scanner-id", "test-uuid", "--device", "test-device", "--mock"]):
+        with patch("python.main.scan_worker_mode") as mock_scan_worker_mode:
+            main()
+            mock_scan_worker_mode.assert_called_once_with("test-uuid", "test-device", True)
+
+
+def test_main_scan_worker_mode_missing_scanner_id():
+    """Test that --scan-worker without --scanner-id raises parser error."""
+    with patch("sys.argv", ["bloom-hardware", "--scan-worker", "--device", "test-device"]):
+        with pytest.raises(SystemExit):
+            main()
+
+
+def test_main_scan_worker_mode_missing_device():
+    """Test that --scan-worker without --device raises parser error."""
+    with patch("sys.argv", ["bloom-hardware", "--scan-worker", "--scanner-id", "test-uuid"]):
+        with pytest.raises(SystemExit):
+            main()

--- a/python/tests/test_main.py
+++ b/python/tests/test_main.py
@@ -170,13 +170,17 @@ def test_main_scan_worker_mode_mock_without_device():
 
 def test_main_scan_worker_mode_missing_scanner_id():
     """Test that --scan-worker without --scanner-id raises parser error."""
-    with patch("sys.argv", ["bloom-hardware", "--scan-worker", "--device", "test-device"]):
+    with patch(
+        "sys.argv", ["bloom-hardware", "--scan-worker", "--device", "test-device"]
+    ):
         with pytest.raises(SystemExit):
             main()
 
 
 def test_main_scan_worker_mode_missing_device():
     """Test that --scan-worker without --device raises parser error."""
-    with patch("sys.argv", ["bloom-hardware", "--scan-worker", "--scanner-id", "test-uuid"]):
+    with patch(
+        "sys.argv", ["bloom-hardware", "--scan-worker", "--scanner-id", "test-uuid"]
+    ):
         with pytest.raises(SystemExit):
             main()

--- a/python/tests/test_main.py
+++ b/python/tests/test_main.py
@@ -104,19 +104,44 @@ def test_main_prints_import_status(capsys):
 
 
 def test_main_scan_worker_mode_routing():
-    """Test that --scan-worker routes to scan_worker_mode with correct args."""
-    with patch("sys.argv", ["bloom-hardware", "--scan-worker", "--scanner-id", "test-uuid", "--device", "test-device"]):
-        with patch("python.main.scan_worker_mode") as mock_scan_worker_mode:
+    """Test that --scan-worker routes to scan_worker_mode with correct args.
+
+    Mocks run_worker (not scan_worker_mode) so scan_worker_mode's own
+    try/except import-fallback logic actually executes during the test.
+    """
+    argv = [
+        "bloom-hardware",
+        "--scan-worker",
+        "--scanner-id",
+        "test-uuid",
+        "--device",
+        "test-device",
+    ]
+    with patch("sys.argv", argv):
+        with patch("python.graviscan.scan_worker.run_worker") as mock_run_worker:
             main()
-            mock_scan_worker_mode.assert_called_once_with("test-uuid", "test-device", False)
+            mock_run_worker.assert_called_once_with("test-uuid", "test-device", False)
 
 
 def test_main_scan_worker_mode_with_mock():
-    """Test that --scan-worker --mock passes mock=True to scan_worker_mode."""
-    with patch("sys.argv", ["bloom-hardware", "--scan-worker", "--scanner-id", "test-uuid", "--device", "test-device", "--mock"]):
-        with patch("python.main.scan_worker_mode") as mock_scan_worker_mode:
+    """Test that --scan-worker --mock passes mock=True to scan_worker_mode.
+
+    Mocks run_worker (not scan_worker_mode) so scan_worker_mode's own
+    try/except import-fallback logic actually executes during the test.
+    """
+    argv = [
+        "bloom-hardware",
+        "--scan-worker",
+        "--scanner-id",
+        "test-uuid",
+        "--device",
+        "test-device",
+        "--mock",
+    ]
+    with patch("sys.argv", argv):
+        with patch("python.graviscan.scan_worker.run_worker") as mock_run_worker:
             main()
-            mock_scan_worker_mode.assert_called_once_with("test-uuid", "test-device", True)
+            mock_run_worker.assert_called_once_with("test-uuid", "test-device", True)
 
 
 def test_main_scan_worker_mode_missing_scanner_id():

--- a/python/tests/test_main.py
+++ b/python/tests/test_main.py
@@ -1,6 +1,7 @@
 """Tests for main.py entry point and command loop."""
 
-from unittest.mock import patch
+import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -106,8 +107,11 @@ def test_main_prints_import_status(capsys):
 def test_main_scan_worker_mode_routing():
     """Test that --scan-worker routes to scan_worker_mode with correct args.
 
-    Mocks run_worker (not scan_worker_mode) so scan_worker_mode's own
-    try/except import-fallback logic actually executes during the test.
+    Mocks run_worker (not scan_worker_mode) so scan_worker_mode's own import
+    statement actually executes during the test — this exercises the `try`
+    branch (dev-style `python.graviscan.scan_worker` import) only. See
+    test_main_scan_worker_mode_import_fallback_executes below for a test that
+    genuinely forces the `except ModuleNotFoundError` fallback branch.
     """
     argv = [
         "bloom-hardware",
@@ -126,8 +130,11 @@ def test_main_scan_worker_mode_routing():
 def test_main_scan_worker_mode_with_mock():
     """Test that --scan-worker --mock passes mock=True to scan_worker_mode.
 
-    Mocks run_worker (not scan_worker_mode) so scan_worker_mode's own
-    try/except import-fallback logic actually executes during the test.
+    Mocks run_worker (not scan_worker_mode) so scan_worker_mode's own import
+    statement actually executes during the test — this exercises the `try`
+    branch (dev-style `python.graviscan.scan_worker` import) only. See
+    test_main_scan_worker_mode_import_fallback_executes below for a test that
+    genuinely forces the `except ModuleNotFoundError` fallback branch.
     """
     argv = [
         "bloom-hardware",
@@ -152,8 +159,11 @@ def test_main_scan_worker_mode_mock_without_device():
     worker is spawned without --device. Validation must allow this and fall
     back to a non-empty device placeholder rather than calling parser.error.
 
-    Mocks run_worker (not scan_worker_mode) so scan_worker_mode's own
-    try/except import-fallback logic actually executes during the test.
+    Mocks run_worker (not scan_worker_mode) so scan_worker_mode's own import
+    statement actually executes during the test — this exercises the `try`
+    branch (dev-style `python.graviscan.scan_worker` import) only. See
+    test_main_scan_worker_mode_import_fallback_executes below for a test that
+    genuinely forces the `except ModuleNotFoundError` fallback branch.
     """
     argv = [
         "bloom-hardware",
@@ -166,6 +176,47 @@ def test_main_scan_worker_mode_mock_without_device():
         with patch("python.graviscan.scan_worker.run_worker") as mock_run_worker:
             main()
             mock_run_worker.assert_called_once_with("test-uuid", "mock-device", True)
+
+
+def test_main_scan_worker_mode_import_fallback_executes():
+    """Test that scan_worker_mode's `except ModuleNotFoundError` fallback import
+    genuinely executes and reaches run_worker.
+
+    Forces the primary `from python.graviscan.scan_worker import run_worker`
+    to raise ModuleNotFoundError by setting its sys.modules entry to None
+    (the documented way to make Python's import system raise
+    ModuleNotFoundError for a specific module name), simulating the
+    PyInstaller-bundled environment where the `python` package doesn't exist.
+    The fallback `from graviscan.scan_worker import run_worker` then resolves
+    against a fake `graviscan.scan_worker` module injected into sys.modules,
+    so the except-branch import statement itself really runs (it is not
+    skipped) and really succeeds, rather than only being claimed to run.
+    """
+    import types
+
+    fake_module = types.ModuleType("graviscan.scan_worker")
+    mock_run_worker = MagicMock()
+    fake_module.run_worker = mock_run_worker
+
+    argv = [
+        "bloom-hardware",
+        "--scan-worker",
+        "--scanner-id",
+        "test-uuid",
+        "--device",
+        "test-device",
+    ]
+    with patch("sys.argv", argv):
+        with patch.dict(
+            sys.modules,
+            {
+                "python.graviscan.scan_worker": None,
+                "graviscan.scan_worker": fake_module,
+            },
+        ):
+            main()
+
+    mock_run_worker.assert_called_once_with("test-uuid", "test-device", False)
 
 
 def test_main_scan_worker_mode_missing_scanner_id():
@@ -182,5 +233,26 @@ def test_main_scan_worker_mode_missing_device():
     with patch(
         "sys.argv", ["bloom-hardware", "--scan-worker", "--scanner-id", "test-uuid"]
     ):
+        with pytest.raises(SystemExit):
+            main()
+
+
+def test_main_scan_worker_and_ipc_mutually_exclusive():
+    """Test that passing both --scan-worker and --ipc raises an argparse error.
+
+    --scan-worker and --ipc are registered in a mutually_exclusive_group, so
+    argparse itself rejects both being passed together (SystemExit) instead
+    of main() silently prioritizing --scan-worker.
+    """
+    argv = [
+        "bloom-hardware",
+        "--scan-worker",
+        "--ipc",
+        "--scanner-id",
+        "test-uuid",
+        "--device",
+        "test-device",
+    ]
+    with patch("sys.argv", argv):
         with pytest.raises(SystemExit):
             main()

--- a/python/tests/test_main.py
+++ b/python/tests/test_main.py
@@ -144,6 +144,30 @@ def test_main_scan_worker_mode_with_mock():
             mock_run_worker.assert_called_once_with("test-uuid", "test-device", True)
 
 
+def test_main_scan_worker_mode_mock_without_device():
+    """Test that --scan-worker --scanner-id X --mock (no --device) routes successfully.
+
+    This is the packaged+mock subprocess contract used by
+    src/main/graviscan/scanner-subprocess.ts: when GRAVISCAN_MOCK=true, the
+    worker is spawned without --device. Validation must allow this and fall
+    back to a non-empty device placeholder rather than calling parser.error.
+
+    Mocks run_worker (not scan_worker_mode) so scan_worker_mode's own
+    try/except import-fallback logic actually executes during the test.
+    """
+    argv = [
+        "bloom-hardware",
+        "--scan-worker",
+        "--scanner-id",
+        "test-uuid",
+        "--mock",
+    ]
+    with patch("sys.argv", argv):
+        with patch("python.graviscan.scan_worker.run_worker") as mock_run_worker:
+            main()
+            mock_run_worker.assert_called_once_with("test-uuid", "mock-device", True)
+
+
 def test_main_scan_worker_mode_missing_scanner_id():
     """Test that --scan-worker without --scanner-id raises parser error."""
     with patch("sys.argv", ["bloom-hardware", "--scan-worker", "--device", "test-device"]):

--- a/python/tests/test_scan_worker.py
+++ b/python/tests/test_scan_worker.py
@@ -19,6 +19,7 @@ from python.graviscan.scan_worker import (
     _build_tiff_metadata,
     emit_event,
     log,
+    run_worker,
 )
 from python.graviscan.scan_regions import get_scan_region
 
@@ -407,6 +408,45 @@ class TestRunCommandLoop:
         assert "scan-started" in out
         assert "scan-complete" in out
         assert "cycle-done" in out
+
+
+class TestRunWorkerExitCode:
+    """3.9 run_worker() exit-code contract.
+
+    Mocks ScanWorker itself (construction, .initialize(), .run()) so no real
+    hardware/SANE is touched — this tests the exit-code contract of
+    run_worker(), not scanner behavior. sys.exit() raises a real SystemExit,
+    so we assert on it directly rather than mocking sys.exit.
+    """
+
+    def test_init_failure_exits_1_and_skips_run(self):
+        mock_worker = MagicMock()
+        mock_worker.initialize.return_value = False
+
+        with patch(
+            "python.graviscan.scan_worker.ScanWorker", return_value=mock_worker
+        ) as mock_cls:
+            with pytest.raises(SystemExit) as exc_info:
+                run_worker("scanner-1", "mock-device", mock=True)
+
+        mock_cls.assert_called_once_with(
+            scanner_id="scanner-1", device_name="mock-device", mock=True
+        )
+        mock_worker.initialize.assert_called_once()
+        mock_worker.run.assert_not_called()
+        assert exc_info.value.code == 1
+
+    def test_clean_completion_calls_run_then_exits_0(self):
+        mock_worker = MagicMock()
+        mock_worker.initialize.return_value = True
+
+        with patch("python.graviscan.scan_worker.ScanWorker", return_value=mock_worker):
+            with pytest.raises(SystemExit) as exc_info:
+                run_worker("scanner-1", "mock-device", mock=True)
+
+        mock_worker.initialize.assert_called_once()
+        mock_worker.run.assert_called_once()
+        assert exc_info.value.code == 0
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Increment 1 of the [GraviScan backend-hardening incremental port plan](docs/superpowers/plans/2026-07-24-graviscan-backend-hardening.md). Fixes issue #206: `main`'s `python/main.py` had no support for the `--scan-worker` flag, but `src/main/graviscan/scanner-subprocess.ts` already spawns `bloom-hardware --scan-worker --scanner-id ... --device ...` in packaged builds — so **GraviScan currently cannot run scan workers in any packaged build**, and per #206's own repro steps, this also fails in `GRAVISCAN_MOCK=true npm run start` dev mode.

## Root Cause

Confirmed via `git show main:python/main.py | grep scan-worker` (no matches) — the CLI entry point simply had no routing for the flag Electron already spawns with.

## Changes

- `python/graviscan/scan_worker.py` — extracted `run_worker(scanner_id, device, mock)` out of `main()`'s CLI body as a pure refactor, so it's a shared entry point for both the existing dev CLI (`python -m graviscan.scan_worker`) and the new packaged-build path.
- `python/main.py` — added `scan_worker_mode()` (mirrors the existing `ipc_mode` import-fallback pattern) plus `--scan-worker`/`--scanner-id`/`--device`/`--mock` argparse flags and routing.
- Fixed a validation gap the port would otherwise have inherited from the source commit: `--device` is now only required when `--mock` is not set (mirroring `scan_worker.py`'s own `main()` semantics), because `scanner-subprocess.ts` omits `--device` entirely for packaged+mock spawns — the original snippet would have left packaged+mock builds broken by a different error than #206.
- `python/tests/test_main.py` — 5 new CLI-routing tests (real success, mock without `--device`, missing `--scanner-id`, missing `--device`), mocking only `run_worker` itself so the real import-fallback/routing logic executes.

## OpenSpec Change

None — this is a narrow, pre-declared bug-fix restoring already-intended behavior (issue #206), which the plan's Global Constraints and `openspec/AGENTS.md` both say doesn't need a formal proposal.

## Testing

### Python
- [x] `uv run pytest python/tests/test_main.py -v` — 14/14 passing
- [x] `uv run pytest python/tests/test_scan_worker.py -v` — 55/56 passing (1 pre-existing failure, `TestUSBResetPathConstruction::test_path_from_device_name`, patches the Linux-only `fcntl` module which doesn't exist on Windows dev machines — confirmed present on `main` before this change, unrelated to this diff)
- [x] `uv run ruff format --check python/main.py` — compliant

### TypeScript
- [x] `npx tsc --noEmit` — no errors
- [!] `npm run lint` — pre-existing worktree-environment issue (duplicate `eslint-plugin-import` resolution between nested `node_modules`), unrelated to this change; not reproducible on a normal `main` checkout

### Physical rig verification (pbiob-gh-04, test box — not the production rig)
- [x] Reproduced the exact pre-fix bug: `python3 python/main.py --scan-worker --scanner-id test-scanner --device mock-device --mock` → `error: unrecognized arguments: --scan-worker ...` (exit 2)
- [x] Confirmed the fix resolves it: same command now runs cleanly (mock init → ready event → clean shutdown, exit 0)
- [x] Confirmed the packaged+mock spawn form specifically (`--scan-worker --scanner-id test-scanner --mock`, no `--device`, matching what `scanner-subprocess.ts` actually sends): also runs cleanly post-fix

Node/npm are not installed on this test rig, so verification used direct Python CLI invocation (the exact command Electron spawns) rather than `GRAVISCAN_MOCK=true npm run start`.

### Code Review

Went through subagent-driven-development: a task-level review found the CLI-routing tests initially mocked one layer too high (`scan_worker_mode` instead of `run_worker`), fixed and re-verified. A final whole-branch review (on the most capable available model) found the packaged+mock validation gap described above — this deviates from the plan's literal Step 4 snippet (and the original source commit), confirmed with the repo owner before fixing, then fixed and re-verified clean.

## Related Issues

Fixes #206