### PR TITLE
fix(graviscan): remove USBDEVFS_RESET from _reopen_device recovery path (#228)

### DIFF
--- a/docs/superpowers/plans/2026-07-29-graviscan-production-parity-gaps.md
+++ b/docs/superpowers/plans/2026-07-29-graviscan-production-parity-gaps.md
@@ -32,6 +32,7 @@ on the production branch yourself before treating any of this as still-accurate,
 since `main` may have moved since 2026-07-29.
 
 Key branch/commit references:
+
 - `main` (this plan's starting point): `ea6fb6a`
 - Production (`origin/fix/v600-wedge-followups-metadata_propogation_followup`): `18657bc`
 - Original 9-increment plan (for cross-reference / established conventions):
@@ -89,7 +90,7 @@ them exactly.)
 - Squash-merge convention: `gh pr merge <N> --squash --delete-branch=false`, then
   manually delete local branch (`git branch -D`), remote branch
   (`git push origin --delete`), and the worktree (`ExitWorktree action:"remove"
-  discard_changes:true` if using the native tool, or `git worktree remove` +
+discard_changes:true` if using the native tool, or `git worktree remove` +
   `git worktree prune` as fallback).
 - Auto-merge policy: the user previously approved auto-merging each clean increment
   without pausing for confirmation, reserving pauses for load-bearing ambiguity or
@@ -132,13 +133,14 @@ them exactly.)
 **This is the most important item in this entire plan.** `python/graviscan/scan_worker.py`
 on `main` still has `_reopen_device()` calling `self._reset_usb_device()` (line ~573
 as of `ea6fb6a`) on every device-reopen during error recovery. Production explicitly
-**removed** this call on 2026-05-21 (issue #228) because kernel-level USBDEVFS_RESET
-makes V600 wedges *worse* — it can trigger a controller FLR (function-level reset) that
+**removed** this call on 2026-05-21 (issue #228) because kernel-level USBDEVFS*RESET
+makes V600 wedges \_worse* — it can trigger a controller FLR (function-level reset) that
 fully detaches the scanner, requiring a physical AC power-cycle to recover. This is
 exactly the failure mode the entire `add-v600-wedge-followups` initiative exists to
 prevent.
 
 Confirm directly before starting:
+
 ```bash
 git show main:python/graviscan/scan_worker.py | grep -n "_reset_usb_device\|_reopen_device"
 git show origin/fix/v600-wedge-followups-metadata_propogation_followup:python/graviscan/scan_worker.py | sed -n '/def _reopen_device/,/def /p'
@@ -157,6 +159,7 @@ likely reflecting work that existed only on a stranded branch and was never actu
 ported.
 
 **Task**:
+
 1. Remove the `self._reset_usb_device()` call from `_reopen_device()`, matching
    production's fix exactly (delete the call, keep `_reset_usb_device()` itself
    defined and retained — production's own comment says it's "retained for
@@ -186,7 +189,7 @@ ported.
    `openspec/AGENTS.md`'s Directory Structure section) — the PR description is where
    this discrepancy gets recorded, not the archive.
 5. Check whether the same "checked but not actually implemented" pattern applies to
-   any *other* checkbox in that same archived tasks.md — task 3.5 has sibling items
+   any _other_ checkbox in that same archived tasks.md — task 3.5 has sibling items
    (3.5.1, 3.5.3, 3.5.4 per the file's numbering) worth a quick audit while you're in
    there, since if one was falsely checked, siblings might be too.
 
@@ -246,6 +249,7 @@ each small and independent of each other:
   idempotent `fs.promises.mkdir(dirPath, {recursive:true})`.
 
 Confirm via:
+
 ```bash
 git show origin/fix/v600-wedge-followups-metadata_propogation_followup:src/main/graviscan-handlers.ts | sed -n '1033,1070p;1770,1875p'
 ```
@@ -324,7 +328,7 @@ vs. production's equivalent in `graviscan-handlers.ts` (~line 2047-2247):
 
 1. **Wave-aware accession lookup** — production falls back to
    `db.graviExperimentWaveMetadata.findMany(...)` keyed by `(experiment_id,
-   wave_number)` when `experiment.accession_id` is null; `main` always uses the single
+wave_number)` when `experiment.accession_id` is null; `main` always uses the single
    legacy accession for every wave. **This is the same, already-known,
    already-deferred gap flagged during Increment 6 of the prior plan** — `main`'s
    Prisma schema has no `GraviExperimentWaveMetadata` model at all, and `main`'s
@@ -339,7 +343,7 @@ vs. production's equivalent in `graviscan-handlers.ts` (~line 2047-2247):
    is NOT tied to the wave-metadata schema gap — port it independently.
 3. **Different target-directory contract** — production auto-resolves
    `app.getPath('downloads')` and only needs `{experimentId, experimentName,
-   waveNumber?}`; `main`'s signature requires an explicit `targetDir: string` with no
+waveNumber?}`; `main`'s signature requires an explicit `targetDir: string` with no
    default. Since `main` has no renderer yet to supply a directory picker, decide
    whether to add the Downloads-folder default now (so a future renderer can omit
    `targetDir` entirely, matching production's simpler contract) or leave it explicit.
@@ -350,8 +354,8 @@ vs. production's equivalent in `graviscan-handlers.ts` (~line 2047-2247):
 Bundle if worth doing at all, otherwise explicitly defer each with a one-line reason
 in this plan's ledger:
 
-- `graviscan:cancel-scan` — production clears the session *before* awaiting
-  `coordinator.shutdown()`; `main` clears it *after*. A caller polling
+- `graviscan:cancel-scan` — production clears the session _before_ awaiting
+  `coordinator.shutdown()`; `main` clears it _after_. A caller polling
   `graviscan:get-scan-status` during that window sees different `isActive` values.
   Decide which ordering is actually correct (main's own comment on a different
   function suggests deferring session-clear until work is truly done is the
@@ -394,16 +398,16 @@ in this plan's ledger:
 Per Global Constraints ("formal proposal warranted = non-trivial new behavior, not a
 narrow bug fix" — the same test the prior plan applied throughout):
 
-| Increment | OpenSpec proposal? | Why |
-|---|---|---|
-| 1 — USBDEVFS_RESET | **No** | Live spec already correct; pure bug fix bringing code into compliance (verified directly, see Increment 1's own notes). |
-| 2 — verify-plates | **Yes** | New capability with no main counterpart at all — real new behavior. |
-| 3 — get-scanner-status / list-scan-files / ensure-dir | **Yes** | New IPC surface, new behavior. |
-| 4 — coordinator correctness | **Likely no**, but check `getScannerStatuses()` specifically — if bundled into Increment 3's proposal (per the suggested merge), it inherits that one; the `initErrors`-clear and `addScanner` race-guard fixes are narrow bug fixes on their own. |
-| 5 — `\|\|` vs `??` | **No** | One-line correctness fix, no behavior change from what was ever intended. |
-| 6 — `graviscan_system_name` | **Yes** | New config field, new persisted behavior — same shape as the prior plan's `slack_webhook_url`/`libusb_endpoint_recovery` work, which did get a proposal (folded into `add-v600-wedge-followups`). |
-| 7 — download-images gaps | **Yes**, for the `plates.csv`/`sections.csv` + target-dir-contract parts (new/changed behavior). The wave-metadata part is explicitly deferred, not implemented — no proposal needed for something not being done. |
-| 8 — minor items | **No**, or fold into whichever of 6/7's proposal is doing the adjacent work if actually implemented rather than deferred. |
+| Increment                                             | OpenSpec proposal?                                                                                                                                                                                                                                 | Why                                                                                                                                                                                               |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1 — USBDEVFS_RESET                                    | **No**                                                                                                                                                                                                                                             | Live spec already correct; pure bug fix bringing code into compliance (verified directly, see Increment 1's own notes).                                                                           |
+| 2 — verify-plates                                     | **Yes**                                                                                                                                                                                                                                            | New capability with no main counterpart at all — real new behavior.                                                                                                                               |
+| 3 — get-scanner-status / list-scan-files / ensure-dir | **Yes**                                                                                                                                                                                                                                            | New IPC surface, new behavior.                                                                                                                                                                    |
+| 4 — coordinator correctness                           | **Likely no**, but check `getScannerStatuses()` specifically — if bundled into Increment 3's proposal (per the suggested merge), it inherits that one; the `initErrors`-clear and `addScanner` race-guard fixes are narrow bug fixes on their own. |
+| 5 — `\|\|` vs `??`                                    | **No**                                                                                                                                                                                                                                             | One-line correctness fix, no behavior change from what was ever intended.                                                                                                                         |
+| 6 — `graviscan_system_name`                           | **Yes**                                                                                                                                                                                                                                            | New config field, new persisted behavior — same shape as the prior plan's `slack_webhook_url`/`libusb_endpoint_recovery` work, which did get a proposal (folded into `add-v600-wedge-followups`). |
+| 7 — download-images gaps                              | **Yes**, for the `plates.csv`/`sections.csv` + target-dir-contract parts (new/changed behavior). The wave-metadata part is explicitly deferred, not implemented — no proposal needed for something not being done.                                 |
+| 8 — minor items                                       | **No**, or fold into whichever of 6/7's proposal is doing the adjacent work if actually implemented rather than deferred.                                                                                                                          |
 
 Don't treat this table as gospel over your own judgment once you're actually looking
 at the code — it's a starting point, re-derive if something doesn't fit once you're in

--- a/python/graviscan/scan_worker.py
+++ b/python/graviscan/scan_worker.py
@@ -517,6 +517,14 @@ class ScanWorker:
         Parses bus:device from the SANE device name and issues USBDEVFS_RESET.
         This is a soft reset — the bus:device address stays the same.
         Only runs on Linux; silently skips on other platforms.
+
+        NOTE (2026-05-21, #228): This method is no longer called by
+        _reopen_device(). The V600 USB-wedge investigation found that
+        USBDEVFS_RESET makes wedges worse — it can trigger controller
+        FLR (function-level reset) and detach the scanner entirely. The
+        method is retained for testability and potential future
+        reconsideration; do NOT re-add a production call site without
+        revisiting the investigation summary (Section 1.2) and #228.
         """
         import platform
 
@@ -569,10 +577,15 @@ class ScanWorker:
             except Exception:
                 pass
 
-        # Flush stale USB bulk transfers before SANE reinit
-        self._reset_usb_device()
+        # USBDEVFS_RESET removed 2026-05-21 per investigation summary
+        # Section 1.2 and #228. Kernel-level reset makes V600 wedges
+        # worse (controller FLR detaches the scanner entirely). The
+        # _reset_usb_device() method is retained for testability.
 
-        # Let the USB bus settle after releasing the device
+        # Let the USB bus settle after releasing the device. The
+        # 3-second interval predates USBDEVFS_RESET removal; it is a
+        # conservative bus-settle pause that helps SANE re-enumerate
+        # cleanly even on non-wedge transient failures.
         time.sleep(3)
 
         log(self.scanner_id, f"Full SANE reinit for device: {self.device_name}")

--- a/python/tests/test_scan_worker_recovery.py
+++ b/python/tests/test_scan_worker_recovery.py
@@ -1,0 +1,198 @@
+"""Task 3.5 (#228): USBDEVFS_RESET removed from production recovery path.
+
+These tests verify that _reopen_device() no longer calls
+_reset_usb_device(), while preserving the rest of the recovery sequence
+(device.cancel → device.close → sane.exit → sleep(3) → sane.init →
+sane.open) and the existing 3-attempt retry-with-backoff.
+
+Per investigation summary Section 1.2 and #228, the USBDEVFS_RESET ioctl
+makes V600 wedges worse (controller FLR detaches the scanner entirely).
+The _reset_usb_device method itself is preserved for testability.
+"""
+
+import io
+import sys
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from python.graviscan.scan_worker import ScanWorker
+
+
+def _make_worker(scanner_id="test-scanner", device_name="epkowa:interpreter:001:007", mock=False):
+    """Make a real-mode (not mock) worker so _reopen_device executes."""
+    return ScanWorker(scanner_id=scanner_id, device_name=device_name, mock=mock)
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestReopenDeviceDoesNotCallResetUsbDevice:
+    """_reopen_device() SHALL NOT invoke _reset_usb_device()."""
+
+    def test_reopen_device_does_not_call_reset_usb_device(self):
+        """Spy on _reset_usb_device; assert it is never called from
+        _reopen_device on the happy path."""
+        w = _make_worker()
+        # Inject a mock sane module with init/open behaviour
+        mock_sane = MagicMock()
+        mock_sane.open.return_value = MagicMock()  # mock device
+        w._sane = mock_sane
+
+        with patch.object(w, "_reset_usb_device") as mock_reset, patch(
+            "python.graviscan.scan_worker.time.sleep"
+        ):
+            w._reopen_device()
+
+        assert mock_reset.call_count == 0, (
+            f"_reset_usb_device should not be called by _reopen_device "
+            f"(was called {mock_reset.call_count} times)"
+        )
+
+    def test_reopen_device_does_not_call_reset_usb_device_on_retry(self):
+        """Even when sane.open() fails on the first attempt and the
+        retry-with-backoff kicks in, _reset_usb_device SHALL NOT be
+        called."""
+        w = _make_worker()
+        mock_sane = MagicMock()
+        # First call raises, second succeeds
+        mock_sane.open.side_effect = [
+            RuntimeError("sane open failed once"),
+            MagicMock(),  # device on second try
+        ]
+        w._sane = mock_sane
+
+        with patch.object(w, "_reset_usb_device") as mock_reset, patch(
+            "python.graviscan.scan_worker.time.sleep"
+        ):
+            w._reopen_device()
+
+        assert mock_reset.call_count == 0
+
+
+class TestReopenDeviceCallsSaneSequenceInOrder:
+    """_reopen_device() SHALL still call device.cancel → device.close →
+    sane.exit → sleep(3) → sane.init → sane.open in that order."""
+
+    def test_full_recovery_sequence_in_order(self):
+        """Track call order of the key recovery operations."""
+        w = _make_worker()
+
+        # Set up a mock previous device + sane
+        mock_device = MagicMock()
+        mock_new_device = MagicMock()
+        w._device = mock_device
+        mock_sane = MagicMock()
+        mock_sane.open.return_value = mock_new_device
+        w._sane = mock_sane
+
+        # Single tracker to record call order across multiple mocks
+        call_order = []
+
+        def track(name):
+            return lambda *args, **kwargs: call_order.append(name) or MagicMock()
+
+        mock_device.cancel.side_effect = track("device.cancel")
+        mock_device.close.side_effect = track("device.close")
+        mock_sane.exit.side_effect = track("sane.exit")
+        mock_sane.init.side_effect = track("sane.init")
+        mock_sane.open.side_effect = lambda *args, **kwargs: (
+            call_order.append("sane.open"),
+            mock_new_device,
+        )[1]
+
+        with patch(
+            "python.graviscan.scan_worker.time.sleep",
+            side_effect=lambda s: call_order.append(f"sleep({s})") if s == 3 else None,
+        ):
+            w._reopen_device()
+
+        # Filter to the recovery steps we care about
+        recovery_steps = [
+            c
+            for c in call_order
+            if c
+            in {
+                "device.cancel",
+                "device.close",
+                "sane.exit",
+                "sleep(3)",
+                "sane.init",
+                "sane.open",
+            }
+        ]
+
+        assert recovery_steps == [
+            "device.cancel",
+            "device.close",
+            "sane.exit",
+            "sleep(3)",
+            "sane.init",
+            "sane.open",
+        ], f"unexpected order: {recovery_steps}"
+
+
+class TestResetUsbDeviceMethodPreserved:
+    """_reset_usb_device method MAY remain on the class for testability."""
+
+    def test_method_is_still_importable(self):
+        """The method SHALL still exist on the ScanWorker class so
+        existing tests at test_scan_worker.py:364-385 continue to
+        pass."""
+        w = _make_worker(mock=True)
+        assert hasattr(w, "_reset_usb_device")
+        assert callable(getattr(w, "_reset_usb_device"))
+
+    def test_method_does_not_raise_on_non_linux(self):
+        """Calling _reset_usb_device directly on a non-Linux platform
+        SHALL return early without raising (existing behavior)."""
+        w = _make_worker(mock=True)
+        # patch platform.system to return something non-Linux
+        with patch("platform.system", return_value="Windows"):
+            # Should be a no-op (no raise, no side effects we care about)
+            w._reset_usb_device()
+
+
+class TestNonWedgeTransientRecovery:
+    """Non-wedge transient failures (e.g., SANE-busy) SHALL still recover
+    via the standard sane.exit → sleep → sane.init → sane.open sequence
+    without USBDEVFS_RESET."""
+
+    def test_recovers_when_sane_open_succeeds_after_one_failure(self):
+        """Mock sane.open to fail once then succeed; assert _reopen_device
+        completes and the device attribute is set."""
+        w = _make_worker()
+        mock_sane = MagicMock()
+        mock_new_device = MagicMock()
+        mock_sane.open.side_effect = [
+            RuntimeError("SANE busy"),
+            mock_new_device,
+        ]
+        w._sane = mock_sane
+
+        with patch.object(w, "_reset_usb_device"), patch(
+            "python.graviscan.scan_worker.time.sleep"
+        ):
+            w._reopen_device()
+
+        # After recovery, device should be the new one returned by sane.open
+        assert w._device is mock_new_device
+        # sane.open was called twice (one fail, one success)
+        assert mock_sane.open.call_count == 2
+
+    def test_raises_after_three_open_failures(self):
+        """The existing 3-attempt retry-with-backoff SHALL be preserved:
+        if sane.open fails all 3 times, _reopen_device raises."""
+        w = _make_worker()
+        mock_sane = MagicMock()
+        mock_sane.open.side_effect = RuntimeError("persistent failure")
+        w._sane = mock_sane
+
+        with patch.object(w, "_reset_usb_device"), patch(
+            "python.graviscan.scan_worker.time.sleep"
+        ):
+            with pytest.raises(RuntimeError, match="Failed to reopen device"):
+                w._reopen_device()
+
+        # 3 attempts before giving up
+        assert mock_sane.open.call_count == 3

--- a/python/tests/test_scan_worker_recovery.py
+++ b/python/tests/test_scan_worker_recovery.py
@@ -10,9 +10,7 @@ makes V600 wedges worse (controller FLR detaches the scanner entirely).
 The _reset_usb_device method itself is preserved for testability.
 """
 
-import io
-import sys
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/python/tests/test_scan_worker_recovery.py
+++ b/python/tests/test_scan_worker_recovery.py
@@ -17,7 +17,9 @@ import pytest
 from python.graviscan.scan_worker import ScanWorker
 
 
-def _make_worker(scanner_id="test-scanner", device_name="epkowa:interpreter:001:007", mock=False):
+def _make_worker(
+    scanner_id="test-scanner", device_name="epkowa:interpreter:001:007", mock=False
+):
     """Make a real-mode (not mock) worker so _reopen_device executes."""
     return ScanWorker(scanner_id=scanner_id, device_name=device_name, mock=mock)
 
@@ -37,8 +39,9 @@ class TestReopenDeviceDoesNotCallResetUsbDevice:
         mock_sane.open.return_value = MagicMock()  # mock device
         w._sane = mock_sane
 
-        with patch.object(w, "_reset_usb_device") as mock_reset, patch(
-            "python.graviscan.scan_worker.time.sleep"
+        with (
+            patch.object(w, "_reset_usb_device") as mock_reset,
+            patch("python.graviscan.scan_worker.time.sleep"),
         ):
             w._reopen_device()
 
@@ -60,8 +63,9 @@ class TestReopenDeviceDoesNotCallResetUsbDevice:
         ]
         w._sane = mock_sane
 
-        with patch.object(w, "_reset_usb_device") as mock_reset, patch(
-            "python.graviscan.scan_worker.time.sleep"
+        with (
+            patch.object(w, "_reset_usb_device") as mock_reset,
+            patch("python.graviscan.scan_worker.time.sleep"),
         ):
             w._reopen_device()
 
@@ -135,7 +139,7 @@ class TestResetUsbDeviceMethodPreserved:
 
     def test_method_is_still_importable(self):
         """The method SHALL still exist on the ScanWorker class so
-        existing tests at test_scan_worker.py:364-385 continue to
+        existing tests at test_scan_worker.py:336-361 continue to
         pass."""
         w = _make_worker(mock=True)
         assert hasattr(w, "_reset_usb_device")
@@ -168,8 +172,9 @@ class TestNonWedgeTransientRecovery:
         ]
         w._sane = mock_sane
 
-        with patch.object(w, "_reset_usb_device"), patch(
-            "python.graviscan.scan_worker.time.sleep"
+        with (
+            patch.object(w, "_reset_usb_device"),
+            patch("python.graviscan.scan_worker.time.sleep"),
         ):
             w._reopen_device()
 
@@ -186,8 +191,9 @@ class TestNonWedgeTransientRecovery:
         mock_sane.open.side_effect = RuntimeError("persistent failure")
         w._sane = mock_sane
 
-        with patch.object(w, "_reset_usb_device"), patch(
-            "python.graviscan.scan_worker.time.sleep"
+        with (
+            patch.object(w, "_reset_usb_device"),
+            patch("python.graviscan.scan_worker.time.sleep"),
         ):
             with pytest.raises(RuntimeError, match="Failed to reopen device"):
                 w._reopen_device()


### PR DESCRIPTION
## Summary

Increment 1 (Critical, do first) of the [GraviScan production-parity-gaps plan](docs/superpowers/plans/2026-07-29-graviscan-production-parity-gaps.md). `python/graviscan/scan_worker.py`'s `_reopen_device()` was still calling `self._reset_usb_device()` on every device-reopen during error recovery — a kernel-level USBDEVFS_RESET that production explicitly removed on 2026-05-21 (issue #228) because it makes V600 scanner wedges *worse*: it can trigger a controller FLR (function-level reset) that fully detaches the scanner, requiring a physical AC power-cycle to recover. This is exactly the failure mode the `add-v600-wedge-followups` initiative exists to prevent, and it was still live on `main`.

## Why this slipped through — and was out of compliance with an already-correct spec

`main`'s live OpenSpec requirement (`openspec/specs/scanning/spec.md`, "Requirement: USBDEVFS_RESET Removed from Recovery Path") already states the correct behavior in full — the spec was never wrong. Only the code, and the archived proposal's task checklist, were.

The archived `openspec/changes/archive/2026-07-29-add-v600-wedge-followups/tasks.md` has Task 3.5 checked `[x]` on **6 separate items** (3.5.1 through 3.5.5, plus the aggregate test-count claim at 11.6) asserting this removal — including a specific regression test — was done. None of it was: no such test file existed on `main`, and the production call site was untouched. This work was never actually part of any of the prior 9-increment plan's dispatched scope; the checkboxes were inherited pre-checked from whatever originally staged the proposal document, most likely reflecting work that existed only on the stranded `fix/v600-wedge-followups*` branches (confirmed: the real fix is commit `5cde84a`, present on those branches, never merged to `main`) and was never actually ported.

Per this repo's convention, `openspec/changes/archive/` is a historical record and is not edited retroactively — this PR description is where the discrepancy is recorded. No OpenSpec change was needed for this PR: this is a narrow bug fix restoring already-documented intended behavior, not new behavior.

## Changes

- **`python/graviscan/scan_worker.py`** — removes the `self._reset_usb_device()` call from `_reopen_device()`, matching production's fix exactly. The `_reset_usb_device()` method itself is retained (unchanged body), for testability and potential future reconsideration, with a doc-comment warning future readers not to re-add a production call site without revisiting the investigation summary (Section 1.2) and #228. The deletion site and the retained 3-second bus-settle sleep both carry explanatory comments.
- **New `python/tests/test_scan_worker_recovery.py`** — 7 tests across 4 classes: asserts `_reopen_device()` makes zero calls to `_reset_usb_device` on both the happy path and the internal 3-attempt retry-with-backoff path, verifies the full recovery sequence order (`device.cancel → device.close → sane.exit → sleep(3) → sane.init → sane.open`), confirms `_reset_usb_device()` remains importable/callable and still no-ops on non-Linux, and confirms non-wedge transient failures still recover without USBDEVFS_RESET.

## Testing

- [x] TDD: RED confirmed (2/7 new tests failed against unmodified code — the exact `_reset_usb_device` zero-call assertions); GREEN after the fix (7/7 passing).
- [x] `pytest python/tests/test_scan_worker_recovery.py python/tests/test_scan_worker.py` — 63 passed, 1 skipped, 1 pre-existing unrelated failure (`TestUSBResetPathConstruction::test_path_from_device_name`, Windows-only `fcntl` import gap — passes on CI's Linux runner, not introduced by this change).
- [x] `uv run ruff check python/` and `uv run black --check python/` — both clean.

### Not verifiable in this environment (documented, not skipped)

Both `pbiob-gh-04` and `graviscan-ms-7c56` are offline (confirmed via `tailscale status`). Manual rig validation, once a rig is back online:

- [ ] Trigger a real wedge event and confirm recovery no longer triggers a controller FLR/detachment requiring physical power-cycle.
- [ ] Trigger a non-wedge transient failure (e.g., two `scanimage` processes racing) and confirm `_reopen_device()` still recovers cleanly via the standard sequence.

### Code Review

Went through `subagent-driven-development`: task-level review (spec + quality) plus a final whole-branch review on the most capable available model, given this increment's Critical severity. The final review independently verified the regression tests are non-vacuous by re-injecting the removed call into an in-memory copy of the module and confirming the spy catches it, grepped the codebase for any other direct or indirect USBDEVFS_RESET path (none found — `libusb-filter.c`'s `libusb_clear_halt` is endpoint-level, not a device reset; the `reset-usb` IPC handler and `WedgeDetector` don't invoke it either), and confirmed no conflicting assertions in the existing `test_scan_worker.py` suite. One Important finding (new test file failed `black --check` under this repo's locked black version) was fixed and re-reviewed clean. Remaining Minor findings (a still-slightly-imprecise docstring line-range citation, some intentionally-inert `patch.object` scaffolding, a minor test-robustness nit) were parked as non-blocking.

## Related

Part of the [GraviScan production-parity-gaps plan](docs/superpowers/plans/2026-07-29-graviscan-production-parity-gaps.md) (Increment 1 of 8). References issue #228 and the archived `add-v600-wedge-followups` proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)