### PR TITLE
fix: compose scan file paths with _et_ timestamp at save time (#154)

### DIFF
--- a/openspec/changes/fix-scan-file-path-with-et-timestamp/proposal.md
+++ b/openspec/changes/fix-scan-file-path-with-et-timestamp/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+After removing row-merge scanning, each plate scans individually and the worker knows both `_st_` (start) and `_et_` (end) timestamps at save time. However, the TS coordinator still renames files post-save to insert `_et_TIMESTAMP`, creating a window where the disk path doesn't match the path emitted by `scan-complete` (issue #154). Since each plate scan is now independent, the worker can write the file with the final name directly — no rename needed.
+
+## What Changes
+
+- `scan_worker.py` `_sane_scan` and `_mock_scan` insert `_et_TIMESTAMP` into the output path before saving
+- `scan_worker.py` `_scan_plate` emits `scan-complete` with the final path (with `_et_`)
+- `scan-coordinator.ts` drops the file rename logic in `scanOnce()` — uses the path from `scan-complete` directly
+- `grid-complete` event still fires but `renamedFiles` becomes a list of final paths (no oldPath/newPath distinction)
+
+### Implementation constraints
+
+- **No new env vars or config.** Hardcode the timestamp format inline.
+- **No backwards compat.** Drop the rename path entirely. `renamedFiles` becomes `completedFiles`.
+- **Single try/catch in coordinator.** No nested error handling around path construction.
+- **Python writes to final path only.** No temp file + rename in Python.
+- **Filename pattern unchanged from disk perspective:** `..._st_T1_et_T2_cy1_S1_00.tif`.
+- **Log prefix:** `[ScanWorker]` for Python, `[ScanCoordinator]` for TS.
+
+## Impact
+
+- Affected specs: `scanning`
+- Affected code:
+  - `python/graviscan/scan_worker.py` — modify `_sane_scan` and `_mock_scan` to insert `_et_` and save to final path; `_scan_plate` emits final path (~15 lines)
+  - `src/main/scan-coordinator.ts` — remove rename loop, simplify grid-complete payload (~30 lines removed)
+  - `src/renderer/hooks/useScanSession.ts` — `grid-complete` handler no longer updates paths (paths are already correct from scan-complete)

--- a/openspec/changes/fix-scan-file-path-with-et-timestamp/specs/scanning/spec.md
+++ b/openspec/changes/fix-scan-file-path-with-et-timestamp/specs/scanning/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Scan File Saved with Final Filename
+
+The scan worker SHALL save scan output files with both `_st_TIMESTAMP` (start) and `_et_TIMESTAMP` (end) in the filename at write time. No post-save rename SHALL occur.
+
+#### Scenario: Plate scan completes with final filename on disk
+
+- **GIVEN** the worker receives `output_path = "..._st_20260413T120530_cy1_S1_00.tif"`
+- **WHEN** the plate scan completes
+- **THEN** the file SHALL be saved as `..._st_20260413T120530_et_20260413T120545_cy1_S1_00.tif`
+- **AND** no rename operation SHALL occur after save
+- **AND** the `scan-complete` event SHALL contain the final path (with `_et_`)
+
+#### Scenario: Database path matches disk path
+
+- **GIVEN** a scan completes successfully
+- **WHEN** the renderer creates a DB record from the `scan-complete` event
+- **THEN** the path stored in the DB SHALL match the file on disk exactly
+
+## REMOVED Requirements
+
+### Requirement: Coordinator File Rename
+
+**Reason**: Replaced by Python worker writing the file with the final name directly. After removing row-merge scanning, the worker knows both timestamps at save time so the rename step is no longer needed.
+
+**Migration**: `scan-coordinator.ts` `scanOnce()` no longer renames files. The `grid-complete` event payload changes from `renamedFiles: { oldPath, newPath }[]` to a list of final paths only.

--- a/openspec/changes/fix-scan-file-path-with-et-timestamp/tasks.md
+++ b/openspec/changes/fix-scan-file-path-with-et-timestamp/tasks.md
@@ -1,0 +1,22 @@
+## 1. Python worker
+
+- [ ] 1.1 Add helper `_with_et_timestamp(path: str) -> str` that inserts `_et_YYYYMMDDTHHMMSS` after `_st_YYYYMMDDTHHMMSS` in the filename
+- [ ] 1.2 Modify `_sane_scan` to compute final path before save, save to final path, return final path
+- [ ] 1.3 Modify `_mock_scan` to do the same
+- [ ] 1.4 Modify `_scan_plate` to use returned path in `scan-complete` event
+
+## 2. TS coordinator
+
+- [ ] 2.1 Remove file rename loop in `scanOnce()`
+- [ ] 2.2 Simplify `grid-complete` event payload — drop `renamedFiles` oldPath/newPath, use list of final paths
+- [ ] 2.3 Update event interface in `ScannerSubprocess` if needed
+
+## 3. Renderer
+
+- [ ] 3.1 Update `useScanSession.ts` `grid-complete` handler to not update DB paths (paths already correct from scan-complete)
+
+## 4. Tests
+
+- [ ] 4.1 Python unit test: `_with_et_timestamp` correctly inserts `_et_` after `_st_`
+- [ ] 4.2 Python unit test: `_mock_scan` saves to path with `_et_`
+- [ ] 4.3 Python unit test: `scan-complete` event has path with `_et_`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,10 @@ dev = []
 [tool.pytest.ini_options]
 testpaths = ["python"]
 python_files = ["test_*.py"]
-addopts = "--cov=python --cov-report=html --cov-report=term --cov-fail-under=80"
+markers = [
+    "hardware: requires the physical GraviScan rig with a real scanner attached (SANE hardware, not mock) — excluded from default runs and CI; run explicitly with `-m hardware`",
+]
+addopts = "--cov=python --cov-report=html --cov-report=term --cov-fail-under=80 -m \"not hardware\""
 
 [tool.coverage.run]
 omit = [

--- a/python/graviscan/scan_worker.py
+++ b/python/graviscan/scan_worker.py
@@ -27,6 +27,7 @@ Protocol:
 import argparse
 import json
 import os
+import re
 import sys
 import time
 import uuid
@@ -84,6 +85,19 @@ def _build_tiff_metadata(
 def emit_event(event: dict) -> None:
     """Emit an EVENT: message to stdout."""
     print(f"EVENT:{json.dumps(event)}", flush=True)
+
+
+def compose_output_path(output_path: str, et: str) -> str:
+    """Insert _et_YYYYMMDDTHHMMSS into output_path's filename, right after
+    the existing _st_YYYYMMDDTHHMMSS segment.
+
+    The coordinator sends a path like "..._st_20260413T120530_cy1_S1_00.tif".
+    Returns "..._st_20260413T120530_et_20260413T120545_cy1_S1_00.tif".
+    If no _st_ pattern is found, returns output_path unchanged.
+    """
+    return re.sub(
+        r"(_st_\d{8}T\d{6})", lambda m: f"{m.group(1)}_et_{et}", output_path, count=1
+    )
 
 
 def log(scanner_id: str, msg: str) -> None:
@@ -284,9 +298,13 @@ class ScanWorker:
 
         try:
             if self.mock:
-                self._mock_scan(grid_mode, plate_index, resolution, output_path)
+                final_path = self._mock_scan(
+                    grid_mode, plate_index, resolution, output_path
+                )
             else:
-                self._sane_scan(grid_mode, plate_index, resolution, output_path)
+                final_path = self._sane_scan(
+                    grid_mode, plate_index, resolution, output_path
+                )
 
             duration_ms = int((time.time() - start_time) * 1000)
 
@@ -296,7 +314,7 @@ class ScanWorker:
                     "scanner_id": self.scanner_id,
                     "plate_index": plate_index,
                     "job_id": job_id,
-                    "path": output_path,
+                    "path": final_path,
                     "duration_ms": duration_ms,
                 }
             )
@@ -322,8 +340,10 @@ class ScanWorker:
         plate_index: str,
         resolution: int,
         output_path: str,
-    ) -> None:
+    ) -> str:
         """Perform a scan using python-sane directly.
+
+        Returns the final path the file was saved to (with _et_ timestamp inserted).
 
         Uses x_resolution/y_resolution (epkowa per-axis options) instead of the
         generic resolution option which only supports [400,800,1600,3200].
@@ -342,9 +362,6 @@ class ScanWorker:
             f"Scanning plate {plate_index} ({grid_mode}) at {resolution}dpi "
             f"region=({region.left},{region.top})-({region.left+region.width},{region.top+region.height})",
         )
-
-        # Ensure output directory exists
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
         last_error = None
 
@@ -383,11 +400,14 @@ class ScanWorker:
                     raise RuntimeError("snap() returned None")
 
                 # Save as TIFF with LZW compression and metadata
+                et = datetime.now().strftime("%Y%m%dT%H%M%S")
+                final_path = compose_output_path(output_path, et)
+                os.makedirs(os.path.dirname(final_path), exist_ok=True)
                 tiff_meta = _build_tiff_metadata(
                     self.scanner_id, grid_mode, plate_index, resolution, region
                 )
                 image.save(
-                    output_path, "TIFF", compression="tiff_lzw", tiffinfo=tiff_meta
+                    final_path, "TIFF", compression="tiff_lzw", tiffinfo=tiff_meta
                 )
 
                 # Cancel to return device to IDLE state for next scan
@@ -396,8 +416,8 @@ class ScanWorker:
                 except Exception:
                     pass
 
-                log(self.scanner_id, f"Scan saved: {output_path}")
-                return
+                log(self.scanner_id, f"Scan saved: {final_path}")
+                return final_path
 
             except Exception as e:
                 last_error = str(e)
@@ -534,8 +554,11 @@ class ScanWorker:
 
     def _mock_scan(
         self, grid_mode: str, plate_index: str, resolution: int, output_path: str
-    ) -> None:
-        """Generate a mock scan image (checkerboard pattern)."""
+    ) -> str:
+        """Generate a mock scan image (checkerboard pattern).
+
+        Returns the final path the file was saved to (with _et_ timestamp inserted).
+        """
         import numpy as np
         from PIL import Image
 
@@ -560,13 +583,16 @@ class ScanWorker:
 
         image = Image.fromarray(img_array, mode="RGB")
 
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        et = datetime.now().strftime("%Y%m%dT%H%M%S")
+        final_path = compose_output_path(output_path, et)
+        os.makedirs(os.path.dirname(final_path), exist_ok=True)
         tiff_meta = _build_tiff_metadata(
             self.scanner_id, grid_mode, plate_index, resolution, region
         )
-        image.save(output_path, "TIFF", compression="tiff_lzw", tiffinfo=tiff_meta)
+        image.save(final_path, "TIFF", compression="tiff_lzw", tiffinfo=tiff_meta)
 
-        log(self.scanner_id, f"Mock scan saved: {output_path}")
+        log(self.scanner_id, f"Mock scan saved: {final_path}")
+        return final_path
 
     def _shutdown(self) -> None:
         """Clean shutdown: close device and exit SANE."""

--- a/python/tests/test_scan_path_composition.py
+++ b/python/tests/test_scan_path_composition.py
@@ -1,0 +1,54 @@
+"""
+Tests for compose_output_path() in scan_worker — pin the `_et_` insertion
+behavior the worker relies on to write files with their final filename
+directly (no post-save rename). See issue #154.
+"""
+
+import os
+
+from python.graviscan.scan_worker import compose_output_path
+
+
+class TestComposeOutputPath:
+    def test_et_inserted_right_after_st(self):
+        output_path = "/tmp/scans/plate_st_20260413T120530_cy1_S1_00.tif"
+        result = compose_output_path(output_path, et="20260413T120545")
+        assert result == (
+            "/tmp/scans/plate_st_20260413T120530_et_20260413T120545_cy1_S1_00.tif"
+        )
+
+    def test_suffix_and_extension_preserved(self):
+        """The _cy/scanner-tag/plate-index suffix and file extension are
+        unchanged — only the _et_ segment is inserted after _st_."""
+        output_path = "/tmp/scans/exp_wave2_st_20260301T120000_cy3_GS1_Sc2_01.tif"
+        result = compose_output_path(output_path, et="20260301T120530")
+        assert result.endswith("_cy3_GS1_Sc2_01.tif")
+        assert os.path.dirname(result) == os.path.dirname(output_path)
+
+    def test_no_st_pattern_returned_unchanged(self):
+        """Documented fallback behavior: if no _st_ pattern is found, the
+        path is returned unchanged."""
+        output_path = "/tmp/scans/scan.tif"
+        result = compose_output_path(output_path, et="20260301T120530")
+        assert result == output_path
+
+    def test_repeated_calls_do_not_double_insert(self):
+        """Calling compose_output_path twice with different et values on the
+        *same original* input each produce a single, correctly-inserted
+        result — no accidental double-insertion. This pins that count=1 in
+        the underlying regex prevents stacking _et_ segments across retries."""
+        output_path = "/tmp/scans/plate_st_20260413T120530_cy1_S1_00.tif"
+
+        first = compose_output_path(output_path, et="20260413T120545")
+        second = compose_output_path(output_path, et="20260413T130000")
+
+        assert first != second
+        assert first == (
+            "/tmp/scans/plate_st_20260413T120530_et_20260413T120545_cy1_S1_00.tif"
+        )
+        assert second == (
+            "/tmp/scans/plate_st_20260413T120530_et_20260413T130000_cy1_S1_00.tif"
+        )
+        # Neither result contains more than one _et_ segment.
+        assert first.count("_et_") == 1
+        assert second.count("_et_") == 1

--- a/python/tests/test_scan_worker.py
+++ b/python/tests/test_scan_worker.py
@@ -1105,9 +1105,7 @@ class TestRealHardwarePathComposition:
         w = ScanWorker(scanner_id="hw-test-scanner", device_name=device, mock=False)
         assert w.initialize(), "Failed to initialize real SANE device"
 
-        output_path = str(
-            tmp_path / "hwtest_st_20260301T120000_cy1_S1_00.tif"
-        )
+        output_path = str(tmp_path / "hwtest_st_20260301T120000_cy1_S1_00.tif")
         final_path = None
         try:
             final_path = w._sane_scan("2grid", "00", 300, output_path)

--- a/python/tests/test_scan_worker.py
+++ b/python/tests/test_scan_worker.py
@@ -7,6 +7,7 @@ state management, and USB reset platform mocking.
 import io
 import json
 import os
+import re
 import sys
 import threading
 from unittest.mock import MagicMock, patch
@@ -53,6 +54,18 @@ def _capture_stderr(func, *args, **kwargs):
 def _make_worker(scanner_id="test-scanner", device_name="mock-device", mock=True):
     """Create a ScanWorker with sensible test defaults."""
     return ScanWorker(scanner_id=scanner_id, device_name=device_name, mock=mock)
+
+
+def _scan_complete_paths(stdout: str) -> list:
+    """Extract `path` from every scan-complete event in captured stdout."""
+    paths = []
+    for line in stdout.strip().split("\n"):
+        if not line.startswith("EVENT:"):
+            continue
+        event = json.loads(line.removeprefix("EVENT:"))
+        if event.get("type") == "scan-complete":
+            paths.append(event["path"])
+    return paths
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -125,20 +138,20 @@ class TestMockScan:
     @patch("time.sleep")
     def test_generates_tiff(self, mock_sleep, tmp_path):
         w = _make_worker()
-        out = tmp_path / "scan.tif"
-        w._mock_scan("2grid", "00", 300, str(out))
-        assert out.exists()
-        img = Image.open(out)
+        out = tmp_path / "scan_st_20260301T120000_cy1_S1_00.tif"
+        final = w._mock_scan("2grid", "00", 300, str(out))
+        assert os.path.exists(final)
+        img = Image.open(final)
         assert img.format == "TIFF"
 
     @patch("time.sleep")
     def test_correct_dimensions(self, mock_sleep, tmp_path):
         w = _make_worker()
-        out = tmp_path / "scan.tif"
-        w._mock_scan("2grid", "00", 300, str(out))
+        out = tmp_path / "scan_st_20260301T120000_cy1_S1_00.tif"
+        final = w._mock_scan("2grid", "00", 300, str(out))
         region = get_scan_region("2grid", "00")
         px = region.to_pixels(300)
-        img = Image.open(out)
+        img = Image.open(final)
         expected_w = max(px["width"], 100)
         expected_h = max(px["height"], 100)
         assert img.size == (expected_w, expected_h)
@@ -146,9 +159,9 @@ class TestMockScan:
     @patch("time.sleep")
     def test_tiff_has_metadata(self, mock_sleep, tmp_path):
         w = _make_worker()
-        out = tmp_path / "scan.tif"
-        w._mock_scan("4grid", "01", 300, str(out))
-        img = Image.open(out)
+        out = tmp_path / "scan_st_20260301T120000_cy1_S1_00.tif"
+        final = w._mock_scan("4grid", "01", 300, str(out))
+        img = Image.open(final)
         desc = json.loads(img.tag_v2[270])
         assert desc["grid_mode"] == "4grid"
         assert desc["plate_index"] == "01"
@@ -246,9 +259,12 @@ class TestSaneScanRetryLogic:
         w._sane = mock_sane
         w._device = mock_device
 
-        out_path = str(tmp_path / "scan.tif")
+        out_path = str(tmp_path / "scan_st_20260301T120000_cy1_S1_00.tif")
         _capture_stderr(w._sane_scan, "2grid", "00", 300, out_path)
-        assert os.path.exists(out_path)
+        # Final path is composed at save time (_et_ inserted) — the original
+        # out_path is never written; verify the actual saved .tif exists.
+        tifs = list(tmp_path.glob("*.tif"))
+        assert len(tifs) == 1
         assert call_count == 3  # failed 2, succeeded on 3rd
 
     @patch("time.sleep")
@@ -430,7 +446,7 @@ class TestFullScanCycleMock:
         w = _make_worker()
         _capture_stdout(w.initialize)
 
-        out_path = str(tmp_path / "plate00.tif")
+        out_path = str(tmp_path / "plate00_st_20260301T120000_cy1_S1_00.tif")
         scan_cmd = json.dumps(
             {
                 "action": "scan",
@@ -458,7 +474,11 @@ class TestFullScanCycleMock:
         assert "scan-started" in types
         assert "scan-complete" in types
         assert "cycle-done" in types
-        assert os.path.exists(out_path)
+        # The actual file written is reported in the scan-complete event payload
+        # (final path includes _et_, composed at save time — not out_path itself).
+        complete_paths = _scan_complete_paths(out)
+        assert len(complete_paths) == 1
+        assert os.path.exists(complete_paths[0])
 
 
 class TestFourGridRowMerge:
@@ -476,7 +496,9 @@ class TestFourGridRowMerge:
                     "plate_index": idx,
                     "grid_mode": "4grid",
                     "resolution": 300,
-                    "output_path": str(tmp_path / f"plate_{idx}.tif"),
+                    "output_path": str(
+                        tmp_path / f"plate_{idx}_st_20260301T120000_cy1_S1_00.tif"
+                    ),
                 }
             )
 
@@ -486,20 +508,13 @@ class TestFourGridRowMerge:
         with patch("sys.stdin", io.StringIO(f"{scan_cmd}\n{quit_cmd}\n")):
             out = _capture_stdout(w.run)
 
-        # All 4 TIFFs should exist
-        for idx in ("00", "01", "10", "11"):
-            path = tmp_path / f"plate_{idx}.tif"
-            assert path.exists(), f"Missing {path}"
+        # All 4 TIFFs should exist — paths reported in scan-complete events.
+        complete_paths = _scan_complete_paths(out)
+        assert len(complete_paths) == 4
+        for path in complete_paths:
+            assert os.path.exists(path), f"Missing {path}"
             img = Image.open(path)
             assert img.size[0] > 0 and img.size[1] > 0
-
-        events = [
-            json.loads(line.removeprefix("EVENT:"))
-            for line in out.strip().split("\n")
-            if line.startswith("EVENT:")
-        ]
-        complete_events = [e for e in events if e["type"] == "scan-complete"]
-        assert len(complete_events) == 4
 
 
 class TestTwoGridIndividualScans:
@@ -515,13 +530,13 @@ class TestTwoGridIndividualScans:
                 "plate_index": "00",
                 "grid_mode": "2grid",
                 "resolution": 300,
-                "output_path": str(tmp_path / "p00.tif"),
+                "output_path": str(tmp_path / "p00_st_20260301T120000_cy1_S1_00.tif"),
             },
             {
                 "plate_index": "01",
                 "grid_mode": "2grid",
                 "resolution": 300,
-                "output_path": str(tmp_path / "p01.tif"),
+                "output_path": str(tmp_path / "p01_st_20260301T120000_cy1_S1_01.tif"),
             },
         ]
         scan_cmd = json.dumps({"action": "scan", "plates": plates})
@@ -530,8 +545,10 @@ class TestTwoGridIndividualScans:
         with patch("sys.stdin", io.StringIO(f"{scan_cmd}\n{quit_cmd}\n")):
             out = _capture_stdout(w.run)
 
-        assert (tmp_path / "p00.tif").exists()
-        assert (tmp_path / "p01.tif").exists()
+        complete_paths = _scan_complete_paths(out)
+        assert len(complete_paths) == 2
+        for path in complete_paths:
+            assert os.path.exists(path)
 
         events = [
             json.loads(line.removeprefix("EVENT:"))
@@ -556,23 +573,25 @@ class TestFourGridSinglePlateInRow:
                 "plate_index": "00",
                 "grid_mode": "4grid",
                 "resolution": 300,
-                "output_path": str(tmp_path / "p00.tif"),
+                "output_path": str(tmp_path / "p00_st_20260301T120000_cy1_S1_00.tif"),
             },
             {
                 "plate_index": "10",
                 "grid_mode": "4grid",
                 "resolution": 300,
-                "output_path": str(tmp_path / "p10.tif"),
+                "output_path": str(tmp_path / "p10_st_20260301T120000_cy1_S1_10.tif"),
             },
         ]
         scan_cmd = json.dumps({"action": "scan", "plates": plates})
         quit_cmd = json.dumps({"action": "quit"})
 
         with patch("sys.stdin", io.StringIO(f"{scan_cmd}\n{quit_cmd}\n")):
-            _capture_stdout(w.run)
+            out = _capture_stdout(w.run)
 
-        assert (tmp_path / "p00.tif").exists()
-        assert (tmp_path / "p10.tif").exists()
+        complete_paths = _scan_complete_paths(out)
+        assert len(complete_paths) == 2
+        for path in complete_paths:
+            assert os.path.exists(path)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -1051,3 +1070,62 @@ class TestBuildTiffMetadata:
         region = get_scan_region("2grid", "01")
         ifd = _build_tiff_metadata("s1", "2grid", "01", 300, region)
         assert ifd[296] == 2  # inches
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 11 — Real Hardware (excluded from default runs / CI)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.hardware
+class TestRealHardwarePathComposition:
+    """11.1 real (non-mock) scan writes directly to its final _et_-stamped
+    filename — no write-then-rename.
+
+    Requires the physical GraviScan rig (a real SANE scanner attached).
+    Excluded from default/CI runs via `-m "not hardware"` in pyproject.toml.
+
+    To run once the rig is back online:
+
+        GRAVISCAN_TEST_DEVICE=<device> uv run pytest python/tests/test_scan_worker.py -m hardware -v
+
+    where <device> is the SANE device name for the attached scanner, e.g.
+    "epkowa:interpreter:001:007".
+    """
+
+    def test_sane_scan_writes_final_path_directly(self, tmp_path):
+        device = os.environ.get("GRAVISCAN_TEST_DEVICE", "")
+        if not device:
+            pytest.skip(
+                "GRAVISCAN_TEST_DEVICE not set — skipping real-hardware test. "
+                "Set it to the SANE device name of the attached scanner to run "
+                "this test on the physical rig."
+            )
+
+        w = ScanWorker(scanner_id="hw-test-scanner", device_name=device, mock=False)
+        assert w.initialize(), "Failed to initialize real SANE device"
+
+        output_path = str(
+            tmp_path / "hwtest_st_20260301T120000_cy1_S1_00.tif"
+        )
+        final_path = None
+        try:
+            final_path = w._sane_scan("2grid", "00", 300, output_path)
+
+            # File was written once, directly, to its final name.
+            assert os.path.exists(final_path)
+
+            basename = os.path.basename(final_path)
+            st_match = re.search(r"_st_(\d{8}T\d{6})", basename)
+            et_match = re.search(r"_et_(\d{8}T\d{6})", basename)
+            assert st_match is not None, f"Missing _st_ segment in {basename}"
+            assert et_match is not None, f"Missing _et_ segment in {basename}"
+            # _et_ timestamp segment appears after _st_ in the filename.
+            assert st_match.start() < et_match.start()
+
+            # No write-then-rename: nothing exists at the original pre-_et_ path.
+            assert not os.path.exists(output_path)
+        finally:
+            if final_path and os.path.exists(final_path):
+                os.remove(final_path)
+            w._shutdown()

--- a/python/tests/test_tiff_metadata.py
+++ b/python/tests/test_tiff_metadata.py
@@ -48,15 +48,19 @@ class TestMockScanTiffMetadata:
 
     def test_mock_scan_embeds_metadata(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            output_path = os.path.join(tmpdir, "scan.tif")
+            output_path = os.path.join(
+                tmpdir, "scan_st_20260301T120000_cy1_S1_00.tif"
+            )
 
             worker = ScanWorker(
                 scanner_id="test-scanner", device_name="mock", mock=True
             )
-            worker._mock_scan("2grid", "00", 300, output_path)
+            final_path = worker._mock_scan("2grid", "00", 300, output_path)
 
-            # Read TIFF and check tags
-            img = Image.open(output_path)
+            # Read TIFF and check tags — read from the path _mock_scan
+            # actually returned (the final, _et_-stamped path), not the
+            # pre-_et_ output_path that was passed in.
+            img = Image.open(final_path)
             tag_data = img.tag_v2
 
             # ImageDescription
@@ -83,15 +87,18 @@ class TestMockScanTiffMetadata:
         with tempfile.TemporaryDirectory() as tmpdir:
             for grid_mode, plate_index in [("2grid", "01"), ("4grid", "10")]:
                 output_path = os.path.join(
-                    tmpdir, f"scan_{grid_mode}_{plate_index}.tif"
+                    tmpdir,
+                    f"scan_{grid_mode}_{plate_index}_st_20260301T120000_cy1_S1_00.tif",
                 )
 
                 worker = ScanWorker(
                     scanner_id="test-scanner", device_name="mock", mock=True
                 )
-                worker._mock_scan(grid_mode, plate_index, 600, output_path)
+                final_path = worker._mock_scan(
+                    grid_mode, plate_index, 600, output_path
+                )
 
-                img = Image.open(output_path)
+                img = Image.open(final_path)
                 desc = json.loads(img.tag_v2[270])
                 assert desc["grid_mode"] == grid_mode
                 assert desc["plate_index"] == plate_index

--- a/python/tests/test_tiff_metadata.py
+++ b/python/tests/test_tiff_metadata.py
@@ -48,9 +48,7 @@ class TestMockScanTiffMetadata:
 
     def test_mock_scan_embeds_metadata(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            output_path = os.path.join(
-                tmpdir, "scan_st_20260301T120000_cy1_S1_00.tif"
-            )
+            output_path = os.path.join(tmpdir, "scan_st_20260301T120000_cy1_S1_00.tif")
 
             worker = ScanWorker(
                 scanner_id="test-scanner", device_name="mock", mock=True
@@ -94,9 +92,7 @@ class TestMockScanTiffMetadata:
                 worker = ScanWorker(
                     scanner_id="test-scanner", device_name="mock", mock=True
                 )
-                final_path = worker._mock_scan(
-                    grid_mode, plate_index, 600, output_path
-                )
+                final_path = worker._mock_scan(grid_mode, plate_index, 600, output_path)
 
                 img = Image.open(final_path)
                 desc = json.loads(img.tag_v2[270])

--- a/src/main/graviscan/scan-coordinator.ts
+++ b/src/main/graviscan/scan-coordinator.ts
@@ -8,7 +8,9 @@
  * Adapted from Ben's scan-coordinator.ts (PR #138) with:
  * - Types imported from shared types file
  * - Implements ScanCoordinatorLike interface
- * - Rename failures surfaced as events
+ * - Real per-plate output paths learned from scan-complete events (the
+ *   Python worker composes the final _et_-stamped filename at save time,
+ *   so no post-save rename is needed — see #154)
  * - File verification after scan-complete
  * - USB stagger delay logged
  * - Dead CoordinatorEvent type removed
@@ -280,24 +282,34 @@ export class ScanCoordinator
           };
         });
 
+        // Accumulate the REAL per-plate paths from each plate's own
+        // scan-complete event. The worker now composes the final filename
+        // (including `_et_`) at save time, so the path we sent above is no
+        // longer guaranteed to be the path on disk — we must learn it from
+        // the event, not assume it.
+        const outputPaths: { plateIndex: string; path: string }[] = [];
+
         const promise = new Promise<{
           scannerId: string;
           outputPaths: { plateIndex: string; path: string }[];
         } | null>((resolve) => {
           const cleanup = () => {
             clearTimeout(rowTimeout);
+            sub.removeListener('scan-complete', onScanComplete);
             sub.removeListener('cycle-done', onCycleDone);
             sub.removeListener('exit', onExit);
           };
+          const onScanComplete = (event: ScanWorkerEvent) => {
+            if (event.plate_index && event.path) {
+              outputPaths.push({
+                plateIndex: event.plate_index,
+                path: event.path,
+              });
+            }
+          };
           const onCycleDone = () => {
             cleanup();
-            resolve({
-              scannerId,
-              outputPaths: platesToScan.map((p) => ({
-                plateIndex: p.plate_index,
-                path: p.output_path,
-              })),
-            });
+            resolve({ scannerId, outputPaths });
           };
           const onExit = () => {
             cleanup();
@@ -314,6 +326,7 @@ export class ScanCoordinator
             });
             resolve(null);
           }, SCAN_ROW_TIMEOUT_MS);
+          sub.on('scan-complete', onScanComplete);
           sub.on('cycle-done', onCycleDone);
           sub.on('exit', onExit);
         });
@@ -326,31 +339,19 @@ export class ScanCoordinator
       const results = await Promise.all(rowDonePromises);
 
       // Check cancelled after await — if cancel fired during the scan,
-      // skip file verification and renaming for this row
+      // skip file verification for this row
       if (this.cancelled) break;
 
       const gridEndedAt = new Date();
-      const etTimestamp = gridEndedAt
-        .toISOString()
-        .replace(/[-:]/g, '')
-        .slice(0, 15);
       this.currentGridEndedAt = gridEndedAt.toISOString();
 
-      scanLog(
-        `Cycle ${this.currentCycle}: row [${rowGrids.join(',')}] complete (et_${etTimestamp})`
-      );
+      scanLog(`Cycle ${this.currentCycle}: row [${rowGrids.join(',')}] complete`);
 
-      // Verify output files and rename with end timestamps
-      const renamedByGrid: Map<
-        string,
-        { oldPath: string; newPath: string; scannerId: string }[]
-      > = new Map();
-      const renameErrors: {
-        scannerId: string;
-        filePath: string;
-        error: string;
-      }[] = [];
-      for (const gridIndex of rowGrids) renamedByGrid.set(gridIndex, []);
+      // Verify output files. The Python worker composed the final filename
+      // (including `_et_`) at save time, so the paths from the scan-complete
+      // events above are already final — no rename is needed here.
+      const verifiedByGrid: Map<string, number> = new Map();
+      for (const gridIndex of rowGrids) verifiedByGrid.set(gridIndex, 0);
 
       for (const result of results) {
         if (!result) continue;
@@ -393,43 +394,10 @@ export class ScanCoordinator
             continue;
           }
 
-          // Rename to include end timestamp
-          try {
-            const dir = path.dirname(outputPath);
-            const ext = path.extname(outputPath);
-            const base = path.basename(outputPath, ext);
-
-            const newBase = base.replace(
-              /(_st_\d{8}T\d{6})/,
-              `$1_et_${etTimestamp}`
-            );
-            const newPath = path.join(dir, newBase + ext);
-
-            await fs.promises.rename(outputPath, newPath);
-            scanLog(
-              `[${result.scannerId}] Renamed: ${path.basename(outputPath)} → ${path.basename(newPath)}`
-            );
-            renamedByGrid.get(plateIndex)?.push({
-              oldPath: outputPath,
-              newPath,
-              scannerId: result.scannerId,
-            });
-          } catch (err) {
-            const errMsg = err instanceof Error ? err.message : String(err);
-            scanLog(
-              `[${result.scannerId}] Failed to rename ${outputPath}: ${errMsg}`
-            );
-            renameErrors.push({
-              scannerId: result.scannerId,
-              filePath: outputPath,
-              error: errMsg,
-            });
-            this.emit('rename-error', {
-              scannerId: result.scannerId,
-              filePath: outputPath,
-              error: errMsg,
-            });
-          }
+          verifiedByGrid.set(
+            plateIndex,
+            (verifiedByGrid.get(plateIndex) || 0) + 1
+          );
         }
       }
 
@@ -437,14 +405,12 @@ export class ScanCoordinator
       for (const gridIndex of rowGrids) {
         this.emit('grid-complete', {
           cycle: this.currentCycle,
-          renamedFiles: renamedByGrid.get(gridIndex) || [],
-          renameErrors,
           gridIndex,
           scanStartedAt: gridStartedAt.toISOString(),
           scanEndedAt: gridEndedAt.toISOString(),
         });
         scanLog(
-          `Cycle ${this.currentCycle}: grid ${gridIndex} complete — ${(renamedByGrid.get(gridIndex) || []).length} files renamed`
+          `Cycle ${this.currentCycle}: grid ${gridIndex} complete — ${verifiedByGrid.get(gridIndex) || 0} files verified`
         );
       }
     }

--- a/src/main/graviscan/scan-coordinator.ts
+++ b/src/main/graviscan/scan-coordinator.ts
@@ -345,7 +345,9 @@ export class ScanCoordinator
       const gridEndedAt = new Date();
       this.currentGridEndedAt = gridEndedAt.toISOString();
 
-      scanLog(`Cycle ${this.currentCycle}: row [${rowGrids.join(',')}] complete`);
+      scanLog(
+        `Cycle ${this.currentCycle}: row [${rowGrids.join(',')}] complete`
+      );
 
       // Verify output files. The Python worker composed the final filename
       // (including `_et_`) at save time, so the paths from the scan-complete

--- a/src/main/graviscan/wiring.ts
+++ b/src/main/graviscan/wiring.ts
@@ -61,7 +61,6 @@ export function setupCoordinatorEventForwarding(
     'overtime',
     'cancelled',
     'scan-error',
-    'rename-error',
   ];
 
   for (const eventName of events) {

--- a/tests/unit/graviscan/main-wiring.test.ts
+++ b/tests/unit/graviscan/main-wiring.test.ts
@@ -172,7 +172,7 @@ describe('GraviScan wiring module', () => {
   });
 
   describe('coordinator event forwarding', () => {
-    it('forwards all 11 coordinator events to renderer', () => {
+    it('forwards all 10 coordinator events to renderer', () => {
       const coordinator = new EventEmitter();
       const send = vi.fn();
       const mockWindow = {
@@ -196,7 +196,6 @@ describe('GraviScan wiring module', () => {
         'overtime',
         'cancelled',
         'scan-error',
-        'rename-error',
       ];
 
       for (const eventName of events) {
@@ -233,32 +232,6 @@ describe('GraviScan wiring module', () => {
         coordinator.emit('scan-event', { test: true })
       ).not.toThrow();
       expect(mockWindow.webContents.send).not.toHaveBeenCalled();
-    });
-
-    it('forwards rename-error events to renderer', () => {
-      const coordinator = new EventEmitter();
-      const send = vi.fn();
-      const mockWindow = {
-        isDestroyed: () => false,
-        webContents: { send },
-      };
-
-      setupCoordinatorEventForwarding(
-        coordinator as any,
-        () => mockWindow as any
-      );
-
-      coordinator.emit('rename-error', {
-        scannerId: 'scanner-1',
-        filePath: '/tmp/scan.tif',
-        error: 'ENOSPC',
-      });
-
-      expect(send).toHaveBeenCalledWith('graviscan:rename-error', {
-        scannerId: 'scanner-1',
-        filePath: '/tmp/scan.tif',
-        error: 'ENOSPC',
-      });
     });
   });
 

--- a/tests/unit/graviscan/scan-coordinator.test.ts
+++ b/tests/unit/graviscan/scan-coordinator.test.ts
@@ -17,12 +17,10 @@ vi.mock('fs', () => ({
   promises: {
     access: vi.fn().mockResolvedValue(undefined),
     stat: vi.fn().mockResolvedValue({ size: 1024 }),
-    rename: vi.fn().mockResolvedValue(undefined),
   },
   // Keep existsSync for any other code that might use it
   existsSync: vi.fn().mockReturnValue(true),
   statSync: vi.fn().mockReturnValue({ size: 1024 }),
-  renameSync: vi.fn(),
 }));
 
 import * as fs from 'fs';
@@ -58,6 +56,24 @@ function createMockSubprocess(scannerId: string): EventEmitter & {
   });
 }
 
+// Helper to emit a scan-complete event per plate, as the real
+// ScannerSubprocess does when the Python worker reports each plate's final
+// (already-_et_-stamped) path. `sub` is whatever mock subprocess received
+// the `scan()` call; `plates` is the array `scan()` was called with.
+function emitScanCompleteForPlates(
+  sub: EventEmitter,
+  plates: PlateConfig[]
+): void {
+  for (const plate of plates) {
+    sub.emit('scan-complete', {
+      type: 'scan-complete',
+      scanner_id: 'test-scanner',
+      plate_index: plate.plate_index,
+      path: plate.output_path,
+    });
+  }
+}
+
 // Track created subprocesses
 let createdSubprocesses: ReturnType<typeof createMockSubprocess>[];
 
@@ -78,7 +94,6 @@ describe('ScanCoordinator', () => {
     // Mock fs.promises
     vi.mocked(fs.promises.access).mockResolvedValue(undefined);
     vi.mocked(fs.promises.stat).mockResolvedValue({ size: 1024 } as fs.Stats);
-    vi.mocked(fs.promises.rename).mockResolvedValue(undefined);
 
     // Suppress console
     vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -270,6 +285,13 @@ describe('ScanCoordinator', () => {
       expect(cycleComplete).toHaveBeenCalledWith(
         expect.objectContaining({ cycle: 1 })
       );
+
+      // grid-complete no longer carries rename bookkeeping — the Python
+      // worker writes the final filename directly, so there is nothing to
+      // rename and nothing to report here.
+      const gridCompletePayload = gridComplete.mock.calls[0][0];
+      expect(gridCompletePayload).not.toHaveProperty('renamedFiles');
+      expect(gridCompletePayload).not.toHaveProperty('renameErrors');
     });
 
     it('regex path rewriting only affects filename, not directory', async () => {
@@ -379,15 +401,58 @@ describe('ScanCoordinator', () => {
       await coordinator.initialize(makeScanners(1));
 
       const sub = createdSubprocesses[0];
-      sub.scan.mockImplementation(() => {
+      sub.scan.mockImplementation((plates: PlateConfig[]) => {
+        emitScanCompleteForPlates(sub, plates);
         process.nextTick(() => sub.emit('cycle-done', {}));
       });
 
       const platesMap = makePlatesMap(['scanner-1']);
       await coordinator.scanOnce(platesMap);
 
-      // fs.promises.access should have been called to verify output files
+      // fs.promises.access should have been called to verify output files —
+      // using the real path from the scan-complete event, not a
+      // coordinator-predicted one.
       expect(fs.promises.access).toHaveBeenCalled();
+    });
+
+    it('verifies the path reported by scan-complete, not the path it sent', async () => {
+      // The Python worker now composes the final filename (with _et_)
+      // itself at save time, so it can legitimately report a DIFFERENT
+      // path than the one the coordinator sent via sub.scan(). The
+      // coordinator must verify (and later use) the real reported path.
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+
+      const sub = createdSubprocesses[0];
+      const sentPath = '/tmp/scan_st_20260410T120000_cy1_S1_00.tif';
+      const realFinalPath =
+        '/tmp/scan_st_20260410T120000_et_20260410T120530_cy1_S1_00.tif';
+
+      sub.scan.mockImplementation(() => {
+        sub.emit('scan-complete', {
+          type: 'scan-complete',
+          scanner_id: 'scanner-1',
+          plate_index: '00',
+          path: realFinalPath,
+        });
+        process.nextTick(() => sub.emit('cycle-done', {}));
+      });
+
+      const platesMap = new Map<string, PlateConfig[]>();
+      platesMap.set('scanner-1', [
+        {
+          plate_index: '00',
+          grid_mode: '2grid',
+          resolution: 600,
+          output_path: sentPath,
+        },
+      ]);
+
+      await coordinator.scanOnce(platesMap);
+
+      // Verification ran against the reported final path, not the sent one.
+      expect(fs.promises.access).toHaveBeenCalledWith(realFinalPath);
+      expect(fs.promises.access).not.toHaveBeenCalledWith(sentPath);
     });
 
     it('emits scan-error when stat rejects (filesystem race)', async () => {
@@ -395,7 +460,8 @@ describe('ScanCoordinator', () => {
       await coordinator.initialize(makeScanners(1));
 
       const sub = createdSubprocesses[0];
-      sub.scan.mockImplementation(() => {
+      sub.scan.mockImplementation((plates: PlateConfig[]) => {
+        emitScanCompleteForPlates(sub, plates);
         process.nextTick(() => sub.emit('cycle-done', {}));
       });
 
@@ -413,33 +479,6 @@ describe('ScanCoordinator', () => {
       expect(scanError).toHaveBeenCalledWith(
         expect.objectContaining({
           error: expect.stringContaining('Cannot stat'),
-        })
-      );
-    });
-
-    it('emits rename-error when rename fails', async () => {
-      const coordinator = await createCoordinator();
-      await coordinator.initialize(makeScanners(1));
-
-      const sub = createdSubprocesses[0];
-      sub.scan.mockImplementation(() => {
-        process.nextTick(() => sub.emit('cycle-done', {}));
-      });
-
-      // Make rename fail
-      vi.mocked(fs.promises.rename).mockRejectedValue(
-        new Error('ENOSPC: no space left on device')
-      );
-
-      const renameError = vi.fn();
-      coordinator.on('rename-error', renameError);
-
-      const platesMap = makePlatesMap(['scanner-1']);
-      await coordinator.scanOnce(platesMap);
-
-      expect(renameError).toHaveBeenCalledWith(
-        expect.objectContaining({
-          error: expect.stringContaining('ENOSPC'),
         })
       );
     });
@@ -553,7 +592,8 @@ describe('ScanCoordinator', () => {
       await coordinator.initialize(makeScanners(1));
 
       const sub = createdSubprocesses[0];
-      sub.scan.mockImplementation(() => {
+      sub.scan.mockImplementation((plates: PlateConfig[]) => {
+        emitScanCompleteForPlates(sub, plates);
         process.nextTick(() => sub.emit('cycle-done', {}));
       });
 
@@ -580,7 +620,8 @@ describe('ScanCoordinator', () => {
       await coordinator.initialize(makeScanners(1));
 
       const sub = createdSubprocesses[0];
-      sub.scan.mockImplementation(() => {
+      sub.scan.mockImplementation((plates: PlateConfig[]) => {
+        emitScanCompleteForPlates(sub, plates);
         process.nextTick(() => sub.emit('cycle-done', {}));
       });
 
@@ -597,21 +638,6 @@ describe('ScanCoordinator', () => {
           error: expect.stringContaining('zero-size'),
         })
       );
-    });
-
-    it('logs successful renames via scanLog', async () => {
-      const coordinator = await createCoordinator();
-      await coordinator.initialize(makeScanners(1));
-
-      const sub = createdSubprocesses[0];
-      sub.scan.mockImplementation(() => {
-        process.nextTick(() => sub.emit('cycle-done', {}));
-      });
-
-      const platesMap = makePlatesMap(['scanner-1']);
-      await coordinator.scanOnce(platesMap);
-
-      expect(scanLog).toHaveBeenCalledWith(expect.stringContaining('Renamed:'));
     });
 
     it('logs grid-complete events via scanLog', async () => {


### PR DESCRIPTION
## Summary

Increment 3 of the [GraviScan backend-hardening incremental port plan](docs/superpowers/plans/2026-07-24-graviscan-backend-hardening.md). Fixes #154: the scan worker used to write a file, then the TS coordinator renamed it post-save to insert the `_et_` end-timestamp — creating a window where the on-disk path didn't match the path `scan-complete` had already reported, and a real (if rare) failure mode if the rename itself failed. Since Increment 2 made every plate scan independently, the worker now knows both `_st_` and `_et_` at save time and writes the final filename directly.

## Investigation corrections (confirmed via git, not assumed)

The plan named two source commits in a specific order and treated the second as foundational. Direct investigation found both claims wrong:

- **Commit order was backwards.** `git merge-base --is-ancestor 0b80c1e b430428` confirms `0b80c1e` is an ancestor of `b430428` (same day, ~11h earlier) — not the reverse the plan stated.
- **`b430428` is an unmerged draft** ("Draft PR #220, kept open for reference" per its own commit message) assuming a renderer/experiment-driven component system (`exp_name`, `wave_number`, `scanner_tag`, etc.) that doesn't exist on `main` — confirmed `main`'s `PlateConfig` is still the simple `{plate_index, grid_mode, resolution, output_path}` shape matching `0b80c1e`'s *before* state exactly.

This PR ports `0b80c1e`'s actual fix (matching what the staged OpenSpec proposal itself documents), adopting only `b430428`'s more forward-looking `compose_output_path` naming/explicit-`et`-parameter style — not its component-dict signature or any renderer plumbing (out of scope until Phase 1b's renderer exists).

## Changes

- `python/graviscan/scan_worker.py` — new `compose_output_path(output_path, et)`; `_sane_scan`/`_mock_scan` compute `et` and compose the final path immediately before save, return it; `_scan_plate` emits `scan-complete` with the final path.
- `src/main/graviscan/scan-coordinator.ts` — the coordinator now **learns each plate's actual saved path from its own `scan-complete` event**, rather than assuming the path it sent is the path that was written (this assumption broke once Python composes `_et_` itself). File-existence/zero-size verification is preserved unchanged, now running against the real reported paths. The rename block, `renamedFiles`/`renameErrors`, and the `rename-error` event are removed entirely (including the dead forwarding entry in `wiring.ts`).
- Python + TS tests updated accordingly; new `python/tests/test_scan_path_composition.py` for `compose_output_path`.
- New `hardware` pytest marker (`pyproject.toml`, excluded from default runs via `addopts -m "not hardware"`) plus one `@pytest.mark.hardware` real-SANE-scan test — the physical rig (`pbiob-gh-04`) is currently offline, so this replaces live verification for now; run it with `GRAVISCAN_TEST_DEVICE=<device> uv run pytest python/tests/test_scan_worker.py -m hardware -v` once the rig is back.

## Testing

- [x] `uv run pytest python/tests/test_scan_path_composition.py python/tests/test_scan_worker.py python/tests/test_tiff_metadata.py -v` — 59 passed, 1 skipped (row-merge, expected), 1 deselected (hardware marker), 3 pre-existing unrelated failures (Windows-only `fcntl`/tempdir issues, confirmed via `git stash` comparison against base)
- [x] `npm run test:unit` — all scan-coordinator/wiring tests pass; pre-existing/flaky failures elsewhere confirmed identical on base branch
- [x] `npx tsc --noEmit` — clean

### Code Review

Went through subagent-driven-development. Task-level review (spec compliance + code quality) specifically scrutinized the coordinator's new event-listener scoping for leaks/races — confirmed each row-scan's `scan-complete` listener is scoped inside the per-scanner loop body and torn down on all 3 exit paths (cycle-done/exit/timeout), with a new regression test pinning "verifies the path reported by scan-complete, not the path it sent." Zero Critical/Important findings. Two Minor items deferred: the *live* OpenSpec spec still documents the removed rename behavior (expected to reconcile at archive time via this change's ADDED/REMOVED delta) and a harmless shift of `os.makedirs` to inside the SANE retry loop.

## Related

Part of the GraviScan backend-hardening incremental port plan (Increment 3 of 9). Lands after Increments 1 (#258) and 2 (#259).