### PR TITLE
feat(graviscan): add reset-usb IPC handler for clean USB recovery (#182)

### DIFF
--- a/openspec/changes/add-reset-usb-button/proposal.md
+++ b/openspec/changes/add-reset-usb-button/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+When a scanner fails mid-session, the USB device disconnects and reconnects with a new device number (issue #182). The current "Reset & Re-detect" button runs `pkill` + lsusb but does not close SANE gracefully and leaves stale `usb_bus`/`usb_device` values in the database. The only reliable recovery is restarting the app.
+
+## What Changes
+
+- New IPC handler `graviscan:reset-usb` that performs a clean reset cycle:
+  1. Gracefully shuts down coordinator (`coordinator.shutdown()` — sends `quit` to each subprocess, SANE closes cleanly)
+  2. Clears `usb_bus` and `usb_device` on all enabled GraviScanner DB records (keeps `usb_port` for stable matching)
+  3. Waits 5s for USB bus release (hardcoded — this is a hardware constant, not configurable)
+  4. Calls `detectEpsonScanners()` for fresh lsusb scan
+  5. Matches detected scanners to DB records by `usb_port`, updates `usb_bus`/`usb_device`
+  6. Calls `coordinator.initialize()` with fresh ScannerConfigs
+  7. Returns `{ success, scanners: [{id, status}] }`
+- Replace "Reset & Re-detect" button label with "Reset USB" and call new handler
+- Keep old `graviscan:reset-scanners` handler until hardware-tested
+
+### Implementation constraints (from `/no-overengineering`, `/self-review`, `/code-standards`)
+
+- **No speculative UI.** No multi-step status display. Button shows "Resetting..." spinner during operation, then result.
+- **No env var for the 5s wait.** This is a USB hardware constant — hardcode as `USB_RELEASE_WAIT_MS = 5000`.
+- **No coordinator changes.** `shutdown()` and `initialize()` already exist and work.
+- **Error handling:** handler catches at the IPC boundary, returns `{ success: false, error }`. No nested try/catch layers.
+- **Type safety:** return type defined as interface in `src/types/graviscan.ts`. `import type` used in handler.
+- **Naming:** IPC channel `graviscan:reset-usb`. Handler logs with `[GraviScan:RESET-USB]` prefix.
+- **No backwards compat shims.** Old button code replaced directly.
+
+## Impact
+
+- Affected specs: `scanning`
+- Affected code:
+  - `src/main/graviscan-handlers.ts` — new `graviscan:reset-usb` handler (~40 lines)
+  - `src/renderer/ConfigureScanner.tsx` — replace button onClick + label (~5 lines changed)
+  - `src/types/electron.d.ts` — add `resetUsb` method signature
+  - `src/main/preload.ts` — expose `resetUsb` to renderer
+  - `src/types/graviscan.ts` — add `ResetUsbResult` interface

--- a/openspec/changes/add-reset-usb-button/specs/scanning/spec.md
+++ b/openspec/changes/add-reset-usb-button/specs/scanning/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Reset USB Scanner Connection
+
+The system SHALL provide a "Reset USB" button on the Configure Scanner page that gracefully shuts down all SANE connections, clears stale USB addresses from the database, re-detects scanners via lsusb, and re-initializes subprocesses.
+
+#### Scenario: Reset with all scanners connected
+
+- **GIVEN** scanners are configured and initialized
+- **WHEN** the user clicks "Reset USB"
+- **THEN** all scanner subprocesses SHALL be gracefully shut down via `coordinator.shutdown()`
+- **AND** `usb_bus` and `usb_device` SHALL be set to null on all enabled GraviScanner records
+- **AND** `usb_port` SHALL be preserved for stable matching
+- **AND** scanners SHALL be re-detected via lsusb with fresh bus/device numbers
+- **AND** detected scanners SHALL be matched to DB records by `usb_port`
+- **AND** subprocesses SHALL be re-initialized for matched scanners
+- **AND** the handler SHALL return per-scanner status (ready or disconnected)
+
+#### Scenario: Reset when a scanner is unplugged
+
+- **GIVEN** 5 scanners were configured but 1 has been physically unplugged
+- **WHEN** the user clicks "Reset USB"
+- **THEN** the 4 connected scanners SHALL be re-initialized with status "ready"
+- **AND** the unplugged scanner SHALL have status "disconnected"
+
+#### Scenario: Reset USB blocked during active scan
+
+- **GIVEN** a scan is in progress
+- **WHEN** the user views the Configure Scanner page
+- **THEN** the "Reset USB" button SHALL be disabled

--- a/openspec/changes/add-reset-usb-button/tasks.md
+++ b/openspec/changes/add-reset-usb-button/tasks.md
@@ -1,0 +1,20 @@
+## 1. Types
+
+- [x] 1.1 Add `ResetUsbResult` interface to `src/types/graviscan.ts`
+- [x] 1.2 Add `resetUsb(): Promise<ResetUsbResult>` to `ElectronAPI.graviscan` in `electron.d.ts`
+- [x] 1.3 Expose `resetUsb` in `preload.ts` context bridge
+
+## 2. IPC Handler
+
+- [x] 2.1 Add `graviscan:reset-usb` handler in `graviscan-handlers.ts`
+
+## 3. UI
+
+- [x] 3.1 Replace "Reset & Re-detect" button with "Reset USB" in `ConfigureScanner.tsx`
+
+## 4. Tests
+
+- [ ] 4.1 Unit test: handler shuts down coordinator, clears DB fields, re-detects, re-initializes
+- [ ] 4.2 Unit test: handler returns disconnected status for unplugged scanner
+- [ ] 4.3 Unit test: handler works when coordinator is null (no scanners configured yet)
+- [ ] 4.4 Unit test: handler works when lsusb returns 0 scanners

--- a/src/main/graviscan/register-handlers.ts
+++ b/src/main/graviscan/register-handlers.ts
@@ -78,6 +78,10 @@ export function registerGraviScanHandlers(
     wrapHandler(() => scannerHandlers.validateConfig(db))()
   );
 
+  ipcMain.handle('graviscan:reset-usb', () =>
+    wrapHandler(() => scannerHandlers.resetUsb(getCoordinator(), db))()
+  );
+
   // --- Session handlers ---
   ipcMain.handle('graviscan:start-scan', async (_event, params) => {
     // Reject if scan already in progress

--- a/src/main/graviscan/scanner-handlers.ts
+++ b/src/main/graviscan/scanner-handlers.ts
@@ -9,12 +9,15 @@
 
 import { PrismaClient } from '@prisma/client';
 import { detectEpsonScanners } from '../lsusb-detection';
+import type { ScanCoordinatorLike } from './session-handlers';
 import type {
   DetectedScanner,
   GraviConfig,
   GraviConfigInput,
   GraviScanner,
   GraviScanPlatformInfo,
+  ResetUsbResult,
+  ScannerConfig,
 } from '../../types/graviscan';
 
 // ---------------------------------------------------------------------------
@@ -22,6 +25,9 @@ import type {
 // ---------------------------------------------------------------------------
 
 const MOCK_SCANNER_COUNT = 2;
+
+/** Time to wait for USB bus to release after subprocess shutdown. */
+const USB_RELEASE_WAIT_MS = 5000;
 
 // ---------------------------------------------------------------------------
 // Helpers — mock-scanner construction & DB matching
@@ -584,6 +590,131 @@ export async function validateConfig(db: PrismaClient) {
       new: [] as DetectedScanner[],
       savedScanners: [] as GraviScanner[],
       detectedScanners: [] as DetectedScanner[],
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// resetUsb
+// ---------------------------------------------------------------------------
+
+/**
+ * Full USB reset: shutdown SANE → clear stale addresses → re-detect → re-initialize.
+ *
+ * Replaces the partial pkill-based reset with a clean lifecycle:
+ * 1. Graceful coordinator shutdown (sends quit to each subprocess, SANE closes)
+ * 2. Clear usb_bus/usb_device in DB (keeps usb_port for stable matching)
+ * 3. Wait for USB bus release
+ * 4. Fresh lsusb detection
+ * 5. Match to DB by usb_port, update usb_bus/usb_device
+ * 6. Re-initialize coordinator with fresh ScannerConfigs
+ */
+export async function resetUsb(
+  coordinator: ScanCoordinatorLike | null,
+  db: PrismaClient
+): Promise<ResetUsbResult> {
+  try {
+    // 1. Shutdown coordinator (graceful quit → SANE close → process exit)
+    if (coordinator) {
+      await coordinator.shutdown();
+    }
+
+    // 2. Clear stale USB addresses from DB (keep usb_port for matching)
+    await (db as any).graviScanner.updateMany({
+      where: { enabled: true },
+      data: { usb_bus: null, usb_device: null },
+    });
+
+    // 3. Wait for USB bus release
+    await new Promise((resolve) => setTimeout(resolve, USB_RELEASE_WAIT_MS));
+
+    // 4. Fresh detection
+    const mockEnabled = process.env.GRAVISCAN_MOCK?.toLowerCase() === 'true';
+    const savedScanners = await (db as any).graviScanner.findMany({
+      where: { enabled: true },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    let detectedScanners: DetectedScanner[];
+
+    if (mockEnabled) {
+      detectedScanners = savedScanners.map((s: any, i: number) => ({
+        name: s.name,
+        scanner_id: s.id,
+        usb_bus: 1,
+        usb_device: i + 1,
+        usb_port: s.usb_port || `1-${i + 1}`,
+        is_available: true,
+        vendor_id: s.vendor_id,
+        product_id: s.product_id,
+        sane_name: `epkowa:interpreter:001:${String(i + 1).padStart(3, '0')}`,
+      }));
+    } else {
+      const lsusbResult = detectEpsonScanners();
+      if (!lsusbResult.success) {
+        return {
+          success: false,
+          scanners: [],
+          error: lsusbResult.error || 'lsusb detection failed',
+        };
+      }
+      detectedScanners = lsusbResult.scanners;
+    }
+
+    // 5. Match detected → saved by usb_port, update usb_bus/usb_device
+    const detectedByPort = new Map<string, DetectedScanner>();
+    for (const detected of detectedScanners) {
+      if (detected.usb_port) {
+        detectedByPort.set(detected.usb_port, detected);
+      }
+    }
+
+    const scannerConfigs: ScannerConfig[] = [];
+    const scannerStatuses: Array<{
+      id: string;
+      status: 'ready' | 'disconnected';
+    }> = [];
+
+    for (const saved of savedScanners) {
+      const detected = saved.usb_port
+        ? detectedByPort.get(saved.usb_port)
+        : undefined;
+
+      if (!detected) {
+        scannerStatuses.push({ id: saved.id, status: 'disconnected' });
+        continue;
+      }
+
+      // Update DB with fresh USB address
+      await (db as any).graviScanner.update({
+        where: { id: saved.id },
+        data: {
+          usb_bus: detected.usb_bus,
+          usb_device: detected.usb_device,
+        },
+      });
+
+      scannerConfigs.push({
+        scannerId: saved.id,
+        saneName:
+          detected.sane_name ||
+          `epkowa:interpreter:${String(detected.usb_bus).padStart(3, '0')}:${String(detected.usb_device).padStart(3, '0')}`,
+        plates: [],
+      });
+      scannerStatuses.push({ id: saved.id, status: 'ready' });
+    }
+
+    // 6. Re-initialize coordinator
+    if (coordinator && scannerConfigs.length > 0) {
+      await coordinator.initialize(scannerConfigs);
+    }
+
+    return { success: true, scanners: scannerStatuses };
+  } catch (error) {
+    return {
+      success: false,
+      scanners: [],
+      error: error instanceof Error ? error.message : 'USB reset failed',
     };
   }
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -303,6 +303,7 @@ const graviAPI = {
   validateScanners: (ids: string[]) =>
     ipcRenderer.invoke('graviscan:validate-scanners', ids),
   validateConfig: () => ipcRenderer.invoke('graviscan:validate-config'),
+  resetUsb: () => ipcRenderer.invoke('graviscan:reset-usb'),
 
   // Session operations
   startScan: (params: any) =>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -38,6 +38,7 @@ import {
   PaginatedScansResponse,
 } from './database';
 import { UploadResult } from '../main/image-uploader';
+import { ResetUsbResult } from './graviscan';
 
 /**
  * Python backend API
@@ -508,6 +509,7 @@ export interface GraviAPI {
   getPlatformInfo: () => Promise<any>;
   validateScanners: (ids: string[]) => Promise<any>;
   validateConfig: () => Promise<any>;
+  resetUsb: () => Promise<ResetUsbResult>;
 
   // Session operations
   startScan: (params: any) => Promise<any>;

--- a/src/types/graviscan.ts
+++ b/src/types/graviscan.ts
@@ -205,6 +205,15 @@ export interface ScannerConfig {
 }
 
 /**
+ * Result of a full USB reset (shutdown → re-detect → re-initialize).
+ */
+export interface ResetUsbResult {
+  success: boolean;
+  scanners?: Array<{ id: string; status: 'ready' | 'disconnected' }>;
+  error?: string;
+}
+
+/**
  * Scanner state during scan operations.
  */
 export type ScannerState =

--- a/tests/unit/graviscan/register-handlers.test.ts
+++ b/tests/unit/graviscan/register-handlers.test.ts
@@ -62,6 +62,7 @@ const CHANNELS = [
   'graviscan:read-scan-image',
   'graviscan:upload-all-scans',
   'graviscan:download-images',
+  'graviscan:reset-usb',
 ];
 
 function createMockIpcMain() {
@@ -116,7 +117,7 @@ describe('registerGraviScanHandlers', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
-  it('registers all 15 IPC channels', () => {
+  it('registers all 16 IPC channels', () => {
     registerGraviScanHandlers(
       mockIpcMain as any,
       mockDb,
@@ -125,7 +126,7 @@ describe('registerGraviScanHandlers', () => {
       mockGetCoordinator
     );
 
-    expect(mockIpcMain.handle).toHaveBeenCalledTimes(15);
+    expect(mockIpcMain.handle).toHaveBeenCalledTimes(16);
     for (const channel of CHANNELS) {
       expect(mockIpcMain._handlers.has(channel)).toBe(true);
     }

--- a/tests/unit/graviscan/reset-usb-handler.test.ts
+++ b/tests/unit/graviscan/reset-usb-handler.test.ts
@@ -1,0 +1,202 @@
+// @vitest-environment node
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../../src/main/lsusb-detection', () => ({
+  detectEpsonScanners: vi.fn(),
+}));
+
+import { detectEpsonScanners } from '../../../src/main/lsusb-detection';
+import { resetUsb } from '../../../src/main/graviscan/scanner-handlers';
+import type { DetectedScanner } from '../../../src/types/graviscan';
+
+const mockDetect = vi.mocked(detectEpsonScanners);
+
+function createMockDb() {
+  return {
+    graviScanner: {
+      findMany: vi.fn().mockResolvedValue([]),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      update: vi.fn(),
+    },
+  } as any;
+}
+
+function createMockCoordinator() {
+  return {
+    isScanning: false,
+    initialize: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+const MOCK_SAVED_SCANNER_1 = {
+  id: 's1',
+  name: 'Scanner 1',
+  usb_port: '1-2',
+  vendor_id: '04b8',
+  product_id: '013a',
+  enabled: true,
+};
+
+const MOCK_SAVED_SCANNER_2 = {
+  id: 's2',
+  name: 'Scanner 2',
+  usb_port: '1-3',
+  vendor_id: '04b8',
+  product_id: '013a',
+  enabled: true,
+};
+
+const MOCK_DETECTED_1: DetectedScanner = {
+  name: 'Perfection V600 Photo',
+  scanner_id: 's1',
+  usb_bus: 1,
+  usb_device: 5,
+  usb_port: '1-2',
+  is_available: true,
+  vendor_id: '04b8',
+  product_id: '013a',
+  sane_name: 'epkowa:interpreter:001:005',
+};
+
+const MOCK_DETECTED_2: DetectedScanner = {
+  name: 'Perfection V600 Photo',
+  scanner_id: 's2',
+  usb_bus: 1,
+  usb_device: 6,
+  usb_port: '1-3',
+  is_available: true,
+  vendor_id: '04b8',
+  product_id: '013a',
+  sane_name: 'epkowa:interpreter:001:006',
+};
+
+describe('resetUsb', () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    vi.stubEnv('GRAVISCAN_MOCK', '');
+    mockDetect.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports ready for all saved scanners matched by usb_port and re-initializes the coordinator', async () => {
+    db.graviScanner.findMany.mockResolvedValue([
+      MOCK_SAVED_SCANNER_1,
+      MOCK_SAVED_SCANNER_2,
+    ]);
+    mockDetect.mockReturnValue({
+      success: true,
+      scanners: [MOCK_DETECTED_1, MOCK_DETECTED_2],
+      count: 2,
+    });
+    const coordinator = createMockCoordinator();
+
+    const resultPromise = resetUsb(coordinator, db);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+    expect(result.scanners).toEqual([
+      { id: 's1', status: 'ready' },
+      { id: 's2', status: 'ready' },
+    ]);
+    expect(coordinator.shutdown).toHaveBeenCalledTimes(1);
+    expect(db.graviScanner.updateMany).toHaveBeenCalledWith({
+      where: { enabled: true },
+      data: { usb_bus: null, usb_device: null },
+    });
+    expect(db.graviScanner.update).toHaveBeenCalledWith({
+      where: { id: 's1' },
+      data: { usb_bus: 1, usb_device: 5 },
+    });
+    expect(db.graviScanner.update).toHaveBeenCalledWith({
+      where: { id: 's2' },
+      data: { usb_bus: 1, usb_device: 6 },
+    });
+    expect(coordinator.initialize).toHaveBeenCalledWith([
+      { scannerId: 's1', saneName: 'epkowa:interpreter:001:005', plates: [] },
+      { scannerId: 's2', saneName: 'epkowa:interpreter:001:006', plates: [] },
+    ]);
+  });
+
+  it('reports disconnected for a saved scanner whose usb_port is not in the fresh detection results', async () => {
+    db.graviScanner.findMany.mockResolvedValue([
+      MOCK_SAVED_SCANNER_1,
+      MOCK_SAVED_SCANNER_2,
+    ]);
+    // Only scanner 1 is detected after replug; scanner 2's port vanished.
+    mockDetect.mockReturnValue({
+      success: true,
+      scanners: [MOCK_DETECTED_1],
+      count: 1,
+    });
+    const coordinator = createMockCoordinator();
+
+    const resultPromise = resetUsb(coordinator, db);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+    expect(result.scanners).toEqual([
+      { id: 's1', status: 'ready' },
+      { id: 's2', status: 'disconnected' },
+    ]);
+    // Only the matched scanner is included in the re-initialize call.
+    expect(coordinator.initialize).toHaveBeenCalledWith([
+      { scannerId: 's1', saneName: 'epkowa:interpreter:001:005', plates: [] },
+    ]);
+    expect(db.graviScanner.update).toHaveBeenCalledTimes(1);
+    expect(db.graviScanner.update).toHaveBeenCalledWith({
+      where: { id: 's1' },
+      data: { usb_bus: 1, usb_device: 5 },
+    });
+  });
+
+  it('skips shutdown/initialize when coordinator is null but still runs the DB-clear/redetect/match steps', async () => {
+    db.graviScanner.findMany.mockResolvedValue([MOCK_SAVED_SCANNER_1]);
+    mockDetect.mockReturnValue({
+      success: true,
+      scanners: [MOCK_DETECTED_1],
+      count: 1,
+    });
+
+    const resultPromise = resetUsb(null, db);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+    expect(result.scanners).toEqual([{ id: 's1', status: 'ready' }]);
+    expect(db.graviScanner.updateMany).toHaveBeenCalled();
+    expect(db.graviScanner.update).toHaveBeenCalledWith({
+      where: { id: 's1' },
+      data: { usb_bus: 1, usb_device: 5 },
+    });
+  });
+
+  it('returns gracefully without throwing when detection fails', async () => {
+    db.graviScanner.findMany.mockResolvedValue([MOCK_SAVED_SCANNER_1]);
+    mockDetect.mockReturnValue({
+      success: false,
+      error: 'lsusb not found',
+      scanners: [],
+      count: 0,
+    });
+    const coordinator = createMockCoordinator();
+
+    const resultPromise = resetUsb(coordinator, db);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(false);
+    expect(result.scanners).toEqual([]);
+    expect(result.error).toBe('lsusb not found');
+    expect(coordinator.initialize).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Increment 8 of the [GraviScan backend-hardening incremental port plan](docs/superpowers/plans/2026-07-24-graviscan-backend-hardening.md). Issue #182: when a scanner fails mid-session, its USB device disconnects and reconnects with a new device number, but nothing re-detects it — the only recovery today is restarting the app. Adds a clean, full USB-reset IPC handler.

## Changes

- **`src/main/graviscan/scanner-handlers.ts`** — new exported `resetUsb(coordinator, db)`: gracefully shuts down the coordinator, clears stale `usb_bus`/`usb_device` on all enabled `GraviScanner` DB records (keeping `usb_port` for stable matching), waits 5s for USB bus release, re-runs `detectEpsonScanners()`, matches detected scanners to DB records by `usb_port` (updating `usb_bus`/`usb_device` on match), and re-initializes the coordinator with whatever matched.
- **`src/main/graviscan/register-handlers.ts`** — registers `graviscan:reset-usb`, following the exact pattern already used for `graviscan:validate-config`.
- **`src/types/graviscan.ts`** — new `ResetUsbResult` interface (narrowed to `'ready' | 'disconnected'` status — the reference source's `'error'` status variant is never actually produced by any code path, so it wasn't ported).
- **`src/main/preload.ts`, `src/types/electron.d.ts`** — expose `resetUsb()` to the renderer, ready for Phase 1b's UI (no renderer button exists on `main` yet — this stops at the IPC-exposed contract, consistent with every other increment in this plan).
- **New `tests/unit/graviscan/reset-usb-handler.test.ts`** — imports and calls the *real* exported handler, not a reimplementation (see below).

## A known anti-pattern deliberately not carried forward

This plan's own 2026-07-24 audit found the stranded branch's own test for this feature (`tests/unit/reset-usb.test.ts`) reimplements the handler logic with injected mocks rather than testing the real exported handler — meaning it could pass even if the real handler were broken. This port's test instead imports `resetUsb` directly and mocks only `detectEpsonScanners()` (hardware) and the DB client, following the same convention already established by this file's `validateConfig` tests.

## Testing

- [x] `npx tsc --noEmit` — clean except one pre-existing, unrelated error in `src/main/graviscan-upload.ts` (Increment 6's file), independently confirmed by the controller across two prior increments to reproduce on the unmodified base commit
- [x] `npm run test:unit -- reset-usb scanner-handlers` — 25/25 passing across 2 test files
- [x] `npm run format:check` — clean

### Not verifiable in this environment (documented, not skipped)

Physical verification of issue #182's exact repro (unplug/replug a scanner mid-session, confirm recovery) requires the physical rig, currently offline — no test suite can perform a physical action. This handler's *logic* (DB updates, port matching, re-init sequencing) is fully covered by the new tests; the hardware-level "does it actually recover" check remains a manual step for later.

### Code Review

Went through subagent-driven-development. Task-level review specifically verified the null-coordinator case still performs DB-clear/redetect/match work (only `shutdown()`/`initialize()` calls are gated on a live coordinator), confirmed `usb_port` matching logic correctly excludes unmatched scanners from re-init, and confirmed the new test file genuinely exercises the real handler rather than mirroring its logic. Zero Critical/Important findings; one Minor test-coverage gap (no dedicated all-scanners-disconnected case, partially covered by the existing unplugged-scanner test) deferred to the final review.

## Related

Part of the GraviScan backend-hardening incremental port plan (Increment 8 of 9). Lands after Increments 1-7 (#258-#264). References issues #182, #161, #230, #203.