### PR TITLE
feat(graviscan): re-enable Bloom (Supabase) upload alongside Box

### DIFF
--- a/openspec/changes/bloom-upload-parallel/proposal.md
+++ b/openspec/changes/bloom-upload-parallel/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+GraviScan currently uploads scan images to Box (via `rclone`) only. Bloom (Supabase) upload was fully removed from `main`'s modular structure during the original refactor and never re-ported — it exists only on a stranded branch (`src/main/graviscan-upload.ts`), where it was itself disabled for a period because the `api.bloom.salk.edu` proxy rejected files over 50MB. That size limit has since been confirmed resolved (2026-07-28), so it's safe to bring Bloom upload back as a first-class, parallel-with-Box upload path.
+
+## What Changes
+
+- Port `src/main/graviscan-upload.ts` (session upload → plate-metadata upload → per-image upload to Supabase) from the stranded branch, pinned to source commit `84b54e6` specifically — **not** the branch tip, which has since layered in unrelated, explicitly-deferred wave-scoped-metadata-linking work (a separate track per this project's incremental port plan).
+- Per-image upload runs with bounded concurrency (4 workers) instead of one-at-a-time.
+- `graviscan:upload-all-scans` runs Bloom and Box uploads in parallel (`Promise.allSettled`) and merges their results, instead of Box-only.
+- Adapt to `main`'s established conventions rather than the stranded branch's: dynamic imports for `@supabase/supabase-js`/`@salk-hpi/bloom-js` (matching `image-uploader.ts`'s documented startup-performance rationale), and `loadEnvConfig()` for credentials (matching `image-uploader.ts`) instead of the stranded branch's own hand-rolled `.env` parser.
+- New `src/types/graviscan-store.ts` type-extension shim for `SupabaseStore` methods not yet in `@salk-hpi/bloom-js`'s own exported types — trimmed to only what the currently-installed package version (`^0.2.0`) is still missing (some of the stranded branch's shim types have since been upstreamed into the package itself).
+
+### Implementation constraints
+
+- No wave-scoped-metadata-linking logic — that's a separate, deferred track.
+- Preserve Box backup behavior exactly; this only adds Bloom alongside it, never replaces it.
+- New test coverage is required — the stranded branch shipped this feature with zero tests.
+
+## Impact
+
+- Affected specs: `scanning`
+- Affected code:
+  - `src/main/graviscan-upload.ts` (new)
+  - `src/types/graviscan-store.ts` (new)
+  - `src/main/graviscan/image-handlers.ts` — `uploadAllScans()` runs Bloom + Box in parallel

--- a/openspec/changes/bloom-upload-parallel/specs/scanning/spec.md
+++ b/openspec/changes/bloom-upload-parallel/specs/scanning/spec.md
@@ -1,0 +1,72 @@
+## MODIFIED Requirements
+
+### Requirement: GraviScan Image Operations
+
+The system SHALL provide image reading, export, and cloud backup as testable functions in `src/main/graviscan/image-handlers.ts`, using callback injection for progress reporting.
+
+#### Scenario: Read scan image as JPEG thumbnail
+
+- **GIVEN** a TIFF scan image exists on disk
+- **WHEN** `readScanImage(filePath)` is called without `full` option
+- **THEN** the system SHALL convert the TIFF to JPEG at quality 85
+- **AND** resize to 400px width (without enlargement)
+- **AND** return a base64 data URI
+
+#### Scenario: Read scan image at full resolution
+
+- **GIVEN** a TIFF scan image exists on disk
+- **WHEN** `readScanImage(filePath, { full: true })` is called
+- **THEN** the system SHALL convert the TIFF to JPEG at quality 95
+- **AND** return the full-resolution image as a base64 data URI
+
+#### Scenario: Handle missing scan image with path fallback
+
+- **GIVEN** the requested file path does not exist
+- **WHEN** `readScanImage(filePath)` is called
+- **THEN** the system SHALL attempt path resolution via `resolveGraviScanPath()` (extension fallback, `_et_` fallback)
+- **AND** return `{ success: false, error: 'File not found' }` if resolution fails
+
+#### Scenario: Get scan output directory
+
+- **GIVEN** the application is running
+- **WHEN** `getOutputDir()` is called
+- **THEN** the system SHALL compute the output path from `app.getAppPath()` (development) or `app.getPath('home')` (production) based on `NODE_ENV`
+- **AND** create the directory if it does not exist
+- **AND** return the resolved output directory path
+
+#### Scenario: Get output directory when directory creation fails
+
+- **GIVEN** the computed output path cannot be created (e.g., permissions error)
+- **WHEN** `getOutputDir()` is called
+- **THEN** the system SHALL return `{ success: false, error: '...' }` with the filesystem error
+
+#### Scenario: Download experiment images with metadata CSV
+
+- **GIVEN** an experiment has GraviScan images across multiple waves
+- **WHEN** `downloadImages(db, { experimentId, experimentName, targetDir })` is called with an already-resolved target directory (dialog handling deferred to IPC wiring in Increment 3c)
+- **THEN** the system SHALL group images by wave number into subdirectories
+- **AND** write a `metadata.csv` per wave with experiment, plate, accession, and image columns
+- **AND** copy image files with concurrent file copy operations
+- **AND** report progress via the injected `onProgress` callback
+
+#### Scenario: Download with no images found
+
+- **GIVEN** an experiment has no GraviScan images
+- **WHEN** `downloadImages(db, params)` is called
+- **THEN** the system SHALL return `{ success: true, total: 0, copied: 0, errors: [] }`
+
+#### Scenario: Upload pending scans to Bloom and Box in parallel
+
+- **GIVEN** scans exist with pending upload status
+- **WHEN** `uploadAllScans(db, onProgress)` is called
+- **THEN** the system SHALL trigger Bloom (Supabase) upload and Box backup (via `runBoxBackup()`) in parallel
+- **AND** Bloom upload SHALL upload each scan's session and plate metadata before its images, then upload images with bounded concurrency (4 workers)
+- **AND** if either upload target throws, the other SHALL still complete (failures isolated via `Promise.allSettled`, not a single combined `try` that aborts both)
+- **AND** the combined result SHALL report success only if both targets succeeded, with merged `uploaded`/`skipped`/`failed` counts and merged `errors`
+- **AND** report progress via the injected `onProgress` callback for each target independently
+
+#### Scenario: Reject concurrent upload
+
+- **GIVEN** an upload is already in progress (module-level `uploadInProgress` guard)
+- **WHEN** `uploadAllScans(db, onProgress)` is called
+- **THEN** the system SHALL return `{ success: false, errors: ['Upload already in progress'], uploaded: 0, skipped: 0, failed: 0 }`

--- a/openspec/changes/bloom-upload-parallel/tasks.md
+++ b/openspec/changes/bloom-upload-parallel/tasks.md
@@ -1,0 +1,18 @@
+## 1. Upload orchestration module
+
+- [ ] 1.1 Port `createAuthenticatedClients()`, `processImageJobs()` (parallel, 4-worker), `uploadSessions()`, `uploadMetadata()`, `uploadAllPendingScans()` from stranded-branch commit `84b54e6`'s `src/main/graviscan-upload.ts`
+- [ ] 1.2 Adapt credential loading to `loadEnvConfig()` (matching `image-uploader.ts`), not a hand-rolled `.env` parser
+- [ ] 1.3 Adapt `@supabase/supabase-js`/`@salk-hpi/bloom-js` imports to dynamic imports (matching `image-uploader.ts`)
+
+## 2. Types
+
+- [ ] 2.1 Create `src/types/graviscan-store.ts`, trimmed to only the `SupabaseStore` extension methods still missing from the installed `@salk-hpi/bloom-js` version's own types
+
+## 3. Wiring
+
+- [ ] 3.1 `src/main/graviscan/image-handlers.ts`'s `uploadAllScans()` runs Bloom (via the new module) and Box in parallel via `Promise.allSettled`, merging results
+
+## 4. Tests
+
+- [ ] 4.1 Unit tests for the upload orchestration module (mocked Supabase client) — none existed on the source branch
+- [ ] 4.2 Updated/new tests for `uploadAllScans()`'s parallel Bloom+Box behavior

--- a/src/main/graviscan-upload.ts
+++ b/src/main/graviscan-upload.ts
@@ -1,0 +1,712 @@
+/**
+ * GraviScan Upload Orchestration
+ *
+ * Uploads local GraviScan images to Supabase cloud:
+ * 1. Calls insert_gravi_image RPC to create scan metadata
+ * 2. Uploads raw image file to graviscan-images storage bucket
+ * 3. Creates gravi_images row with the storage path
+ * 4. Updates local SQLite status to "uploaded"
+ *
+ * IMPORTANT: Uses dynamic imports for @supabase/supabase-js and
+ * @salk-hpi/bloom-js to avoid loading these modules at app startup. This
+ * prevents startup issues in the packaged app, matching the pattern used in
+ * image-uploader.ts and config-store.ts.
+ *
+ * Ported from stranded branch commit 84b54e6 (src/main/graviscan-upload.ts),
+ * which never made it into the modular src/main/graviscan/ refactor. Adapted
+ * to current conventions (loadEnvConfig(), dynamic imports) and to the
+ * currently-installed @salk-hpi/bloom-js@0.2.1, whose SupabaseStore/
+ * SupabaseUploader surface has drifted from what the reference file assumed
+ * — see inline comments below and task-6-report.md for the full list of
+ * deviations.
+ */
+
+import { PrismaClient } from '@prisma/client';
+import type {
+  SupabaseStore,
+  SupabaseUploader,
+  GraviImageMetadata,
+} from '@salk-hpi/bloom-js';
+import { resolveGraviScanPath } from './graviscan-path-utils';
+import { loadEnvConfig } from './config-store';
+import type {
+  GraviScanStoreExtensions,
+  GraviScanSessionParams,
+  GraviScanMetadataParams,
+} from '../types/graviscan-store';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as crypto from 'crypto';
+
+export interface UploadProgress {
+  total: number;
+  completed: number;
+  failed: number;
+  currentFile: string;
+}
+
+export interface UploadResult {
+  success: boolean;
+  uploaded: number;
+  skipped: number;
+  failed: number;
+  errors: string[];
+}
+
+/**
+ * Locally validate that Bloom credentials are present in ~/.bloom/.env (via
+ * loadEnvConfig(), same source image-uploader.ts uses). Pure local check —
+ * no network call — so callers can bail out before touching the DB or the
+ * network when credentials are missing.
+ */
+function validateBloomConfig(
+  config: ReturnType<typeof loadEnvConfig>
+): string | null {
+  if (
+    !config.bloom_api_url ||
+    !config.bloom_anon_key ||
+    !config.bloom_scanner_username ||
+    !config.bloom_scanner_password
+  ) {
+    return 'Bloom credentials not found in ~/.bloom/.env';
+  }
+  return null;
+}
+
+/**
+ * Authenticate with Supabase and create the store + uploader clients.
+ * Assumes `config` has already passed validateBloomConfig().
+ */
+async function authenticateBloomClients(
+  config: ReturnType<typeof loadEnvConfig>
+): Promise<
+  | {
+      store: SupabaseStore;
+      uploader: SupabaseUploader;
+    }
+  | { error: string }
+> {
+  // Dynamic imports to avoid loading Supabase at app startup
+  const { createClient } = await import('@supabase/supabase-js');
+  const { SupabaseStore, SupabaseUploader } = await import(
+    '@salk-hpi/bloom-js'
+  );
+
+  const supabase = createClient(config.bloom_api_url, config.bloom_anon_key);
+  const { error: authError } = await supabase.auth.signInWithPassword({
+    email: config.bloom_scanner_username,
+    password: config.bloom_scanner_password,
+  });
+
+  if (authError) {
+    return { error: `Authentication failed: ${authError.message}` };
+  }
+
+  return {
+    store: new SupabaseStore(supabase),
+    uploader: new SupabaseUploader(supabase),
+  };
+}
+
+/**
+ * Map a file extension to a storage Content-Type for raw (non-re-encoded)
+ * uploads.
+ */
+function rawContentType(ext: string): string {
+  switch (ext.toLowerCase()) {
+    case '.tif':
+    case '.tiff':
+      return 'image/tiff';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+/**
+ * Upload a file's raw bytes to Supabase Storage, without re-encoding.
+ *
+ * The installed @salk-hpi/bloom-js's SupabaseUploader only exposes
+ * uploadImage() (re-encodes to PNG via sharp) and uploadJpegImage()
+ * (re-encodes to JPEG) — both lossy and inappropriate for GraviScan's raw
+ * TIFF captures, and neither matches the reference file's `uploadRawFile()`
+ * call (which does not exist in the installed package at all — verified via
+ * `grep -r uploadRawFile node_modules/@salk-hpi/bloom-js`). SupabaseUploader
+ * exposes its underlying Supabase client as a public `supabase` property, so
+ * we call `.storage.from(bucket).upload(...)` directly the same way
+ * uploadImage()/uploadJpegImage() do internally, minus the sharp re-encode.
+ */
+async function uploadRawFile(
+  uploader: SupabaseUploader,
+  filePath: string,
+  storagePath: string,
+  bucket: string
+): Promise<{ error: Error | null }> {
+  try {
+    const buffer = await fs.promises.readFile(filePath);
+    const contentType = rawContentType(path.extname(filePath));
+    const { error } = await uploader.supabase.storage
+      .from(bucket)
+      .upload(storagePath, buffer, { contentType });
+    return { error: error ? new Error(error.message) : null };
+  } catch (err) {
+    return { error: err instanceof Error ? err : new Error(String(err)) };
+  }
+}
+
+/**
+ * Upload a list of scan+image jobs to Supabase.
+ * Shared logic used by both per-experiment and global upload.
+ */
+async function processImageJobs(
+  db: PrismaClient,
+  store: SupabaseStore,
+  uploader: SupabaseUploader,
+  imageJobs: Array<{
+    scan: {
+      id: string;
+      scanner: { name: string };
+      phenotyper: { name: string; email: string };
+      experiment: {
+        name: string;
+        species: string;
+        scientist: { name: string; email: string } | null;
+        accession: {
+          name: string;
+          graviPlateAccessions: Array<{
+            id: string;
+            plate_id: string;
+            accession: string;
+            transplant_date?: Date | null;
+            custom_note?: string | null;
+            sections: Array<{
+              plate_section_id: string;
+              plant_qr: string;
+              medium: string | null;
+            }>;
+          }>;
+        } | null;
+      };
+      plate_barcode: string | null;
+      capture_date: Date;
+      grid_mode: string;
+      plate_index: string;
+      resolution: number;
+      format: string;
+      cycle_number: number | null;
+      wave_number: number;
+      session_id: string | null;
+    };
+    image: { id: string; path: string };
+  }>,
+  sessionIdMap: Map<string, number>,
+  metadataIdMap: Map<string, number>,
+  onProgress?: (progress: UploadProgress) => void
+): Promise<UploadResult> {
+  // Bounded concurrency for Bloom uploads. Each image is 3 round-trips
+  // (insert RPC → file upload → update RPC); 4 workers keeps HTTPS pipes
+  // saturated without overwhelming Bloom's API or the local network when
+  // running alongside rclone's Box backup.
+  const UPLOAD_CONCURRENCY = 4;
+
+  const errors: string[] = [];
+  const total = imageJobs.length;
+  let uploaded = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  type Job = (typeof imageJobs)[number];
+
+  const processOne = async (job: Job): Promise<void> => {
+    const { scan, image } = job;
+    try {
+      // Resolve stale paths (DB may have _st_ only, disk file renamed with _et_)
+      const resolvedPath = resolveGraviScanPath(image.path);
+      if (!resolvedPath) {
+        errors.push(`File not found: ${image.path}`);
+        await db.graviImage.update({
+          where: { id: image.id },
+          data: { status: 'failed' },
+        });
+        failed++;
+        return;
+      }
+      if (resolvedPath !== image.path) {
+        console.log(
+          `[GraviScan:UPLOAD] Resolved stale path: ${path.basename(image.path)} → ${path.basename(resolvedPath)}`
+        );
+        await db.graviImage.update({
+          where: { id: image.id },
+          data: { path: resolvedPath },
+        });
+        await db.graviScan.update({
+          where: { id: scan.id },
+          data: { path: resolvedPath },
+        });
+        image.path = resolvedPath;
+      }
+
+      // Find the matching plate metadata for this scan's plant barcode
+      const matchedPlate = scan.experiment.accession?.graviPlateAccessions.find(
+        (p) => p.plate_id === scan.plate_barcode
+      );
+
+      const metadata: GraviImageMetadata & Record<string, unknown> = {
+        species: scan.experiment.species,
+        experiment: scan.experiment.name,
+        scanner_name: scan.scanner.name,
+        phenotyper_name: scan.phenotyper.name,
+        phenotyper_email: scan.phenotyper.email,
+        scientist_name: scan.experiment.scientist?.name || scan.phenotyper.name,
+        scientist_email:
+          scan.experiment.scientist?.email || scan.phenotyper.email,
+        // NOTE: @salk-hpi/bloom-js's installed GraviImageMetadata type (and
+        // its insertGraviImageMetadata RPC wrapper) names this field
+        // `plant_barcode`, not `plate_barcode` — verified against
+        // node_modules/@salk-hpi/bloom-js/dist/core/supabase/data-store.js,
+        // which maps `metadata.plant_barcode` to the `plant_barcode_` RPC
+        // param. GraviScan's own Prisma schema calls it `plate_barcode`;
+        // this is purely an external API naming difference.
+        plant_barcode: scan.plate_barcode,
+        capture_date: scan.capture_date.toISOString(),
+        grid_mode: scan.grid_mode,
+        plate_index: scan.plate_index,
+        resolution: scan.resolution,
+        format: scan.format,
+        accession_name:
+          matchedPlate?.accession ||
+          scan.experiment.accession?.graviPlateAccessions[0]?.accession,
+        // The fields below (cycle_number..custom_note) are not yet forwarded
+        // by the installed package's insertGraviImageMetadata RPC call (it
+        // only relays a fixed field list — see data-store.js). They're kept
+        // here for forward-compatibility: harmless extra properties today,
+        // automatically wired up once bloom-js's RPC wrapper catches up.
+        cycle_number: scan.cycle_number ?? undefined,
+        wave_number: scan.wave_number ?? 0,
+        session_id: scan.session_id
+          ? sessionIdMap.get(scan.session_id)
+          : undefined,
+        system_name: process.env.GRAVISCAN_SYSTEM_NAME ?? undefined,
+        metadata_id: matchedPlate
+          ? metadataIdMap.get(matchedPlate.id)
+          : undefined,
+        transplant_date: matchedPlate?.transplant_date
+          ? matchedPlate.transplant_date.toISOString()
+          : undefined,
+        custom_note: matchedPlate?.custom_note ?? undefined,
+      };
+
+      const { created: scanId, error: rpcError } =
+        await store.insertGraviImageMetadata(metadata);
+
+      if (rpcError) {
+        errors.push(`RPC error for ${image.path}: ${rpcError.message}`);
+        await db.graviImage.update({
+          where: { id: image.id },
+          data: { status: 'failed' },
+        });
+        failed++;
+        return;
+      }
+
+      if (scanId === null) {
+        await db.graviImage.update({
+          where: { id: image.id },
+          data: { status: 'uploaded' },
+        });
+        skipped++;
+        return;
+      }
+
+      const ext = path.extname(image.path);
+      const originalName = path.basename(image.path, ext);
+      const shortId = crypto.randomUUID().slice(0, 8);
+      const storagePath = `gravi-images/${originalName}_${shortId}${ext}`;
+      const uploadResult = await uploadRawFile(
+        uploader,
+        image.path,
+        storagePath,
+        'graviscan-images'
+      );
+
+      if (uploadResult.error) {
+        errors.push(
+          `Upload error for ${image.path}: ${uploadResult.error.message}`
+        );
+        await db.graviImage.update({
+          where: { id: image.id },
+          data: { status: 'failed' },
+        });
+        failed++;
+        return;
+      }
+
+      // Native SupabaseStore.updateGraviImageMetadata only accepts
+      // `object_path` — the installed package's `gravi_images` table has no
+      // file_hash/file_size_bytes columns (verified against
+      // database.types.d.ts), so those reference-file fields are dropped.
+      const { error: imageError } = await store.updateGraviImageMetadata(
+        scanId,
+        { object_path: storagePath }
+      );
+
+      if (imageError) {
+        errors.push(
+          `Image record error for ${image.path}: ${imageError.message}`
+        );
+        await db.graviImage.update({
+          where: { id: image.id },
+          data: { status: 'failed' },
+        });
+        failed++;
+        return;
+      }
+
+      await db.graviImage.update({
+        where: { id: image.id },
+        data: { status: 'uploaded' },
+      });
+      uploaded++;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      errors.push(`Error processing ${image.path}: ${msg}`);
+      await db.graviImage.update({
+        where: { id: image.id },
+        data: { status: 'failed' },
+      });
+      failed++;
+    }
+  };
+
+  // Worker-pool pattern: N workers share a single index cursor and pull
+  // from `imageJobs` until the queue is exhausted. Counter mutations are
+  // safe because JS is single-threaded between awaits.
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= imageJobs.length) return;
+      const job = imageJobs[idx];
+      await processOne(job);
+      onProgress?.({
+        total,
+        completed: uploaded + skipped + failed,
+        failed,
+        currentFile: path.basename(job.image.path),
+      });
+    }
+  };
+
+  const workerCount = Math.min(UPLOAD_CONCURRENCY, imageJobs.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  onProgress?.({
+    total,
+    completed: uploaded + skipped + failed,
+    failed,
+    currentFile: '',
+  });
+
+  return { success: failed === 0, uploaded, skipped, failed, errors };
+}
+
+/**
+ * Upload sessions to Supabase and return a map of local session IDs to
+ * Supabase session IDs.
+ *
+ * `SupabaseStore.insertGraviScanSession` does not exist in the installed
+ * @salk-hpi/bloom-js@0.2.1 (no method, no backing RPC/table wrapper) —
+ * verified via `grep -r insertGraviScanSession node_modules/@salk-hpi/bloom-js`
+ * returning nothing. Feature-detect and skip gracefully rather than fail the
+ * whole Bloom upload on a feature the installed package doesn't support yet;
+ * this activates automatically once bloom-js adds it.
+ */
+async function uploadSessions(
+  store: SupabaseStore,
+  scans: Array<{
+    session_id: string | null;
+    session: {
+      scan_mode: string;
+      interval_seconds: number | null;
+      duration_seconds: number | null;
+      total_cycles: number | null;
+      started_at: Date;
+      completed_at: Date | null;
+      cancelled: boolean;
+    } | null;
+    experiment: {
+      name: string;
+      species: string;
+      scientist: { name: string; email: string } | null;
+      accession: {
+        name: string;
+        graviPlateAccessions: Array<{ accession: string }>;
+      } | null;
+    };
+    phenotyper: { name: string; email: string };
+  }>
+): Promise<{ sessionIdMap: Map<string, number>; errors: string[] }> {
+  const sessionIdMap = new Map<string, number>();
+  const errors: string[] = [];
+
+  const extendedStore = store as GraviScanStoreExtensions;
+  if (typeof extendedStore.insertGraviScanSession !== 'function') {
+    console.log(
+      '[GraviScan:UPLOAD] SupabaseStore.insertGraviScanSession not available in installed @salk-hpi/bloom-js — skipping session upload'
+    );
+    return { sessionIdMap, errors };
+  }
+
+  const seenSessionIds = new Set<string>();
+
+  for (const scan of scans) {
+    if (
+      !scan.session_id ||
+      !scan.session ||
+      seenSessionIds.has(scan.session_id)
+    )
+      continue;
+    seenSessionIds.add(scan.session_id);
+
+    try {
+      const params: GraviScanSessionParams = {
+        species: scan.experiment.species,
+        experiment: scan.experiment.name,
+        phenotyper_name: scan.phenotyper.name,
+        phenotyper_email: scan.phenotyper.email,
+        scientist_name: scan.experiment.scientist?.name || scan.phenotyper.name,
+        scientist_email:
+          scan.experiment.scientist?.email || scan.phenotyper.email,
+        accession_name:
+          scan.experiment.accession?.graviPlateAccessions?.[0]?.accession,
+        scan_mode: scan.session.scan_mode,
+        interval_seconds: scan.session.interval_seconds ?? undefined,
+        duration_seconds: scan.session.duration_seconds ?? undefined,
+        total_cycles: scan.session.total_cycles ?? undefined,
+        actual_duration_seconds:
+          scan.session.started_at && scan.session.completed_at
+            ? Math.round(
+                (new Date(scan.session.completed_at).getTime() -
+                  new Date(scan.session.started_at).getTime()) /
+                  1000
+              )
+            : undefined,
+        completed_at: scan.session.completed_at
+          ? new Date(scan.session.completed_at).toISOString()
+          : undefined,
+        cancelled: scan.session.cancelled,
+        system_name: process.env.GRAVISCAN_SYSTEM_NAME ?? undefined,
+      };
+
+      const { created: supabaseSessionId, error } =
+        await extendedStore.insertGraviScanSession(params);
+      if (error) {
+        errors.push(
+          `Session upload error for ${scan.session_id}: ${error.message}`
+        );
+      } else if (supabaseSessionId !== null) {
+        sessionIdMap.set(scan.session_id, supabaseSessionId);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      errors.push(`Session upload error for ${scan.session_id}: ${msg}`);
+    }
+  }
+
+  return { sessionIdMap, errors };
+}
+
+/**
+ * Upload plate metadata (GraviPlateAccession + sections) to Supabase.
+ * Returns a map of local GraviPlateAccession IDs to Supabase metadata IDs.
+ *
+ * `SupabaseStore.insertGraviScanMetadata` does not exist in the installed
+ * @salk-hpi/bloom-js@0.2.1 either — same feature-detection rationale as
+ * uploadSessions() above.
+ */
+async function uploadMetadata(
+  store: SupabaseStore,
+  scans: Array<{
+    wave_number: number;
+    experiment: {
+      accession: {
+        graviPlateAccessions: Array<{
+          id: string;
+          plate_id: string;
+          accession: string;
+          transplant_date: Date | null;
+          custom_note: string | null;
+          sections: Array<{
+            plate_section_id: string;
+            plant_qr: string;
+            medium: string | null;
+          }>;
+        }>;
+      } | null;
+    };
+  }>
+): Promise<{ metadataIdMap: Map<string, number>; errors: string[] }> {
+  const metadataIdMap = new Map<string, number>();
+  const errors: string[] = [];
+
+  const extendedStore = store as GraviScanStoreExtensions;
+  if (typeof extendedStore.insertGraviScanMetadata !== 'function') {
+    console.log(
+      '[GraviScan:UPLOAD] SupabaseStore.insertGraviScanMetadata not available in installed @salk-hpi/bloom-js — skipping metadata upload'
+    );
+    return { metadataIdMap, errors };
+  }
+
+  const seenPlateIds = new Set<string>();
+
+  for (const scan of scans) {
+    if (!scan.experiment.accession) {
+      continue;
+    }
+
+    for (const plate of scan.experiment.accession.graviPlateAccessions) {
+      if (seenPlateIds.has(plate.id)) continue;
+      seenPlateIds.add(plate.id);
+
+      try {
+        const params: GraviScanMetadataParams = {
+          accession_name: plate.accession,
+          plate_id: plate.plate_id,
+          wave_number: scan.wave_number,
+          transplant_date: plate.transplant_date
+            ? plate.transplant_date.toISOString()
+            : null,
+          custom_note: plate.custom_note,
+          sections: plate.sections.map((s) => ({
+            plate_section_id: s.plate_section_id,
+            plant_qr: s.plant_qr,
+            medium: s.medium,
+          })),
+        };
+
+        const { created: supabaseMetadataId, error } =
+          await extendedStore.insertGraviScanMetadata(params);
+        if (error) {
+          errors.push(
+            `Metadata upload error for plate ${plate.plate_id}: ${error.message}`
+          );
+        } else if (supabaseMetadataId !== null) {
+          metadataIdMap.set(plate.id, supabaseMetadataId);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Unknown error';
+        errors.push(
+          `Metadata upload error for plate ${plate.plate_id}: ${msg}`
+        );
+      }
+    }
+  }
+
+  return { metadataIdMap, errors };
+}
+
+/**
+ * Upload all pending/failed scans across ALL experiments to Supabase.
+ *
+ * Ordering is deliberate: validate credentials locally (no network) before
+ * touching the DB, then check for pending work (cheap Prisma read) before
+ * paying for a real Supabase auth round-trip. This means a scanner with no
+ * pending uploads never calls Supabase at all, and a scanner with missing
+ * credentials never queries the DB at all.
+ */
+export async function uploadAllPendingScans(
+  db: PrismaClient,
+  onProgress?: (progress: UploadProgress) => void
+): Promise<UploadResult> {
+  const envPath = path.join(os.homedir(), '.bloom', '.env');
+  const config = loadEnvConfig(envPath);
+
+  const configError = validateBloomConfig(config);
+  if (configError) {
+    return {
+      success: false,
+      uploaded: 0,
+      skipped: 0,
+      failed: 0,
+      errors: [configError],
+    };
+  }
+
+  const scans = await db.graviScan.findMany({
+    where: {
+      deleted: false,
+      images: {
+        some: { status: { in: ['pending', 'failed'] } },
+      },
+    },
+    include: {
+      images: { where: { status: { in: ['pending', 'failed'] } } },
+      scanner: true,
+      phenotyper: true,
+      session: true,
+      experiment: {
+        include: {
+          scientist: true,
+          accession: {
+            include: {
+              graviPlateAccessions: {
+                include: { sections: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (scans.length === 0) {
+    return { success: true, uploaded: 0, skipped: 0, failed: 0, errors: [] };
+  }
+
+  const clients = await authenticateBloomClients(config);
+  if ('error' in clients) {
+    return {
+      success: false,
+      uploaded: 0,
+      skipped: 0,
+      failed: 0,
+      errors: [clients.error],
+    };
+  }
+
+  // Upload sessions first, then map local session IDs to Supabase session IDs
+  const { sessionIdMap, errors: sessionErrors } = await uploadSessions(
+    clients.store,
+    scans
+  );
+
+  // Upload plate metadata, then map local GraviPlateAccession IDs to Supabase metadata IDs
+  const { metadataIdMap, errors: metadataErrors } = await uploadMetadata(
+    clients.store,
+    scans
+  );
+
+  const imageJobs = scans.flatMap((scan) =>
+    scan.images.map((img) => ({ scan, image: img }))
+  );
+
+  const result = await processImageJobs(
+    db,
+    clients.store,
+    clients.uploader,
+    imageJobs,
+    sessionIdMap,
+    metadataIdMap,
+    onProgress
+  );
+  result.errors = [...sessionErrors, ...metadataErrors, ...result.errors];
+  if (sessionErrors.length > 0 || metadataErrors.length > 0)
+    result.success = false;
+
+  return result;
+}

--- a/src/main/graviscan-upload.ts
+++ b/src/main/graviscan-upload.ts
@@ -52,7 +52,26 @@ export interface UploadResult {
   skipped: number;
   failed: number;
   errors: string[];
+  /**
+   * Whether the installed @salk-hpi/bloom-js supports session/plate-metadata
+   * linking (both `insertGraviScanSession` and `insertGraviScanMetadata`
+   * present on SupabaseStore). `false` means the image upload still ran
+   * normally, but session/wave/transplant/note metadata was NOT linked —
+   * see uploadSessions()/uploadMetadata() below. This is surfaced on the
+   * result (rather than only logged) so a future renderer can show
+   * operators when metadata linking isn't active, since console.log is
+   * invisible in a packaged Electron app.
+   */
+  metadataLinkingAvailable: boolean;
 }
+
+/**
+ * UploadResult as returned by processImageJobs(), which has no way to know
+ * whether session/metadata linking was available (that's determined by
+ * uploadSessions()/uploadMetadata(), which run before it). Callers combine
+ * this with `metadataLinkingAvailable` to build the full UploadResult.
+ */
+type ImageUploadResult = Omit<UploadResult, 'metadataLinkingAvailable'>;
 
 /**
  * Locally validate that Bloom credentials are present in ~/.bloom/.env (via
@@ -207,7 +226,7 @@ async function processImageJobs(
   sessionIdMap: Map<string, number>,
   metadataIdMap: Map<string, number>,
   onProgress?: (progress: UploadProgress) => void
-): Promise<UploadResult> {
+): Promise<ImageUploadResult> {
   // Bounded concurrency for Bloom uploads. Each image is 3 round-trips
   // (insert RPC → file upload → update RPC); 4 workers keeps HTTPS pipes
   // saturated without overwhelming Bloom's API or the local network when
@@ -450,16 +469,21 @@ async function uploadSessions(
     };
     phenotyper: { name: string; email: string };
   }>
-): Promise<{ sessionIdMap: Map<string, number>; errors: string[] }> {
+): Promise<{
+  sessionIdMap: Map<string, number>;
+  errors: string[];
+  available: boolean;
+}> {
   const sessionIdMap = new Map<string, number>();
   const errors: string[] = [];
 
   const extendedStore = store as GraviScanStoreExtensions;
-  if (typeof extendedStore.insertGraviScanSession !== 'function') {
+  const available = typeof extendedStore.insertGraviScanSession === 'function';
+  if (!available) {
     console.log(
       '[GraviScan:UPLOAD] SupabaseStore.insertGraviScanSession not available in installed @salk-hpi/bloom-js — skipping session upload'
     );
-    return { sessionIdMap, errors };
+    return { sessionIdMap, errors, available };
   }
 
   const seenSessionIds = new Set<string>();
@@ -518,7 +542,7 @@ async function uploadSessions(
     }
   }
 
-  return { sessionIdMap, errors };
+  return { sessionIdMap, errors, available };
 }
 
 /**
@@ -550,16 +574,21 @@ async function uploadMetadata(
       } | null;
     };
   }>
-): Promise<{ metadataIdMap: Map<string, number>; errors: string[] }> {
+): Promise<{
+  metadataIdMap: Map<string, number>;
+  errors: string[];
+  available: boolean;
+}> {
   const metadataIdMap = new Map<string, number>();
   const errors: string[] = [];
 
   const extendedStore = store as GraviScanStoreExtensions;
-  if (typeof extendedStore.insertGraviScanMetadata !== 'function') {
+  const available = typeof extendedStore.insertGraviScanMetadata === 'function';
+  if (!available) {
     console.log(
       '[GraviScan:UPLOAD] SupabaseStore.insertGraviScanMetadata not available in installed @salk-hpi/bloom-js — skipping metadata upload'
     );
-    return { metadataIdMap, errors };
+    return { metadataIdMap, errors, available };
   }
 
   const seenPlateIds = new Set<string>();
@@ -607,7 +636,7 @@ async function uploadMetadata(
     }
   }
 
-  return { metadataIdMap, errors };
+  return { metadataIdMap, errors, available };
 }
 
 /**
@@ -634,6 +663,7 @@ export async function uploadAllPendingScans(
       skipped: 0,
       failed: 0,
       errors: [configError],
+      metadataLinkingAvailable: false,
     };
   }
 
@@ -665,7 +695,14 @@ export async function uploadAllPendingScans(
   });
 
   if (scans.length === 0) {
-    return { success: true, uploaded: 0, skipped: 0, failed: 0, errors: [] };
+    return {
+      success: true,
+      uploaded: 0,
+      skipped: 0,
+      failed: 0,
+      errors: [],
+      metadataLinkingAvailable: false,
+    };
   }
 
   const clients = await authenticateBloomClients(config);
@@ -676,20 +713,28 @@ export async function uploadAllPendingScans(
       skipped: 0,
       failed: 0,
       errors: [clients.error],
+      metadataLinkingAvailable: false,
     };
   }
 
   // Upload sessions first, then map local session IDs to Supabase session IDs
-  const { sessionIdMap, errors: sessionErrors } = await uploadSessions(
-    clients.store,
-    scans
-  );
+  const {
+    sessionIdMap,
+    errors: sessionErrors,
+    available: sessionUploadAvailable,
+  } = await uploadSessions(clients.store, scans);
 
   // Upload plate metadata, then map local GraviPlateAccession IDs to Supabase metadata IDs
-  const { metadataIdMap, errors: metadataErrors } = await uploadMetadata(
-    clients.store,
-    scans
-  );
+  const {
+    metadataIdMap,
+    errors: metadataErrors,
+    available: metadataUploadAvailable,
+  } = await uploadMetadata(clients.store, scans);
+
+  // Both must be available for metadata linking to actually happen end to
+  // end — session upload alone (or vice versa) still leaves images unlinked.
+  const metadataLinkingAvailable =
+    sessionUploadAvailable && metadataUploadAvailable;
 
   const imageJobs = scans.flatMap((scan) =>
     scan.images.map((img) => ({ scan, image: img }))
@@ -708,5 +753,5 @@ export async function uploadAllPendingScans(
   if (sessionErrors.length > 0 || metadataErrors.length > 0)
     result.success = false;
 
-  return result;
+  return { ...result, metadataLinkingAvailable };
 }

--- a/src/main/graviscan-upload.ts
+++ b/src/main/graviscan-upload.ts
@@ -407,7 +407,10 @@ async function processImageJobs(
   // safe because JS is single-threaded between awaits.
   let cursor = 0;
   const worker = async (): Promise<void> => {
-    while (true) {
+    // eslint-friendly idiomatic infinite loop — exit condition is inside
+    // (idx >= imageJobs.length → return). Avoids no-constant-condition
+    // vs `while (true)`.
+    for (;;) {
       const idx = cursor++;
       if (idx >= imageJobs.length) return;
       const job = imageJobs[idx];

--- a/src/main/graviscan/image-handlers.ts
+++ b/src/main/graviscan/image-handlers.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs';
 import sharp from 'sharp';
 import { resolveGraviScanPath } from '../graviscan-path-utils';
 import { runBoxBackup } from '../box-backup';
+import { uploadAllPendingScans } from '../graviscan-upload';
 import { getGraviscanOutputDir } from '../graviscan-output-dir';
 
 // ---------------------------------------------------------------------------
@@ -170,9 +171,14 @@ export async function readScanImage(
 // ---------------------------------------------------------------------------
 
 /**
- * Upload all pending/failed scans to Box backup.
- * Bloom (Supabase) upload is temporarily disabled due to proxy size limit.
- * Progress events delivered via onProgress callback.
+ * Upload all pending/failed scans to Bloom (Supabase) and Box (rclone).
+ * Both run in parallel via Promise.allSettled; their results are merged.
+ * A thrown/rejected branch becomes a synthesized failed result rather than
+ * aborting the other branch or the whole function — Bloom failing doesn't
+ * prevent Box from completing, and vice versa.
+ * Progress events from both targets are delivered via the single onProgress
+ * callback (the IPC layer forwards it to the 'graviscan:upload-progress'
+ * channel; it does not distinguish source, matching the existing wiring).
  */
 export async function uploadAllScans(
   db: PrismaClient,
@@ -196,22 +202,59 @@ export async function uploadAllScans(
   }
   uploadInProgress = true;
   try {
-    console.log(
-      '[GraviScan:UPLOAD] Bloom upload disabled (proxy size limit) — Box backup only'
-    );
+    console.log('[GraviScan:UPLOAD] Starting Bloom + Box upload in parallel');
 
-    const boxResult = await runBoxBackup(db, (progress) => {
-      onProgress?.(progress);
-    });
+    const [bloomSettled, boxSettled] = await Promise.allSettled([
+      uploadAllPendingScans(db, (progress) => {
+        onProgress?.(progress);
+      }),
+      runBoxBackup(db, (progress) => {
+        onProgress?.(progress);
+      }),
+    ]);
 
-    console.log('[GraviScan:UPLOAD] Box backup result:', boxResult);
+    const bloomResult =
+      bloomSettled.status === 'fulfilled'
+        ? bloomSettled.value
+        : {
+            success: false,
+            uploaded: 0,
+            skipped: 0,
+            failed: 0,
+            errors: [
+              `Bloom upload threw: ${
+                bloomSettled.reason instanceof Error
+                  ? bloomSettled.reason.message
+                  : String(bloomSettled.reason)
+              }`,
+            ],
+          };
+
+    const boxResult =
+      boxSettled.status === 'fulfilled'
+        ? boxSettled.value
+        : {
+            success: false,
+            experiments: 0,
+            filesCopied: 0,
+            errors: [
+              `Box backup threw: ${
+                boxSettled.reason instanceof Error
+                  ? boxSettled.reason.message
+                  : String(boxSettled.reason)
+              }`,
+            ],
+          };
+
+    console.log('[GraviScan:UPLOAD] Bloom result:', bloomResult);
+    console.log('[GraviScan:UPLOAD] Box result:', boxResult);
 
     return {
-      success: boxResult.success,
-      uploaded: boxResult.filesCopied,
-      skipped: 0,
-      failed: boxResult.errors.length,
-      errors: boxResult.errors,
+      success: bloomResult.success && boxResult.success,
+      uploaded: bloomResult.uploaded + boxResult.filesCopied,
+      skipped: bloomResult.skipped,
+      failed: bloomResult.failed + boxResult.errors.length,
+      errors: [...bloomResult.errors, ...boxResult.errors],
     };
   } catch (error) {
     console.error('[GraviScan:UPLOAD] Error:', error);

--- a/src/main/graviscan/image-handlers.ts
+++ b/src/main/graviscan/image-handlers.ts
@@ -189,6 +189,13 @@ export async function uploadAllScans(
   skipped: number;
   failed: number;
   errors: string[];
+  /**
+   * Whether the installed @salk-hpi/bloom-js supports Bloom session/plate-
+   * metadata linking (see graviscan-upload.ts's UploadResult). Surfaced here
+   * so a future renderer can show operators when metadata linking isn't
+   * active, rather than that only being visible in main-process logs.
+   */
+  metadataLinkingAvailable: boolean;
 }> {
   if (uploadInProgress) {
     console.log('[GraviScan:UPLOAD] Upload already in progress — skipping');
@@ -198,6 +205,7 @@ export async function uploadAllScans(
       skipped: 0,
       failed: 0,
       errors: ['Upload already in progress'],
+      metadataLinkingAvailable: false,
     };
   }
   uploadInProgress = true;
@@ -228,6 +236,7 @@ export async function uploadAllScans(
                   : String(bloomSettled.reason)
               }`,
             ],
+            metadataLinkingAvailable: false,
           };
 
     const boxResult =
@@ -255,6 +264,7 @@ export async function uploadAllScans(
       skipped: bloomResult.skipped,
       failed: bloomResult.failed + boxResult.errors.length,
       errors: [...bloomResult.errors, ...boxResult.errors],
+      metadataLinkingAvailable: bloomResult.metadataLinkingAvailable,
     };
   } catch (error) {
     console.error('[GraviScan:UPLOAD] Error:', error);
@@ -264,6 +274,7 @@ export async function uploadAllScans(
       skipped: 0,
       failed: 0,
       errors: [error instanceof Error ? error.message : 'Upload failed'],
+      metadataLinkingAvailable: false,
     };
   } finally {
     uploadInProgress = false;

--- a/src/types/graviscan-store.ts
+++ b/src/types/graviscan-store.ts
@@ -1,0 +1,91 @@
+/**
+ * Type definitions for GraviScan external store interfaces.
+ *
+ * These types cover methods on @salk-hpi/bloom-js's SupabaseStore that are
+ * GraviScan-specific and not yet exported from the package's own type
+ * definitions. Once the package adds proper exports, this file can be
+ * trimmed further (or removed).
+ *
+ * NOTE (verified against installed @salk-hpi/bloom-js@0.2.1, 2026-07-28):
+ * `insertGraviImageMetadata` and `updateGraviImageMetadata` are ALREADY
+ * natively typed (and implemented) on `SupabaseStore` — see
+ * node_modules/@salk-hpi/bloom-js/dist/{types,core/supabase}/data-store.d.ts.
+ * They are intentionally NOT redeclared here to avoid conflicting with the
+ * package's own types. `insertGraviScanSession` and `insertGraviScanMetadata`
+ * remain genuinely missing (no method, and no corresponding Supabase RPC/table
+ * in the installed package's generated `database.types.d.ts` — the
+ * `gravi_scan_sessions` table exists but nothing wraps it, and there is no
+ * plate/accession-metadata table or RPC at all yet). Callers in
+ * `src/main/graviscan-upload.ts` feature-detect these methods at runtime and
+ * skip session/metadata upload gracefully when absent, so this file only
+ * needs to supply the types for when the package catches up.
+ */
+
+import type { SupabaseStore } from '@salk-hpi/bloom-js';
+import type { PostgrestError } from '@supabase/postgrest-js';
+
+// ---------------------------------------------------------------------------
+// SupabaseStore GraviScan Extensions
+// ---------------------------------------------------------------------------
+
+/**
+ * Parameters for inserting a GraviScan session into Supabase.
+ */
+export interface GraviScanSessionParams {
+  species: string;
+  experiment: string;
+  phenotyper_name: string;
+  phenotyper_email: string;
+  scientist_name: string;
+  scientist_email: string;
+  accession_name?: string;
+  scan_mode: string;
+  interval_seconds?: number;
+  duration_seconds?: number;
+  total_cycles?: number;
+  actual_duration_seconds?: number;
+  completed_at?: string;
+  cancelled: boolean;
+  system_name?: string;
+}
+
+/**
+ * Parameters for inserting GraviScan plate metadata into Supabase.
+ */
+export interface GraviScanMetadataParams {
+  accession_name: string;
+  plate_id: string;
+  wave_number?: number;
+  transplant_date: string | null;
+  custom_note: string | null;
+  sections: Array<{
+    plate_section_id: string;
+    plant_qr: string;
+    medium: string | null;
+  }>;
+}
+
+/**
+ * Common return type for Supabase store insert operations.
+ */
+export interface StoreResult<T = number> {
+  created: T;
+  error: PostgrestError | null;
+}
+
+/**
+ * GraviScan-specific methods on SupabaseStore that are not yet part of the
+ * installed @salk-hpi/bloom-js package's own types/implementation.
+ *
+ * Usage: cast `store` to this interface instead of `any`, and feature-detect
+ * before calling since the package may not implement these yet:
+ *   const ext = store as GraviScanStoreExtensions;
+ *   if (typeof ext.insertGraviScanSession === 'function') { ... }
+ */
+export interface GraviScanStoreExtensions extends SupabaseStore {
+  insertGraviScanSession(params: GraviScanSessionParams): Promise<StoreResult>;
+
+  insertGraviScanMetadata(
+    params: GraviScanMetadataParams
+  ): Promise<StoreResult>;
+}

--- a/tests/unit/graviscan-upload.test.ts
+++ b/tests/unit/graviscan-upload.test.ts
@@ -163,6 +163,7 @@ describe('graviscan-upload', () => {
         skipped: 0,
         failed: 0,
         errors: [],
+        metadataLinkingAvailable: false,
       });
       expect(createClient).not.toHaveBeenCalled();
       expect(mockSupabaseClient.auth.signInWithPassword).not.toHaveBeenCalled();
@@ -338,6 +339,62 @@ describe('graviscan-upload', () => {
       expect(result.success).toBe(true);
       expect(result.uploaded).toBe(1);
       expect(result.errors).toHaveLength(0);
+      // Surfaced on the result (not just logged) so a future renderer can
+      // show operators that metadata linking isn't active — console.log is
+      // invisible in a packaged Electron app.
+      expect(result.metadataLinkingAvailable).toBe(false);
+    });
+
+    it('reports metadataLinkingAvailable=true when the store implements both session and metadata RPCs', async () => {
+      mockStore.insertGraviScanSession = vi
+        .fn()
+        .mockResolvedValue({ created: 10, error: null });
+      mockStore.insertGraviScanMetadata = vi
+        .fn()
+        .mockResolvedValue({ created: 20, error: null });
+
+      db.graviScan.findMany.mockResolvedValue([makeScan()]);
+
+      const result = await uploadAllPendingScans(db);
+
+      expect(result.success).toBe(true);
+      expect(result.metadataLinkingAvailable).toBe(true);
+      expect(mockStore.insertGraviScanSession).not.toHaveBeenCalled(); // no session on this scan
+      expect(mockStore.insertGraviScanMetadata).not.toHaveBeenCalled(); // no accession on this scan
+    });
+
+    it('reports metadataLinkingAvailable=false when only one of the two RPCs is implemented', async () => {
+      mockStore.insertGraviScanSession = vi
+        .fn()
+        .mockResolvedValue({ created: 10, error: null });
+      // insertGraviScanMetadata intentionally left unimplemented.
+
+      db.graviScan.findMany.mockResolvedValue([makeScan()]);
+
+      const result = await uploadAllPendingScans(db);
+
+      expect(result.metadataLinkingAvailable).toBe(false);
+    });
+  });
+
+  describe('uploadAllPendingScans — metadataLinkingAvailable on early-return paths', () => {
+    it('reports false when there is no pending work (never checked the store)', async () => {
+      db.graviScan.findMany.mockResolvedValue([]);
+
+      const result = await uploadAllPendingScans(db);
+
+      expect(result.metadataLinkingAvailable).toBe(false);
+    });
+
+    it('reports false when credentials are missing', async () => {
+      (loadEnvConfig as Mock).mockReturnValue({
+        ...mockCredentials,
+        bloom_scanner_username: '',
+      });
+
+      const result = await uploadAllPendingScans(db);
+
+      expect(result.metadataLinkingAvailable).toBe(false);
     });
   });
 });

--- a/tests/unit/graviscan-upload.test.ts
+++ b/tests/unit/graviscan-upload.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Unit tests for graviscan-upload module
+ *
+ * Ported feature (task 6, GraviScan backend hardening): Bloom (Supabase)
+ * upload re-enabled alongside Box backup. This file shipped with zero test
+ * coverage on the stranded branch it was ported from — these are new,
+ * written per this project's TDD discipline.
+ *
+ * All Supabase/network interaction is mocked. Real end-to-end upload against
+ * production Supabase/Bloom requires live credentials this environment
+ * doesn't have — that remains a manual verification step (see
+ * task-6-report.md).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, beforeEach, vi, Mock } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('@salk-hpi/bloom-js', () => ({
+  SupabaseStore: vi.fn(),
+  SupabaseUploader: vi.fn(),
+}));
+
+vi.mock('../../src/main/config-store', () => ({
+  loadEnvConfig: vi.fn(),
+}));
+
+vi.mock('../../src/main/graviscan-path-utils', () => ({
+  resolveGraviScanPath: vi.fn((p: string) => p),
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readFile: vi.fn().mockResolvedValue(Buffer.from('fake-tiff-bytes')),
+    },
+  };
+});
+
+import { createClient } from '@supabase/supabase-js';
+import { SupabaseStore, SupabaseUploader } from '@salk-hpi/bloom-js';
+import { loadEnvConfig } from '../../src/main/config-store';
+import { resolveGraviScanPath } from '../../src/main/graviscan-path-utils';
+
+import { uploadAllPendingScans } from '../../src/main/graviscan-upload';
+
+const mockCredentials = {
+  scanner_mode: 'graviscan' as const,
+  scanner_name: 'TestScanner',
+  camera_ip_address: 'mock',
+  scans_dir: '/test/scans',
+  bloom_api_url: 'https://api.bloom.salk.edu/proxy',
+  bloom_scanner_username: 'scanner@salk.edu',
+  bloom_scanner_password: 'password123',
+  bloom_anon_key: 'test-anon-key',
+  num_frames: 72,
+  seconds_per_rot: 7.0,
+};
+
+function makeScan(overrides: Partial<any> = {}) {
+  return {
+    id: overrides.id ?? 'scan-1',
+    scanner: { name: 'GraviScanner1' },
+    phenotyper: { name: 'Test Phenotyper', email: 'phenotyper@salk.edu' },
+    experiment: {
+      name: 'Test Experiment',
+      species: 'arabidopsis',
+      scientist: { name: 'Dr. Test', email: 'scientist@salk.edu' },
+      accession: null,
+    },
+    plate_barcode: 'PLATE-001',
+    capture_date: new Date('2026-07-01T00:00:00Z'),
+    grid_mode: '2grid',
+    plate_index: '00',
+    resolution: 1200,
+    format: 'tiff',
+    cycle_number: null,
+    wave_number: 0,
+    session_id: null,
+    session: null,
+    images: [{ id: 'img-1', path: '/scans/img-1.tiff' }],
+    ...overrides,
+  };
+}
+
+function createMockDb() {
+  return {
+    graviScan: {
+      findMany: vi.fn().mockResolvedValue([]),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    graviImage: {
+      update: vi.fn().mockResolvedValue({}),
+    },
+  } as any;
+}
+
+describe('graviscan-upload', () => {
+  let db: ReturnType<typeof createMockDb>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockSupabaseClient: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockStore: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockUploader: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = createMockDb();
+
+    (loadEnvConfig as Mock).mockReturnValue(mockCredentials);
+    (resolveGraviScanPath as Mock).mockImplementation((p: string) => p);
+
+    mockSupabaseClient = {
+      auth: {
+        signInWithPassword: vi.fn().mockResolvedValue({ error: null }),
+      },
+    };
+    (createClient as Mock).mockReturnValue(mockSupabaseClient);
+
+    mockStore = {
+      insertGraviImageMetadata: vi
+        .fn()
+        .mockResolvedValue({ created: 1, error: null }),
+      updateGraviImageMetadata: vi.fn().mockResolvedValue({ error: null }),
+    };
+    (SupabaseStore as unknown as Mock).mockImplementation(() => mockStore);
+
+    mockUploader = {
+      supabase: {
+        storage: {
+          from: vi.fn().mockReturnValue({
+            upload: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        },
+      },
+    };
+    (SupabaseUploader as unknown as Mock).mockImplementation(
+      () => mockUploader
+    );
+  });
+
+  describe('uploadAllPendingScans — no pending work', () => {
+    it('returns success with all-zero counts and never calls Supabase auth', async () => {
+      db.graviScan.findMany.mockResolvedValue([]);
+
+      const result = await uploadAllPendingScans(db);
+
+      expect(result).toEqual({
+        success: true,
+        uploaded: 0,
+        skipped: 0,
+        failed: 0,
+        errors: [],
+      });
+      expect(createClient).not.toHaveBeenCalled();
+      expect(mockSupabaseClient.auth.signInWithPassword).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('uploadAllPendingScans — missing/invalid credentials', () => {
+    it('returns failure without querying the DB when credentials are missing', async () => {
+      (loadEnvConfig as Mock).mockReturnValue({
+        ...mockCredentials,
+        bloom_scanner_username: '',
+        bloom_scanner_password: '',
+      });
+
+      const result = await uploadAllPendingScans(db);
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('Bloom credentials not found');
+      expect(db.graviScan.findMany).not.toHaveBeenCalled();
+      expect(createClient).not.toHaveBeenCalled();
+    });
+
+    it('returns failure without touching image/scan records when Supabase auth itself fails', async () => {
+      db.graviScan.findMany.mockResolvedValue([makeScan()]);
+      mockSupabaseClient.auth.signInWithPassword.mockResolvedValue({
+        error: { message: 'Invalid login credentials' },
+      });
+
+      const result = await uploadAllPendingScans(db);
+
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toContain('Authentication failed');
+      expect(db.graviImage.update).not.toHaveBeenCalled();
+      expect(db.graviScan.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('uploadAllPendingScans — concurrency bounding', () => {
+    it('never has more than 4 image uploads in flight at once', async () => {
+      const scans = Array.from({ length: 6 }, (_, i) =>
+        makeScan({
+          id: `scan-${i}`,
+          images: [{ id: `img-${i}`, path: `/scans/img-${i}.tiff` }],
+        })
+      );
+      db.graviScan.findMany.mockResolvedValue(scans);
+
+      const callOrder: string[] = [];
+      const resolvers: Array<() => void> = [];
+      let callIndex = 0;
+
+      mockStore.insertGraviImageMetadata.mockImplementation(() => {
+        const idx = ++callIndex;
+        callOrder.push(`start:${idx}`);
+        return new Promise((resolve) => {
+          resolvers[idx] = () => {
+            callOrder.push(`end:${idx}`);
+            resolve({ created: idx, error: null });
+          };
+        });
+      });
+
+      const resultPromise = uploadAllPendingScans(db);
+
+      // Flush microtasks so all workers that CAN start have started.
+      await new Promise((r) => setTimeout(r, 0));
+
+      // With 6 jobs and 4 workers, exactly 4 should have started — the
+      // remaining 2 are queued behind the worker pool's cursor.
+      expect(callOrder.filter((c) => c.startsWith('start:'))).toHaveLength(4);
+
+      // Finish the first in-flight call; only then should a 5th start.
+      resolvers[1]();
+      await new Promise((r) => setTimeout(r, 0));
+      expect(callOrder.filter((c) => c.startsWith('start:'))).toHaveLength(5);
+
+      // Finish another; only then should the 6th (last) start.
+      resolvers[2]();
+      await new Promise((r) => setTimeout(r, 0));
+      expect(callOrder.filter((c) => c.startsWith('start:'))).toHaveLength(6);
+
+      // All 6 jobs have now started (none queued) — resolve the rest so the
+      // batch can complete.
+      resolvers[3]();
+      resolvers[4]();
+      resolvers[5]();
+      resolvers[6]();
+
+      const result = await resultPromise;
+      expect(result.success).toBe(true);
+      expect(result.uploaded).toBe(6);
+    });
+  });
+
+  describe('uploadAllPendingScans — per-image failure isolation', () => {
+    it('marks a failed image as failed in the DB without aborting the rest of the batch', async () => {
+      const scans = [
+        makeScan({
+          id: 'scan-1',
+          images: [{ id: 'img-1', path: '/scans/1.tiff' }],
+        }),
+        makeScan({
+          id: 'scan-2',
+          images: [{ id: 'img-2', path: '/scans/2.tiff' }],
+        }),
+        makeScan({
+          id: 'scan-3',
+          images: [{ id: 'img-3', path: '/scans/3.tiff' }],
+        }),
+      ];
+      db.graviScan.findMany.mockResolvedValue(scans);
+
+      // insertGraviImageMetadata uses the default beforeEach mock (always
+      // succeeds). Make the raw storage upload fail only for img-2's
+      // generated storage path to exercise per-image failure isolation.
+      // Storage paths are `gravi-images/<original-basename>_<random>.tiff` —
+      // match on the basename prefix, not a raw substring, since the random
+      // suffix could coincidentally contain "2" for another image.
+      mockUploader.supabase.storage.from.mockReturnValue({
+        upload: vi.fn().mockImplementation((storagePath: string) => {
+          if (storagePath.startsWith('gravi-images/2_')) {
+            return Promise.resolve({
+              error: { message: 'Storage upload failed' },
+            });
+          }
+          return Promise.resolve({ error: null });
+        }),
+      });
+
+      const result = await uploadAllPendingScans(db);
+
+      expect(result.success).toBe(false);
+      expect(result.uploaded).toBe(2);
+      expect(result.failed).toBe(1);
+      expect(db.graviImage.update).toHaveBeenCalledWith({
+        where: { id: 'img-2' },
+        data: { status: 'failed' },
+      });
+      expect(db.graviImage.update).toHaveBeenCalledWith({
+        where: { id: 'img-1' },
+        data: { status: 'uploaded' },
+      });
+      expect(db.graviImage.update).toHaveBeenCalledWith({
+        where: { id: 'img-3' },
+        data: { status: 'uploaded' },
+      });
+    });
+  });
+
+  describe('uploadAllPendingScans — session/metadata upload capability detection', () => {
+    it('does not fail the image upload when the installed bloom-js lacks insertGraviScanSession/insertGraviScanMetadata', async () => {
+      // mockStore intentionally has no insertGraviScanSession/insertGraviScanMetadata
+      // methods, matching the installed @salk-hpi/bloom-js@0.2.1 — this test
+      // pins that the image upload still succeeds rather than being marked
+      // failed just because these optional, not-yet-implemented RPCs are absent.
+      const scan = makeScan({
+        session_id: 'session-1',
+        session: {
+          scan_mode: 'single',
+          interval_seconds: null,
+          duration_seconds: null,
+          total_cycles: null,
+          started_at: new Date('2026-07-01T00:00:00Z'),
+          completed_at: null,
+          cancelled: false,
+        },
+      });
+      db.graviScan.findMany.mockResolvedValue([scan]);
+
+      const result = await uploadAllPendingScans(db);
+
+      expect(result.success).toBe(true);
+      expect(result.uploaded).toBe(1);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+});

--- a/tests/unit/graviscan/image-handlers.test.ts
+++ b/tests/unit/graviscan/image-handlers.test.ts
@@ -29,6 +29,10 @@ vi.mock('../../../src/main/box-backup', () => ({
   runBoxBackup: vi.fn(),
 }));
 
+vi.mock('../../../src/main/graviscan-upload', () => ({
+  uploadAllPendingScans: vi.fn(),
+}));
+
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
   return {
@@ -46,10 +50,12 @@ vi.mock('fs', async () => {
 import { app } from 'electron';
 import { resolveGraviScanPath } from '../../../src/main/graviscan-path-utils';
 import { runBoxBackup } from '../../../src/main/box-backup';
+import { uploadAllPendingScans } from '../../../src/main/graviscan-upload';
 import * as fs from 'fs';
 
 const mockResolvePath = vi.mocked(resolveGraviScanPath);
 const mockRunBoxBackup = vi.mocked(runBoxBackup);
+const mockUploadAllPendingScans = vi.mocked(uploadAllPendingScans);
 
 function createMockDb() {
   return {
@@ -78,6 +84,7 @@ describe('image-handlers', () => {
     vi.mocked(fs.readFileSync).mockReturnValue('');
     mockResolvePath.mockReset();
     mockRunBoxBackup.mockReset();
+    mockUploadAllPendingScans.mockReset();
     resetUploadState();
     sharpMockInstance.resize.mockClear();
     sharpMockInstance.jpeg.mockClear();
@@ -250,6 +257,18 @@ describe('image-handlers', () => {
   });
 
   describe('uploadAllScans', () => {
+    beforeEach(() => {
+      // Default: Bloom upload has nothing to do — most tests below only
+      // care about Box behavior unless they override this.
+      mockUploadAllPendingScans.mockResolvedValue({
+        success: true,
+        uploaded: 0,
+        skipped: 0,
+        failed: 0,
+        errors: [],
+      });
+    });
+
     it('should trigger box backup and report results', async () => {
       mockRunBoxBackup.mockResolvedValue({
         success: true,
@@ -277,6 +296,117 @@ describe('image-handlers', () => {
 
       expect(second.success).toBe(false);
       expect(second.errors).toContain('Upload already in progress');
+    });
+
+    it('should run Bloom and Box uploads in parallel', async () => {
+      mockUploadAllPendingScans.mockResolvedValue({
+        success: true,
+        uploaded: 3,
+        skipped: 0,
+        failed: 0,
+        errors: [],
+      });
+      mockRunBoxBackup.mockResolvedValue({
+        success: true,
+        experiments: 1,
+        filesCopied: 3,
+        errors: [],
+      } as any);
+
+      const result = await uploadAllScans(db);
+
+      expect(mockUploadAllPendingScans).toHaveBeenCalled();
+      expect(mockRunBoxBackup).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.uploaded).toBe(6); // 3 Bloom + 3 Box
+    });
+
+    it('should let Box complete successfully when Bloom upload fails', async () => {
+      mockUploadAllPendingScans.mockResolvedValue({
+        success: false,
+        uploaded: 0,
+        skipped: 0,
+        failed: 2,
+        errors: ['Bloom: authentication failed'],
+      });
+      mockRunBoxBackup.mockResolvedValue({
+        success: true,
+        experiments: 1,
+        filesCopied: 4,
+        errors: [],
+      } as any);
+
+      const result = await uploadAllScans(db);
+
+      // Box's success is not masked by Bloom's failure.
+      expect(mockRunBoxBackup).toHaveBeenCalled();
+      expect(result.success).toBe(false); // overall still false (Bloom failed)
+      expect(result.uploaded).toBe(4); // Box's files still counted
+      expect(result.failed).toBe(2);
+      expect(result.errors).toContain('Bloom: authentication failed');
+    });
+
+    it('should let Bloom complete successfully when Box backup fails', async () => {
+      mockUploadAllPendingScans.mockResolvedValue({
+        success: true,
+        uploaded: 5,
+        skipped: 0,
+        failed: 0,
+        errors: [],
+      });
+      mockRunBoxBackup.mockResolvedValue({
+        success: false,
+        experiments: 0,
+        filesCopied: 0,
+        errors: ['rclone not installed'],
+      } as any);
+
+      const result = await uploadAllScans(db);
+
+      // Bloom's success is not masked by Box's failure.
+      expect(mockUploadAllPendingScans).toHaveBeenCalled();
+      expect(result.success).toBe(false); // overall still false (Box failed)
+      expect(result.uploaded).toBe(5); // Bloom's uploads still counted
+      expect(result.errors).toContain('rclone not installed');
+    });
+
+    it('should isolate a thrown Bloom upload from a successful Box backup', async () => {
+      mockUploadAllPendingScans.mockRejectedValue(
+        new Error('Unexpected Bloom crash')
+      );
+      mockRunBoxBackup.mockResolvedValue({
+        success: true,
+        experiments: 1,
+        filesCopied: 2,
+        errors: [],
+      } as any);
+
+      const result = await uploadAllScans(db);
+
+      expect(result.success).toBe(false);
+      expect(result.uploaded).toBe(2); // Box still completed and is counted
+      expect(
+        result.errors.some((e) => e.includes('Unexpected Bloom crash'))
+      ).toBe(true);
+    });
+
+    it('should isolate a thrown Box backup from a successful Bloom upload', async () => {
+      mockUploadAllPendingScans.mockResolvedValue({
+        success: true,
+        uploaded: 3,
+        skipped: 0,
+        failed: 0,
+        errors: [],
+      });
+      mockRunBoxBackup.mockRejectedValue(new Error('Unexpected Box crash'));
+
+      const result = await uploadAllScans(db);
+
+      expect(result.success).toBe(false);
+      expect(result.uploaded).toBe(3); // Bloom still completed and is counted
+      expect(
+        result.errors.some((e) => e.includes('Unexpected Box crash'))
+      ).toBe(true);
     });
   });
 

--- a/tests/unit/graviscan/image-handlers.test.ts
+++ b/tests/unit/graviscan/image-handlers.test.ts
@@ -266,6 +266,7 @@ describe('image-handlers', () => {
         skipped: 0,
         failed: 0,
         errors: [],
+        metadataLinkingAvailable: false,
       });
     });
 
@@ -305,6 +306,7 @@ describe('image-handlers', () => {
         skipped: 0,
         failed: 0,
         errors: [],
+        metadataLinkingAvailable: false,
       });
       mockRunBoxBackup.mockResolvedValue({
         success: true,
@@ -321,6 +323,41 @@ describe('image-handlers', () => {
       expect(result.uploaded).toBe(6); // 3 Bloom + 3 Box
     });
 
+    it('should surface metadataLinkingAvailable from the Bloom result on the merged return value', async () => {
+      mockUploadAllPendingScans.mockResolvedValue({
+        success: true,
+        uploaded: 1,
+        skipped: 0,
+        failed: 0,
+        errors: [],
+        metadataLinkingAvailable: true,
+      });
+      mockRunBoxBackup.mockResolvedValue({
+        success: true,
+        experiments: 1,
+        filesCopied: 1,
+        errors: [],
+      } as any);
+
+      const result = await uploadAllScans(db);
+
+      expect(result.metadataLinkingAvailable).toBe(true);
+    });
+
+    it('should report metadataLinkingAvailable=false when Bloom upload throws', async () => {
+      mockUploadAllPendingScans.mockRejectedValue(new Error('Bloom crash'));
+      mockRunBoxBackup.mockResolvedValue({
+        success: true,
+        experiments: 1,
+        filesCopied: 1,
+        errors: [],
+      } as any);
+
+      const result = await uploadAllScans(db);
+
+      expect(result.metadataLinkingAvailable).toBe(false);
+    });
+
     it('should let Box complete successfully when Bloom upload fails', async () => {
       mockUploadAllPendingScans.mockResolvedValue({
         success: false,
@@ -328,6 +365,7 @@ describe('image-handlers', () => {
         skipped: 0,
         failed: 2,
         errors: ['Bloom: authentication failed'],
+        metadataLinkingAvailable: false,
       });
       mockRunBoxBackup.mockResolvedValue({
         success: true,
@@ -353,6 +391,7 @@ describe('image-handlers', () => {
         skipped: 0,
         failed: 0,
         errors: [],
+        metadataLinkingAvailable: false,
       });
       mockRunBoxBackup.mockResolvedValue({
         success: false,
@@ -397,6 +436,7 @@ describe('image-handlers', () => {
         skipped: 0,
         failed: 0,
         errors: [],
+        metadataLinkingAvailable: false,
       });
       mockRunBoxBackup.mockRejectedValue(new Error('Unexpected Box crash'));
 


### PR DESCRIPTION
## Summary

Increment 6 of the [GraviScan backend-hardening incremental port plan](docs/superpowers/plans/2026-07-24-graviscan-backend-hardening.md). GraviScan currently uploads scan images to Box only. This PR ports and re-enables Bloom (Supabase) upload alongside Box, running both in parallel.

## Important context: this was flagged and confirmed with the repo owner before implementation

The stranded branch's "re-enable Bloom upload" commit (`84b54e6`) is **itself an unmerged draft** ("Draft PR #222, kept open for reference") that restores the upload code path without ever fixing the reason it was originally disabled: the `api.bloom.salk.edu` proxy rejecting files over 50MB. No evidence was found anywhere in local branch history that this limit was ever addressed. **Confirmed resolved with the repo owner (2026-07-28) before any code was written.**

`src/main/graviscan-upload.ts` also does not exist anywhere on `main` — this is a full port (never carried over during the modular refactor), not a small re-enable, pinned specifically to source commit `84b54e6` rather than the stranded branch's current tip, which has since layered in unrelated, explicitly-deferred wave-scoped-metadata-linking work.

## Changes

- **New `src/main/graviscan-upload.ts`** — session upload → plate-metadata upload → per-image upload (4-worker bounded concurrency) to Supabase.
- **New `src/types/graviscan-store.ts`** — trimmed `SupabaseStore` type-extension shim, kept to only what's genuinely still missing from the installed `@salk-hpi/bloom-js@0.2.1`'s own types (some of the reference shim's types have since been upstreamed into the real package).
- **`src/main/graviscan/image-handlers.ts`** — `uploadAllScans()` now runs Bloom and Box in parallel via `Promise.allSettled`, isolating failures between the two targets (previously only Box existed, so there was no isolation concern).
- Adapted to `main`'s established conventions rather than the stranded branch's own: dynamic imports for `@supabase/supabase-js`/`@salk-hpi/bloom-js` (matching `image-uploader.ts`'s documented startup-performance rationale) and `loadEnvConfig()` for credentials instead of a duplicate hand-rolled `.env` parser.

### Real drift found in the installed package (verified by reading compiled JS, not just `.d.ts` files)

1. **`SupabaseUploader.uploadRawFile()` doesn't exist** in the installed package at all — worked around with a local helper calling `uploader.supabase.storage` directly (a genuinely public property, confirmed).
2. **Field name mismatch: `plant_barcode`, not `plate_barcode`.** The reference source file (and GraviScan's own Prisma schema) uses `plate_barcode` — the installed package's actual RPC parameter is `plant_barcode`. A literal port would have silently sent an empty barcode on **every single uploaded image**, masked by a permissive type escape hatch (not a compile error). Fixed by explicitly mapping the field.
3. **`insertGraviScanSession`/`insertGraviScanMetadata` don't exist** in the installed package or its backend schema at all. Rather than a blind port (which would mark every Bloom upload as failed over functionality the backend doesn't support yet), session/metadata linking now feature-detects and skips gracefully — and a new `metadataLinkingAvailable` field on the result surfaces this so a future renderer can show it, rather than it being invisible in main-process console logs only.

All three findings were independently re-verified by the task reviewer against the compiled package source before this PR was finalized — see Code Review below.

## Testing

- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:unit -- graviscan-upload image-handlers` — 32/32 passing (zero test coverage existed on the source branch at all)
- [x] `npm run format:check` — clean
- [x] Full suite: same 6 pre-existing failures as unmodified `main` (Windows path-separator issues), verified via `git stash` comparison — no regressions

### Not verifiable in this environment (documented, not skipped)

Real end-to-end upload against production Supabase/Bloom and Box requires live credentials unavailable here. Specifically worth a manual pass before relying on this in production:
- Confirm the raw-storage-upload workaround actually succeeds against the real `graviscan-images` bucket with real TIFF files.
- Confirm `plant_barcode` really is the correct live RPC parameter name (verified only via reading compiled client code, not by calling the real API).

### Code Review

Went through subagent-driven-development. Task-level review specifically independently re-verified all three package-drift claims by reading the compiled `@salk-hpi/bloom-js` source directly (not trusting the implementer's report) — all three CONFIRMED, including that the `plate_barcode`/`plant_barcode` fix prevents a real, previously-unnoticed data-correctness bug in the reference source itself. One Important finding (feature-detection skip was only visible via console log) was fixed in one round — the `metadataLinkingAvailable` field now surfaces it — and re-verified clean by a scoped re-review.

## Related

Part of the GraviScan backend-hardening incremental port plan (Increment 6 of 9). Lands after Increments 1-5 (#258-#262).