### PR TITLE
fix(graviscan): use ?? instead of || for usb_bus/usb_device/usb_port

### DIFF
--- a/src/main/graviscan/scanner-upsert.ts
+++ b/src/main/graviscan/scanner-upsert.ts
@@ -88,9 +88,9 @@ export async function upsertScannerRow(
         display_name: payload.display_name ?? existing.display_name ?? null,
         vendor_id: payload.vendor_id,
         product_id: payload.product_id,
-        usb_port: payload.usb_port || null,
-        usb_bus: payload.usb_bus || null,
-        usb_device: payload.usb_device || null,
+        usb_port: payload.usb_port ?? null,
+        usb_bus: payload.usb_bus ?? null,
+        usb_device: payload.usb_device ?? null,
         // Critical fix (final-review #1): re-detecting a scanner MUST
         // re-enable it. Without this, a row disabled by
         // disableStaleScannerRows()/validateConfig()/disableScannerById()
@@ -113,12 +113,12 @@ export async function upsertScannerRow(
   const created = await (db as any).graviScanner.create({
     data: {
       name: payload.name,
-      display_name: payload.display_name || null,
+      display_name: payload.display_name ?? null,
       vendor_id: payload.vendor_id,
       product_id: payload.product_id,
-      usb_port: payload.usb_port || null,
-      usb_bus: payload.usb_bus || null,
-      usb_device: payload.usb_device || null,
+      usb_port: payload.usb_port ?? null,
+      usb_bus: payload.usb_bus ?? null,
+      usb_device: payload.usb_device ?? null,
       enabled: true,
     },
   });

--- a/tests/unit/graviscan/scanner-upsert.test.ts
+++ b/tests/unit/graviscan/scanner-upsert.test.ts
@@ -233,6 +233,53 @@ describe('upsertScannerRow', () => {
 
     expect(saved.display_name).toBe('Bench 3');
   });
+
+  it('preserves usb_device: 0 and usb_bus: 0 on CREATE (regression: nullish coalescing)', async () => {
+    const db = makeMockDb([]);
+
+    const saved = await upsertScannerRow(db as never, {
+      name: 'Scanner Zero',
+      vendor_id: '04b8',
+      product_id: '013c',
+      usb_port: '1-1',
+      usb_bus: 0,
+      usb_device: 0,
+    });
+
+    // usb_device and usb_bus of 0 are valid USB hardware addresses and must
+    // round-trip correctly, not be coerced to null by || operator
+    expect(saved.usb_bus).toBe(0);
+    expect(saved.usb_device).toBe(0);
+    expect(db._rows[0].usb_bus).toBe(0);
+    expect(db._rows[0].usb_device).toBe(0);
+  });
+
+  it('preserves usb_device: 0 and usb_bus: 0 on UPDATE (regression: nullish coalescing)', async () => {
+    const db = makeMockDb([
+      makeRow({
+        id: 'row-zero',
+        usb_port: '1-1',
+        usb_bus: 1,
+        usb_device: 7,
+      }),
+    ]);
+
+    const saved = await upsertScannerRow(db as never, {
+      name: 'Scanner Zero',
+      vendor_id: '04b8',
+      product_id: '013c',
+      usb_port: '1-1',
+      usb_bus: 0,
+      usb_device: 0,
+    });
+
+    // usb_device and usb_bus of 0 are valid USB hardware addresses and must
+    // round-trip correctly on UPDATE, not be coerced to null by || operator
+    expect(saved.usb_bus).toBe(0);
+    expect(saved.usb_device).toBe(0);
+    expect(db._rows[0].usb_bus).toBe(0);
+    expect(db._rows[0].usb_device).toBe(0);
+  });
 });
 
 describe('disableStaleScannerRows (#230)', () => {


### PR DESCRIPTION
## Summary

Increment 5 (Important, small) of the [GraviScan production-parity-gaps plan](docs/superpowers/plans/2026-07-29-graviscan-production-parity-gaps.md). `upsertScannerRow()` used `||` instead of `??` for `usb_port`/`usb_bus`/`usb_device` in both the UPDATE and CREATE blocks. Since `usb_bus`/`usb_device` can legitimately be `0` (a valid USB bus/device number), `||` silently coerced `0` to `null`, breaking the hardware-identity match key used by `detectScanners`/`resetUsb`/auto-init. Production uses `??`.

Also changed `display_name: payload.display_name || null` to `?? null` on the CREATE path for consistency with the UPDATE path (which already used `??` there) — same bug class, harmless, not separately tested.

## Testing

- TDD: 2 new regression tests (CREATE + UPDATE paths) asserting `usb_bus: 0`/`usb_device: 0` round-trip without coercion to `null`. Confirmed RED against the pre-fix code (reverted and re-ran: exactly the 2 new tests fail), GREEN after the fix.
- `npx vitest run tests/unit/graviscan/scanner-upsert.test.ts` — 25/25 passing.
- `tsc --noEmit` — one pre-existing, unrelated error in `graviscan-upload.ts` (confirmed present at base commit too, not introduced here).
- Task-level review: clean. Final whole-branch review: clean, ready to merge.

Follow-up (not in scope here, noted for later): `scanner-handlers.ts` has similar `||` defaults (`usb_bus || 1`, `usb_device || i + 1`, `usb_port || ...`) for constructing display/sane_name fallback strings — different in kind (placeholder ID synthesis, not the hardware-match key), but worth a future sweep since `0` is a valid value system-wide.

No OpenSpec proposal needed — narrow bug fix restoring intended behavior, matching this repo's own guidance to skip proposals for bug fixes.