### PR TITLE
feat(graviscan): embed exp_name, wave_number, st_timestamp, phenotyper_name in TIFF

### DIFF
--- a/openspec/changes/embed-tiff-metadata/proposal.md
+++ b/openspec/changes/embed-tiff-metadata/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+GraviScan TIFF files already embed hardware/capture provenance (`scanner_id`, `grid_mode`, `plate_index`, `resolution_dpi`, `scan_region_mm`, `capture_timestamp`, `bloom_version`) so files are self-describing without the local DB. They don't yet embed _experiment_-level provenance — which experiment, wave, row-start timestamp, and phenotyper produced a given scan. Every parameter that affects a scan output should appear alongside the images, matching this project's existing metadata-preservation value (already applied to hardware/capture parameters; this closes the gap for experiment-level ones).
+
+## What Changes
+
+- `_build_tiff_metadata()` in `python/graviscan/scan_worker.py` gains four new fields in the `ImageDescription` JSON: `exp_name`, `wave_number`, `st_timestamp`, `phenotyper_name`.
+- The row-start timestamp (`st_timestamp`) is wired with a real, already-computed value from `scan-coordinator.ts` (the same value already used to build each row's `_st_` filename segment) — no placeholder needed for this one field.
+- `exp_name`, `wave_number`, `phenotyper_name` are plumbed as optional fields through `PlateConfig`/the Python `plate` dict, defaulting to empty/zero. No renderer exists on `main` yet to supply real values for these three (that's Phase 1b work) — this change makes the plumbing ready so Phase 1b's renderer can supply them with no further backend changes.
+
+### Implementation constraints
+
+- No behavior change to existing embedded fields.
+- `_build_tiff_metadata()`'s existing positional-argument calling convention is preserved (new fields added as keyword arguments with defaults), not converted to a whole-dict signature — `main`'s Python call sites still pass individual fields positionally, unlike the (unmerged, draft) stranded-branch source commit this is adapted from.
+
+## Impact
+
+- Affected specs: `scanning`
+- Affected code:
+  - `python/graviscan/scan_worker.py` — `_build_tiff_metadata()` signature + `ImageDescription` JSON
+  - `src/types/graviscan.ts` — `PlateConfig` gains `exp_name?`, `wave_number?`, `phenotyper_name?`, `st_timestamp?`
+  - `src/main/graviscan/scan-coordinator.ts` — passes the real `st_timestamp` value through when forwarding plates to the Python worker

--- a/openspec/changes/embed-tiff-metadata/specs/scanning/spec.md
+++ b/openspec/changes/embed-tiff-metadata/specs/scanning/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: GraviScan TIFF Metadata Embedding
+
+The system SHALL embed scan provenance metadata into output TIFF images so files are self-describing for downstream analysis.
+
+#### Scenario: TIFF ImageDescription contains scan metadata
+
+- **GIVEN** a scan is performed by the scan worker (real or mock mode)
+- **WHEN** the output TIFF image is written
+- **THEN** TIFF tag 270 (ImageDescription) SHALL contain JSON with `scanner_id`, `grid_mode`, `plate_index`, `resolution_dpi`, `scan_region_mm`, `exp_name`, `wave_number`, `st_timestamp`, `phenotyper_name`, `capture_timestamp`, and `bloom_version`
+- **AND** `exp_name`, `wave_number`, and `phenotyper_name` SHALL default to an empty string / zero when not supplied by the caller (no renderer populates them yet)
+- **AND** `st_timestamp` SHALL reflect the actual row-start timestamp used to build the scan's output filename
+
+#### Scenario: TIFF resolution tags match scan DPI
+
+- **GIVEN** a scan is performed at a specific DPI resolution
+- **WHEN** the output TIFF image is written
+- **THEN** TIFF tags 282 (XResolution) and 283 (YResolution) SHALL match the scan resolution
+- **AND** TIFF tag 296 (ResolutionUnit) SHALL be set to inches (2)

--- a/openspec/changes/embed-tiff-metadata/tasks.md
+++ b/openspec/changes/embed-tiff-metadata/tasks.md
@@ -1,0 +1,15 @@
+## 1. Python
+
+- [ ] 1.1 Extend `_build_tiff_metadata()` with `exp_name`, `wave_number`, `st_timestamp`, `phenotyper_name` keyword params (defaults: `""`, `0`, `""`, `""`), embedded in the `ImageDescription` JSON
+- [ ] 1.2 Thread the 4 fields from `plate` dict (via `.get(key, default)`) through `_scan_plate` → `_sane_scan`/`_mock_scan` → `_build_tiff_metadata`
+
+## 2. TS plumbing (no renderer exists yet — plumbing only)
+
+- [ ] 2.1 `src/types/graviscan.ts`'s `PlateConfig` gains `exp_name?: string`, `wave_number?: number`, `phenotyper_name?: string`, `st_timestamp?: string`
+- [ ] 2.2 `scan-coordinator.ts` passes the real, already-computed row-start timestamp through as `st_timestamp` when forwarding plates to the Python worker
+
+## 3. Tests
+
+- [ ] 3.1 `_build_tiff_metadata()` unit tests for all 4 new fields, including defaults when absent
+- [ ] 3.2 Round-trip test: write a TIFF, read it back, assert all 4 fields present and correct (not just that the function runs)
+- [ ] 3.3 Real-hardware test (gated, rig currently offline): a real (non-mock) scan embeds the same 4 fields correctly — SANE and mock are separate code paths that could diverge

--- a/python/graviscan/scan_worker.py
+++ b/python/graviscan/scan_worker.py
@@ -51,11 +51,17 @@ def _build_tiff_metadata(
     plate_index: str,
     resolution: int,
     region,
+    exp_name: str = "",
+    wave_number: int = 0,
+    st_timestamp: str = "",
+    phenotyper_name: str = "",
 ) -> ImageFileDirectory_v2:
     """Build TIFF metadata tags for a scan image.
 
     Embeds scan provenance into standard TIFF tags so files are self-describing.
-    Structured metadata goes into ImageDescription as JSON.
+    Structured metadata (incl. experiment + phenotyper attribution) goes into
+    ImageDescription as JSON so the .tif is portable to Box, downstream
+    pipelines, or scientists' laptops without the local DB.
     """
     ifd = ImageFileDirectory_v2()
     ifd[270] = json.dumps(
@@ -70,6 +76,10 @@ def _build_tiff_metadata(
                 "width": region.width,
                 "height": region.height,
             },
+            "exp_name": exp_name,
+            "wave_number": wave_number,
+            "st_timestamp": st_timestamp,
+            "phenotyper_name": phenotyper_name,
             "capture_timestamp": datetime.now(timezone.utc).isoformat(),
             "bloom_version": _BLOOM_VERSION,
         }
@@ -283,6 +293,10 @@ class ScanWorker:
         grid_mode = plate.get("grid_mode", "2grid")
         resolution = plate.get("resolution", 300)
         output_path = plate.get("output_path", "/tmp/scan.jpg")
+        exp_name = plate.get("exp_name", "")
+        wave_number = plate.get("wave_number", 0)
+        st_timestamp = plate.get("st_timestamp", "")
+        phenotyper_name = plate.get("phenotyper_name", "")
         job_id = str(uuid.uuid4())
 
         emit_event(
@@ -299,11 +313,25 @@ class ScanWorker:
         try:
             if self.mock:
                 final_path = self._mock_scan(
-                    grid_mode, plate_index, resolution, output_path
+                    grid_mode,
+                    plate_index,
+                    resolution,
+                    output_path,
+                    exp_name,
+                    wave_number,
+                    st_timestamp,
+                    phenotyper_name,
                 )
             else:
                 final_path = self._sane_scan(
-                    grid_mode, plate_index, resolution, output_path
+                    grid_mode,
+                    plate_index,
+                    resolution,
+                    output_path,
+                    exp_name,
+                    wave_number,
+                    st_timestamp,
+                    phenotyper_name,
                 )
 
             duration_ms = int((time.time() - start_time) * 1000)
@@ -340,6 +368,10 @@ class ScanWorker:
         plate_index: str,
         resolution: int,
         output_path: str,
+        exp_name: str = "",
+        wave_number: int = 0,
+        st_timestamp: str = "",
+        phenotyper_name: str = "",
     ) -> str:
         """Perform a scan using python-sane directly.
 
@@ -404,7 +436,15 @@ class ScanWorker:
                 final_path = compose_output_path(output_path, et)
                 os.makedirs(os.path.dirname(final_path), exist_ok=True)
                 tiff_meta = _build_tiff_metadata(
-                    self.scanner_id, grid_mode, plate_index, resolution, region
+                    self.scanner_id,
+                    grid_mode,
+                    plate_index,
+                    resolution,
+                    region,
+                    exp_name,
+                    wave_number,
+                    st_timestamp,
+                    phenotyper_name,
                 )
                 image.save(
                     final_path, "TIFF", compression="tiff_lzw", tiffinfo=tiff_meta
@@ -553,7 +593,15 @@ class ScanWorker:
         self._device.cancel()
 
     def _mock_scan(
-        self, grid_mode: str, plate_index: str, resolution: int, output_path: str
+        self,
+        grid_mode: str,
+        plate_index: str,
+        resolution: int,
+        output_path: str,
+        exp_name: str = "",
+        wave_number: int = 0,
+        st_timestamp: str = "",
+        phenotyper_name: str = "",
     ) -> str:
         """Generate a mock scan image (checkerboard pattern).
 
@@ -587,7 +635,15 @@ class ScanWorker:
         final_path = compose_output_path(output_path, et)
         os.makedirs(os.path.dirname(final_path), exist_ok=True)
         tiff_meta = _build_tiff_metadata(
-            self.scanner_id, grid_mode, plate_index, resolution, region
+            self.scanner_id,
+            grid_mode,
+            plate_index,
+            resolution,
+            region,
+            exp_name,
+            wave_number,
+            st_timestamp,
+            phenotyper_name,
         )
         image.save(final_path, "TIFF", compression="tiff_lzw", tiffinfo=tiff_meta)
 

--- a/python/tests/test_scan_worker.py
+++ b/python/tests/test_scan_worker.py
@@ -1071,6 +1071,34 @@ class TestBuildTiffMetadata:
         ifd = _build_tiff_metadata("s1", "2grid", "01", 300, region)
         assert ifd[296] == 2  # inches
 
+    def test_embeds_exp_wave_st_phenotyper_when_supplied(self):
+        region = get_scan_region("2grid", "00")
+        ifd = _build_tiff_metadata(
+            "scanner-1",
+            "2grid",
+            "00",
+            300,
+            region,
+            exp_name="myexp",
+            wave_number=3,
+            st_timestamp="20260502T101530",
+            phenotyper_name="Alice",
+        )
+        desc = json.loads(ifd[270])
+        assert desc["exp_name"] == "myexp"
+        assert desc["wave_number"] == 3
+        assert desc["st_timestamp"] == "20260502T101530"
+        assert desc["phenotyper_name"] == "Alice"
+
+    def test_new_fields_default_when_omitted(self):
+        region = get_scan_region("2grid", "00")
+        ifd = _build_tiff_metadata("scanner-1", "2grid", "00", 300, region)
+        desc = json.loads(ifd[270])
+        assert desc["exp_name"] == ""
+        assert desc["wave_number"] == 0
+        assert desc["st_timestamp"] == ""
+        assert desc["phenotyper_name"] == ""
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Section 11 — Real Hardware (excluded from default runs / CI)
@@ -1123,6 +1151,64 @@ class TestRealHardwarePathComposition:
 
             # No write-then-rename: nothing exists at the original pre-_et_ path.
             assert not os.path.exists(output_path)
+        finally:
+            if final_path and os.path.exists(final_path):
+                os.remove(final_path)
+            w._shutdown()
+
+
+@pytest.mark.hardware
+class TestRealHardwareMetadataFields:
+    """11.2 real (non-mock) scan embeds exp_name/wave_number/st_timestamp/
+    phenotyper_name identically to the mock path.
+
+    SANE and mock are separate code paths in this file (_sane_scan vs
+    _mock_scan) and could diverge on how these new fields are threaded
+    through to `_build_tiff_metadata()`.
+
+    Requires the physical GraviScan rig (a real SANE scanner attached).
+    Excluded from default/CI runs via `-m "not hardware"` in pyproject.toml.
+
+    To run once the rig is back online:
+
+        GRAVISCAN_TEST_DEVICE=<device> uv run pytest python/tests/test_scan_worker.py -m hardware -v
+
+    where <device> is the SANE device name for the attached scanner, e.g.
+    "epkowa:interpreter:001:007".
+    """
+
+    def test_sane_scan_embeds_new_fields(self, tmp_path):
+        device = os.environ.get("GRAVISCAN_TEST_DEVICE", "")
+        if not device:
+            pytest.skip(
+                "GRAVISCAN_TEST_DEVICE not set — skipping real-hardware test. "
+                "Set it to the SANE device name of the attached scanner to run "
+                "this test on the physical rig."
+            )
+
+        w = ScanWorker(scanner_id="hw-test-scanner", device_name=device, mock=False)
+        assert w.initialize(), "Failed to initialize real SANE device"
+
+        output_path = str(tmp_path / "hwtest_st_20260301T120000_cy1_S1_00.tif")
+        final_path = None
+        try:
+            final_path = w._sane_scan(
+                "2grid",
+                "00",
+                300,
+                output_path,
+                "hw-exp",
+                7,
+                "20260301T120000",
+                "Hardware Tester",
+            )
+
+            img = Image.open(final_path)
+            desc = json.loads(img.tag_v2[270])
+            assert desc["exp_name"] == "hw-exp"
+            assert desc["wave_number"] == 7
+            assert desc["st_timestamp"] == "20260301T120000"
+            assert desc["phenotyper_name"] == "Hardware Tester"
         finally:
             if final_path and os.path.exists(final_path):
                 os.remove(final_path)

--- a/python/tests/test_tiff_metadata.py
+++ b/python/tests/test_tiff_metadata.py
@@ -31,6 +31,12 @@ class TestBuildTiffMetadata:
         assert "capture_timestamp" in desc
         assert "bloom_version" in desc
 
+        # New embedded fields default when omitted
+        assert desc["exp_name"] == ""
+        assert desc["wave_number"] == 0
+        assert desc["st_timestamp"] == ""
+        assert desc["phenotyper_name"] == ""
+
         # Software (305)
         assert ifd[305] == "Bloom Desktop / GraviScan"
 
@@ -41,6 +47,25 @@ class TestBuildTiffMetadata:
 
         # DateTime (306)
         assert len(ifd[306]) == 19  # "YYYY:MM:DD HH:MM:SS"
+
+    def test_embeds_new_fields_when_supplied(self):
+        region = get_scan_region("2grid", "00")
+        ifd = _build_tiff_metadata(
+            "scanner-001",
+            "2grid",
+            "00",
+            300,
+            region,
+            exp_name="exp",
+            wave_number=1,
+            st_timestamp="20260301T120000",
+            phenotyper_name="Alice",
+        )
+        desc = json.loads(ifd[270])
+        assert desc["exp_name"] == "exp"
+        assert desc["wave_number"] == 1
+        assert desc["st_timestamp"] == "20260301T120000"
+        assert desc["phenotyper_name"] == "Alice"
 
 
 class TestMockScanTiffMetadata:
@@ -79,6 +104,52 @@ class TestMockScanTiffMetadata:
 
             # DateTime
             assert 306 in tag_data
+
+    def test_mock_scan_embeds_new_fields(self):
+        """Round-trip: write a TIFF via _mock_scan, read it back, and
+        confirm exp_name/wave_number/st_timestamp/phenotyper_name are
+        embedded correctly when supplied."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "scan_st_20260301T120000_cy1_S1_00.tif")
+
+            worker = ScanWorker(
+                scanner_id="test-scanner", device_name="mock", mock=True
+            )
+            final_path = worker._mock_scan(
+                "2grid",
+                "00",
+                300,
+                output_path,
+                "myexp",
+                4,
+                "20260301T120000",
+                "Alice",
+            )
+
+            img = Image.open(final_path)
+            desc = json.loads(img.tag_v2[270])
+            assert desc["exp_name"] == "myexp"
+            assert desc["wave_number"] == 4
+            assert desc["st_timestamp"] == "20260301T120000"
+            assert desc["phenotyper_name"] == "Alice"
+
+    def test_mock_scan_new_fields_default_when_omitted(self):
+        """Round-trip: when the caller omits the new fields, they default
+        to empty/zero in the decoded ImageDescription JSON."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "scan_st_20260301T120000_cy1_S1_00.tif")
+
+            worker = ScanWorker(
+                scanner_id="test-scanner", device_name="mock", mock=True
+            )
+            final_path = worker._mock_scan("2grid", "00", 300, output_path)
+
+            img = Image.open(final_path)
+            desc = json.loads(img.tag_v2[270])
+            assert desc["exp_name"] == ""
+            assert desc["wave_number"] == 0
+            assert desc["st_timestamp"] == ""
+            assert desc["phenotyper_name"] == ""
 
     def test_mock_scan_different_grid_modes(self):
         """Verify metadata reflects the actual grid mode and plate index."""

--- a/src/main/graviscan/scan-coordinator.ts
+++ b/src/main/graviscan/scan-coordinator.ts
@@ -279,6 +279,7 @@ export class ScanCoordinator
           return {
             ...plate,
             output_path: path.join(dir, basename),
+            st_timestamp: stTimestamp,
           };
         });
 

--- a/src/types/graviscan.ts
+++ b/src/types/graviscan.ts
@@ -188,6 +188,10 @@ export interface PlateConfig {
   grid_mode: GridMode;
   resolution: number;
   output_path: string;
+  exp_name?: string;
+  wave_number?: number;
+  phenotyper_name?: string;
+  st_timestamp?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Increment 7 of the [GraviScan backend-hardening incremental port plan](docs/superpowers/plans/2026-07-24-graviscan-backend-hardening.md). GraviScan TIFFs already embed hardware/capture provenance. This adds experiment-level provenance: `exp_name`, `wave_number`, `st_timestamp`, `phenotyper_name`.

**Note on branch name:** originally targeted `feat/embed-tiff-metadata`, but that name collides with a pre-existing, unrelated **open draft PR #224** ("Draft PR #224, kept open for reference" — the exact stranded-branch PR referenced in this port's own source commit message). Renamed to avoid touching it. PR #224 is now fully superseded by this PR; worth closing at the repo owner's discretion.

## Changes

- `python/graviscan/scan_worker.py` — `_build_tiff_metadata()` gains `exp_name`, `wave_number`, `st_timestamp`, `phenotyper_name` as new keyword args with safe defaults (`""`, `0`, `""`, `""`), embedded in the existing `ImageDescription` JSON. Threaded through `_scan_plate` → `_sane_scan`/`_mock_scan`.
- `src/types/graviscan.ts` — `PlateConfig` gains the four fields, all optional.
- `src/main/graviscan/scan-coordinator.ts` — `st_timestamp` is wired with the real, already-computed row-start timestamp (the same value already used to build each row's `_st_` filename segment) — not a stub.

## Scope decision: adapted signature, not a literal port

The source commit (`7c67fa4`, itself an unmerged draft) changes `_build_tiff_metadata()` to take a whole `plate: dict` and read `plate["exp_name"]` etc. directly — assuming the component-dict plate shape from `b430428`, which `main` never adopted (Increment 3 made this same scoping call for `compose_output_path()`, for the same reason: that architecture depends on renderer/experiment plumbing that doesn't exist on `main`). This port instead keeps `_build_tiff_metadata()`'s existing positional-argument signature and adds the four new fields as keyword arguments with defaults — consistent with `main`'s actual current code shape.

No GraviScan renderer exists on `main` yet (confirmed: no `GraviScan.tsx`, no experiment/phenotyper tracking anywhere in `session-handlers.ts`), so `exp_name`/`wave_number`/`phenotyper_name` can't be sourced with real values today — that's Phase 1b work, and this PR plumbs them as optional fields defaulting to empty/zero, ready for a future renderer to supply real values with no further backend changes. `st_timestamp` is the one exception: it already has a real, computed value in the coordinator today, so it's wired for real rather than left a placeholder.

## Testing

- [x] `uv run pytest python/tests/test_scan_worker.py python/tests/test_tiff_metadata.py -v` — all passing, including new round-trip tests (write TIFF via `_mock_scan`, read back with `Image.open()`, decode `tag_v2[270]`, assert all 4 new fields) and one `@pytest.mark.hardware` test for a real (non-mock) SANE scan, following Increment 3's established hardware-test convention (env-var-gated device, rig currently offline — deferred to manual verification later)
- [x] `npx tsc --noEmit` — clean except one pre-existing, unrelated error in `src/main/graviscan-upload.ts` (Increment 6's file) — independently confirmed by the controller to reproduce on the unmodified base commit via `git stash`, not introduced by this PR
- [x] `npm run test:unit`, `npm run format:check` — clean, no regressions

### Code Review

Went through subagent-driven-development. Task-level review specifically verified every call site actually uses the brief's mandated positional-args style (not the reference's dict signature), confirmed `st_timestamp` is wired with a real value while the other three correctly avoid fabricated placeholders, and confirmed the round-trip tests genuinely exercise save/load (not just in-memory IFD inspection). Zero Critical/Important findings.

## Related

Part of the GraviScan backend-hardening incremental port plan (Increment 7 of 9). Lands after Increments 1-6 (#258-#263).