### PR TITLE
feat(graviscan): add plates.csv/sections.csv exports and Downloads-folder default

### DIFF
--- a/openspec/changes/add-download-images-csv-exports/proposal.md
+++ b/openspec/changes/add-download-images-csv-exports/proposal.md
@@ -48,7 +48,7 @@ uses.
   `db.graviExperimentWaveMetadata.findMany(...)` fallback when
   `experiment.accession_id` is null). `main`'s Prisma schema has no
   `GraviExperimentWaveMetadata` model (`grep GraviExperimentWaveMetadata
-  prisma/schema.prisma` returns nothing), and `main`'s `ExperimentForm.tsx`
+prisma/schema.prisma` returns nothing), and `main`'s `ExperimentForm.tsx`
   zod schema still requires `accession_id` at experiment creation
   (`accession_id: z.string().min(1, 'Accession is required')`), so the
   null-accession case this fallback exists for cannot occur via `main`'s

--- a/openspec/changes/add-download-images-csv-exports/proposal.md
+++ b/openspec/changes/add-download-images-csv-exports/proposal.md
@@ -1,0 +1,81 @@
+## Why
+
+Production's GraviScan image download (`graviscan-handlers.ts`, `graviscan:download-images`
+handler) writes three CSVs per wave subfolder — `metadata.csv`, `plates.csv`,
+`sections.csv` — plus auto-resolves the user's Downloads folder so a single click
+downloads everything. `main`'s equivalent (`downloadImages()` in
+`src/main/graviscan/image-handlers.ts`) only writes `metadata.csv` and requires
+an explicit `targetDir` from the caller. Analysts who rely on the plate/section
+CSVs when working from `main`'s exports currently get nothing — the plate
+accession and section (plant QR / medium) data those files carry is silently
+dropped, even though `main`'s own Prisma schema already has the exact
+`GraviPlateAccession.sections -> GraviPlateSectionMapping` relation production
+uses.
+
+## What Changes
+
+- Add `plates.csv` (header: `experiment,wave_number,plate_id,accession,transplant_date,custom_note`,
+  one row per `GraviPlateAccession` linked to the experiment's legacy
+  accession) and `sections.csv` (header:
+  `experiment,wave_number,plate_id,section_id,plant_qr,medium`, one row per
+  `GraviPlateSectionMapping` under each plate) to each wave subfolder written
+  by `downloadImages()`, alongside the existing `metadata.csv`. Both new files
+  are written **only when there is data beyond the header row**, matching
+  production's "don't hand analysts an empty file" behavior.
+- Add `sections: true` to the existing `graviPlateAccessions` include in
+  `downloadImages()`'s `graviScan.findMany()` query so section data is
+  available without a second query.
+- Reuse the existing `csvEscape(value: string)` helper for the two new
+  files' cells, wrapping numeric/nullable source fields
+  (`wave_number`, `transplant_date`, `custom_note`, `medium`) with
+  `String(...)`/`?? ''` first, matching `metadata.csv`'s existing call-site
+  pattern. Both new files get the same UTF-8 BOM prefix (`'﻿'`) that
+  `metadata.csv` already uses, for consistency within `main`'s own wave-subfolder
+  CSV convention (Excel compatibility with non-ASCII free-text fields like
+  `custom_note`).
+- **Target-directory contract**: make `downloadImages()`'s `targetDir` param
+  optional, defaulting to `app.getPath('downloads')` when omitted. An
+  explicitly-provided `targetDir` still wins. This does not change any
+  existing caller (no renderer currently calls `downloadImages`/
+  `graviscan:download-images` — confirmed via search of `src/renderer/`), and
+  lets a future renderer match production's simpler one-click-download
+  contract (`{experimentId, experimentName, waveNumber?}`, no directory
+  picker) without a further signature change later.
+
+## Out of scope
+
+- **Wave-aware accession lookup** (production's
+  `db.graviExperimentWaveMetadata.findMany(...)` fallback when
+  `experiment.accession_id` is null). `main`'s Prisma schema has no
+  `GraviExperimentWaveMetadata` model (`grep GraviExperimentWaveMetadata
+  prisma/schema.prisma` returns nothing), and `main`'s `ExperimentForm.tsx`
+  zod schema still requires `accession_id` at experiment creation
+  (`accession_id: z.string().min(1, 'Accession is required')`), so the
+  null-accession case this fallback exists for cannot occur via `main`'s
+  current UI. This is the same gap already deferred during the prior plan's
+  Increment 6; it stays deferred here too, tied to a separate, not-yet-started
+  "add-wave-scoped-metadata-linking" initiative that needs the schema
+  migration first. `plates.csv`/`sections.csv` in this proposal are populated
+  from the same legacy single-accession link `metadata.csv` already uses
+  (`scan.experiment.accession.graviPlateAccessions`), so they are correct for
+  every experiment `main` can currently create — they just don't yet handle
+  the not-currently-reachable wave-metadata-linked case.
+- Any renderer UI (directory picker, download button, progress display) —
+  `main` has no renderer surface for GraviScan image download yet.
+- Changing `metadata.csv`'s header or row contents — it is already
+  byte-identical to production's.
+
+## Impact
+
+- **Affected specs:** `scanning` (MODIFIED: "GraviScan Image Operations")
+- **Affected code:**
+  - `src/main/graviscan/image-handlers.ts` (`downloadImages()`, ~lines
+    294-460)
+- **Tests:** `tests/unit/graviscan/image-handlers.test.ts` — new cases for
+  plates.csv/sections.csv presence, absence-when-empty, and the
+  targetDir-omitted Downloads-folder default.
+- **Database:** none — no schema change; `sections: true` is a query
+  include addition, not a migration.
+- **Renderer:** none — no `src/renderer/` caller of `downloadImages`/
+  `graviscan:download-images` exists yet; `targetDir` remains accepted (now
+  optional) so this is purely additive for future renderer work.

--- a/openspec/changes/add-download-images-csv-exports/specs/scanning/spec.md
+++ b/openspec/changes/add-download-images-csv-exports/specs/scanning/spec.md
@@ -1,0 +1,95 @@
+## MODIFIED Requirements
+
+### Requirement: GraviScan Image Operations
+
+The system SHALL provide image reading, export, and cloud backup as testable functions in `src/main/graviscan/image-handlers.ts`, using callback injection for progress reporting.
+
+#### Scenario: Read scan image as JPEG thumbnail
+
+- **GIVEN** a TIFF scan image exists on disk
+- **WHEN** `readScanImage(filePath)` is called without `full` option
+- **THEN** the system SHALL convert the TIFF to JPEG at quality 85
+- **AND** resize to 400px width (without enlargement)
+- **AND** return a base64 data URI
+
+#### Scenario: Read scan image at full resolution
+
+- **GIVEN** a TIFF scan image exists on disk
+- **WHEN** `readScanImage(filePath, { full: true })` is called
+- **THEN** the system SHALL convert the TIFF to JPEG at quality 95
+- **AND** return the full-resolution image as a base64 data URI
+
+#### Scenario: Handle missing scan image with path fallback
+
+- **GIVEN** the requested file path does not exist
+- **WHEN** `readScanImage(filePath)` is called
+- **THEN** the system SHALL attempt path resolution via `resolveGraviScanPath()` (extension fallback, `_et_` fallback)
+- **AND** return `{ success: false, error: 'File not found' }` if resolution fails
+
+#### Scenario: Get scan output directory
+
+- **GIVEN** the application is running
+- **WHEN** `getOutputDir()` is called
+- **THEN** the system SHALL compute the output path from `app.getAppPath()` (development) or `app.getPath('home')` (production) based on `NODE_ENV`
+- **AND** create the directory if it does not exist
+- **AND** return the resolved output directory path
+
+#### Scenario: Get output directory when directory creation fails
+
+- **GIVEN** the computed output path cannot be created (e.g., permissions error)
+- **WHEN** `getOutputDir()` is called
+- **THEN** the system SHALL return `{ success: false, error: '...' }` with the filesystem error
+
+#### Scenario: Download experiment images with metadata, plates, and sections CSVs
+
+- **GIVEN** an experiment has GraviScan images across multiple waves, with plate accessions and section mappings linked via the experiment's legacy accession
+- **WHEN** `downloadImages(db, { experimentId, experimentName, targetDir?, waveNumber? })` is called
+- **THEN** the system SHALL group images by wave number into subdirectories
+- **AND** write a `metadata.csv` per wave with experiment, plate, accession, and image columns (header: `experiment,wave_number,plate_barcode,plate_index,grid_mode,capture_date,accession,transplant_date,custom_note,image_filename`)
+- **AND** write a `plates.csv` per wave with one row per plate accession linked to the wave (header: `experiment,wave_number,plate_id,accession,transplant_date,custom_note`), only when there is at least one plate accession
+- **AND** write a `sections.csv` per wave with one row per section mapping under each plate (header: `experiment,wave_number,plate_id,section_id,plant_qr,medium`), only when there is at least one section mapping
+- **AND** copy image files with concurrent file copy operations
+- **AND** report progress via the injected `onProgress` callback
+
+#### Scenario: Omit plates.csv and sections.csv when there is no plate/section data
+
+- **GIVEN** an experiment's accession has no linked `GraviPlateAccession` records
+- **WHEN** `downloadImages(db, params)` is called
+- **THEN** the system SHALL still write `metadata.csv` per wave
+- **AND** SHALL NOT write `plates.csv` or `sections.csv` for that wave
+
+#### Scenario: Omit sections.csv when a plate has no section mappings
+
+- **GIVEN** a wave's plate accessions exist but none has any linked `GraviPlateSectionMapping` records
+- **WHEN** `downloadImages(db, params)` is called
+- **THEN** the system SHALL write `plates.csv` for that wave
+- **AND** SHALL NOT write `sections.csv` for that wave
+
+#### Scenario: Default target directory to the Downloads folder
+
+- **GIVEN** `downloadImages()` is called without a `targetDir`
+- **WHEN** the function resolves where to write the experiment's export folder
+- **THEN** the system SHALL default to `app.getPath('downloads')`
+- **AND** an explicitly-provided `targetDir` SHALL be used instead, without consulting `app.getPath('downloads')`
+
+#### Scenario: Download with no images found
+
+- **GIVEN** an experiment has no GraviScan images
+- **WHEN** `downloadImages(db, params)` is called
+- **THEN** the system SHALL return `{ success: true, total: 0, copied: 0, errors: [] }`
+
+#### Scenario: Upload pending scans to Bloom and Box in parallel
+
+- **GIVEN** scans exist with pending upload status
+- **WHEN** `uploadAllScans(db, onProgress)` is called
+- **THEN** the system SHALL trigger Bloom (Supabase) upload and Box backup (via `runBoxBackup()`) in parallel
+- **AND** Bloom upload SHALL upload each scan's session and plate metadata before its images, then upload images with bounded concurrency (4 workers)
+- **AND** if either upload target throws, the other SHALL still complete (failures isolated via `Promise.allSettled`, not a single combined `try` that aborts both)
+- **AND** the combined result SHALL report success only if both targets succeeded, with merged `uploaded`/`skipped`/`failed` counts and merged `errors`
+- **AND** report progress via the injected `onProgress` callback for each target independently
+
+#### Scenario: Reject concurrent upload
+
+- **GIVEN** an upload is already in progress (module-level `uploadInProgress` guard)
+- **WHEN** `uploadAllScans(db, onProgress)` is called
+- **THEN** the system SHALL return `{ success: false, errors: ['Upload already in progress'], uploaded: 0, skipped: 0, failed: 0 }`

--- a/openspec/changes/add-download-images-csv-exports/tasks.md
+++ b/openspec/changes/add-download-images-csv-exports/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Add plates.csv/sections.csv exports + Downloads-folder default
+
+TDD: write the test FIRST, watch it fail, then write the minimum code to make
+it pass.
+
+## 1. plates.csv / sections.csv
+
+- [x] 1.1 Write failing tests in `tests/unit/graviscan/image-handlers.test.ts`
+      (new cases in the `downloadImages` describe block):
+  - does not write `plates.csv`/`sections.csv` when the experiment has no
+    plate accessions (only `metadata.csv` is written).
+  - writes `plates.csv` with one row per plate accession and `sections.csv`
+    with one row per section mapping, with the exact confirmed headers and
+    correctly-escaped free-text fields (comma-containing `custom_note`).
+  - writes `plates.csv` but not `sections.csv` when a plate has no sections.
+- [x] 1.2 Add `sections: true` to the `graviPlateAccessions` include in
+      `downloadImages()`'s `graviScan.findMany()` query.
+- [x] 1.3 Add `platesHeader`/`sectionsHeader` constants and build
+      `platesRows`/`sectionsRows` per wave from the wave's plate accessions
+      (same source `scan.experiment.accession?.graviPlateAccessions` already
+      used for `metadata.csv`'s accession lookup), reusing `csvEscape()` with
+      `String(...)`/`?? ''` wrapping for numeric/nullable fields.
+- [x] 1.4 Write `plates.csv`/`sections.csv` only when their row arrays have
+      more than the header row (`length > 1`).
+- [x] 1.5 Confirm 1.1's tests pass.
+
+## 2. Target-directory contract
+
+- [x] 2.1 Write failing tests: `downloadImages()` defaults to
+      `app.getPath('downloads')` when `targetDir` is omitted; an explicit
+      `targetDir` is used as-is without consulting `app.getPath('downloads')`.
+- [x] 2.2 Make `targetDir` optional in `downloadImages()`'s params type;
+      resolve it to `params.targetDir ?? app.getPath('downloads')` at the top
+      of the function body.
+- [x] 2.3 Confirm 2.1's tests pass.
+
+## 3. Verification
+
+- [x] 3.1 `npx vitest run tests/unit/graviscan/image-handlers.test.ts` passes.
+- [x] 3.2 `npx vitest run tests/unit/graviscan/` passes except the two
+      pre-existing, unrelated Windows path-separator failures
+      (`register-handlers.test.ts` "allows paths within output directory",
+      `scan-coordinator.test.ts` "regex path rewriting only affects filename,
+      not directory") — confirmed failing identically on the base commit
+      before this change.
+- [x] 3.3 `npx tsc --noEmit` — confirm no new errors versus the base commit
+      (one pre-existing unrelated error in `graviscan-upload.ts:278` remains).
+- [x] 3.4 `npx prettier --check` passes on all touched files.
+- [x] 3.5 `openspec validate add-download-images-csv-exports --strict`
+      passes.
+- [x] 3.6 `npx eslint --resolve-plugins-relative-to . <touched files>` is
+      clean (workaround for this worktree's known `eslint-plugin-import`
+      duplicate-resolution conflict with `npm run lint`).

--- a/src/main/graviscan/image-handlers.ts
+++ b/src/main/graviscan/image-handlers.ts
@@ -296,7 +296,7 @@ export async function downloadImages(
   params: {
     experimentId: string;
     experimentName: string;
-    targetDir: string;
+    targetDir?: string;
     waveNumber?: number;
   },
   onProgress?: (progress: {
@@ -311,6 +311,11 @@ export async function downloadImages(
   errors: string[];
 }> {
   try {
+    // No explicit targetDir ⇒ default to the user's Downloads folder, so a
+    // future renderer can omit it entirely (matching production's simpler
+    // one-click-download contract). An explicit targetDir always wins.
+    const targetDir = params.targetDir ?? app.getPath('downloads');
+
     const scans = await (db as any).graviScan.findMany({
       where: {
         experiment_id: params.experimentId,
@@ -324,7 +329,9 @@ export async function downloadImages(
         experiment: {
           include: {
             accession: {
-              include: { graviPlateAccessions: true },
+              include: {
+                graviPlateAccessions: { include: { sections: true } },
+              },
             },
           },
         },
@@ -338,7 +345,7 @@ export async function downloadImages(
 
     // Sanitize experiment name for safe use as directory name
     const safeName = params.experimentName.replace(/[/\\:*?"<>|.]/g, '_');
-    const expDir = path.join(params.targetDir, safeName);
+    const expDir = path.join(targetDir, safeName);
 
     // Group scans by wave number for subfolder organization
     const waveGroups = new Map<number, typeof scans>();
@@ -350,18 +357,58 @@ export async function downloadImages(
 
     const csvHeader =
       'experiment,wave_number,plate_barcode,plate_index,grid_mode,capture_date,accession,transplant_date,custom_note,image_filename';
+    const platesHeader =
+      'experiment,wave_number,plate_id,accession,transplant_date,custom_note';
+    const sectionsHeader =
+      'experiment,wave_number,plate_id,section_id,plant_qr,medium';
     const filesToCopy: { src: string; dest: string }[] = [];
 
     for (const [waveNum, waveScans] of waveGroups) {
       const waveDir = path.join(expDir, `wave_${waveNum}`);
       fs.mkdirSync(waveDir, { recursive: true });
 
+      // Same-experiment legacy accession link, shared by every scan in this
+      // wave (wave-aware GraviExperimentWaveMetadata lookup is deferred —
+      // see proposal's "Out of scope").
+      const wavePlates: any[] =
+        waveScans[0]?.experiment.accession?.graviPlateAccessions ?? [];
+
       const csvRows: string[] = [csvHeader];
+      const platesRows: string[] = [platesHeader];
+      const sectionsRows: string[] = [sectionsHeader];
+
+      for (const plate of wavePlates) {
+        platesRows.push(
+          [
+            csvEscape(params.experimentName),
+            csvEscape(String(waveNum)),
+            csvEscape(plate.plate_id),
+            csvEscape(plate.accession),
+            csvEscape(
+              plate.transplant_date
+                ? plate.transplant_date.toISOString().split('T')[0]
+                : ''
+            ),
+            csvEscape(plate.custom_note ?? ''),
+          ].join(',')
+        );
+
+        for (const section of plate.sections ?? []) {
+          sectionsRows.push(
+            [
+              csvEscape(params.experimentName),
+              csvEscape(String(waveNum)),
+              csvEscape(plate.plate_id),
+              csvEscape(section.plate_section_id),
+              csvEscape(section.plant_qr),
+              csvEscape(section.medium ?? ''),
+            ].join(',')
+          );
+        }
+      }
 
       for (const scan of waveScans) {
-        const plateAccessions =
-          scan.experiment.accession?.graviPlateAccessions ?? [];
-        const matchedPlate = plateAccessions.find(
+        const matchedPlate = wavePlates.find(
           (p: any) => p.plate_id === scan.plate_barcode
         );
         const accession = matchedPlate?.accession ?? '';
@@ -397,12 +444,28 @@ export async function downloadImages(
         }
       }
 
-      // Write metadata.csv per wave subfolder
+      // Write the three CSVs per wave subfolder. plates.csv/sections.csv are
+      // only emitted when there's data beyond the header row, so analysts
+      // don't get empty files (matches production's behavior).
       fs.writeFileSync(
         path.join(waveDir, 'metadata.csv'),
         '\uFEFF' + csvRows.join('\n') + '\n',
         'utf-8'
       );
+      if (platesRows.length > 1) {
+        fs.writeFileSync(
+          path.join(waveDir, 'plates.csv'),
+          '\uFEFF' + platesRows.join('\n') + '\n',
+          'utf-8'
+        );
+      }
+      if (sectionsRows.length > 1) {
+        fs.writeFileSync(
+          path.join(waveDir, 'sections.csv'),
+          '\uFEFF' + sectionsRows.join('\n') + '\n',
+          'utf-8'
+        );
+      }
     }
 
     // Copy files with progress (async, 4 concurrent copies)

--- a/tests/unit/graviscan/image-handlers.test.ts
+++ b/tests/unit/graviscan/image-handlers.test.ts
@@ -82,6 +82,7 @@ describe('image-handlers', () => {
     vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
     // Default: no GRAVISCAN_OUTPUT_DIR override — falls back to hardcoded path.
     vi.mocked(fs.readFileSync).mockReturnValue('');
+    vi.mocked(fs.writeFileSync).mockClear();
     mockResolvePath.mockReset();
     mockRunBoxBackup.mockReset();
     mockUploadAllPendingScans.mockReset();
@@ -528,6 +529,172 @@ describe('image-handlers', () => {
       expect(fs.writeFileSync).toHaveBeenCalled(); // metadata CSV
       expect(fs.promises.copyFile).toHaveBeenCalled();
       expect(onProgress).toHaveBeenCalled();
+    });
+
+    it('should not write plates.csv or sections.csv when the experiment has no plate accessions', async () => {
+      db.graviScan.findMany.mockResolvedValue([
+        {
+          wave_number: 0,
+          plate_barcode: 'PLATE-001',
+          plate_index: '00',
+          grid_mode: '2grid',
+          capture_date: new Date('2026-04-01'),
+          experiment: { accession: { graviPlateAccessions: [] } },
+          images: [{ path: '/scan/image.tiff' }],
+        },
+      ]);
+      mockResolvePath.mockReturnValue('/scan/image.tiff');
+
+      await downloadImages(db, {
+        experimentId: 'exp-1',
+        experimentName: 'Test Exp',
+        targetDir: '/tmp/download',
+      });
+
+      const writtenPaths = vi
+        .mocked(fs.writeFileSync)
+        .mock.calls.map((call) => String(call[0]));
+      expect(writtenPaths.some((p) => p.endsWith('metadata.csv'))).toBe(true);
+      expect(writtenPaths.some((p) => p.endsWith('plates.csv'))).toBe(false);
+      expect(writtenPaths.some((p) => p.endsWith('sections.csv'))).toBe(false);
+    });
+
+    it('should write plates.csv with one row per plate accession and sections.csv with one row per section mapping', async () => {
+      db.graviScan.findMany.mockResolvedValue([
+        {
+          wave_number: 2,
+          plate_barcode: 'PLATE-001',
+          plate_index: '00',
+          grid_mode: '2grid',
+          capture_date: new Date('2026-04-01'),
+          experiment: {
+            accession: {
+              graviPlateAccessions: [
+                {
+                  plate_id: 'PLATE-001',
+                  accession: 'ACC-1',
+                  transplant_date: new Date('2026-03-15'),
+                  custom_note: 'note, with comma',
+                  sections: [
+                    {
+                      plate_section_id: 'SEC-1',
+                      plant_qr: 'QR-1',
+                      medium: 'soil',
+                    },
+                    {
+                      plate_section_id: 'SEC-2',
+                      plant_qr: 'QR-2',
+                      medium: null,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          images: [{ path: '/scan/image.tiff' }],
+        },
+      ]);
+      mockResolvePath.mockReturnValue('/scan/image.tiff');
+
+      await downloadImages(db, {
+        experimentId: 'exp-1',
+        experimentName: 'Test Exp',
+        targetDir: '/tmp/download',
+      });
+
+      const calls = vi.mocked(fs.writeFileSync).mock.calls;
+      const platesCall = calls.find((call) =>
+        String(call[0]).endsWith('plates.csv')
+      );
+      const sectionsCall = calls.find((call) =>
+        String(call[0]).endsWith('sections.csv')
+      );
+      expect(platesCall).toBeDefined();
+      expect(sectionsCall).toBeDefined();
+
+      const platesContent = String(platesCall![1]);
+      const platesLines = platesContent.trim().split('\n');
+      expect(platesLines[0]).toBe(
+        'experiment,wave_number,plate_id,accession,transplant_date,custom_note'
+      );
+      expect(platesLines).toHaveLength(2);
+      expect(platesLines[1]).toBe(
+        'Test Exp,2,PLATE-001,ACC-1,2026-03-15,"note, with comma"'
+      );
+
+      const sectionsContent = String(sectionsCall![1]);
+      const sectionsLines = sectionsContent.trim().split('\n');
+      expect(sectionsLines[0]).toBe(
+        'experiment,wave_number,plate_id,section_id,plant_qr,medium'
+      );
+      expect(sectionsLines).toHaveLength(3);
+      expect(sectionsLines[1]).toBe('Test Exp,2,PLATE-001,SEC-1,QR-1,soil');
+      expect(sectionsLines[2]).toBe('Test Exp,2,PLATE-001,SEC-2,QR-2,');
+    });
+
+    it('should write plates.csv but not sections.csv when a plate has no sections', async () => {
+      db.graviScan.findMany.mockResolvedValue([
+        {
+          wave_number: 0,
+          plate_barcode: 'PLATE-001',
+          plate_index: '00',
+          grid_mode: '2grid',
+          capture_date: new Date('2026-04-01'),
+          experiment: {
+            accession: {
+              graviPlateAccessions: [
+                {
+                  plate_id: 'PLATE-001',
+                  accession: 'ACC-1',
+                  transplant_date: null,
+                  custom_note: null,
+                  sections: [],
+                },
+              ],
+            },
+          },
+          images: [{ path: '/scan/image.tiff' }],
+        },
+      ]);
+      mockResolvePath.mockReturnValue('/scan/image.tiff');
+
+      await downloadImages(db, {
+        experimentId: 'exp-1',
+        experimentName: 'Test Exp',
+        targetDir: '/tmp/download',
+      });
+
+      const writtenPaths = vi
+        .mocked(fs.writeFileSync)
+        .mock.calls.map((call) => String(call[0]));
+      expect(writtenPaths.some((p) => p.endsWith('plates.csv'))).toBe(true);
+      expect(writtenPaths.some((p) => p.endsWith('sections.csv'))).toBe(false);
+    });
+
+    it('should default the target directory to the Downloads folder when targetDir is omitted', async () => {
+      vi.mocked(app.getPath).mockReturnValue('/mock/downloads');
+      db.graviScan.findMany.mockResolvedValue([]);
+
+      const result = await downloadImages(db, {
+        experimentId: 'exp-1',
+        experimentName: 'Test Exp',
+      } as any);
+
+      expect(app.getPath).toHaveBeenCalledWith('downloads');
+      expect(result.success).toBe(true);
+    });
+
+    it('should use the explicit targetDir when provided, without consulting Downloads', async () => {
+      vi.mocked(app.getPath).mockClear();
+      db.graviScan.findMany.mockResolvedValue([]);
+
+      await downloadImages(db, {
+        experimentId: 'exp-1',
+        experimentName: 'Test Exp',
+        targetDir: '/tmp/explicit-download',
+      });
+
+      expect(app.getPath).not.toHaveBeenCalledWith('downloads');
     });
   });
 });


### PR DESCRIPTION
## Summary

Increment 7 (Important) of the [GraviScan production-parity-gaps plan](docs/superpowers/plans/2026-07-29-graviscan-production-parity-gaps.md). Three gaps in `downloadImages()` vs. production's equivalent:

1. **Wave-aware accession lookup** — re-confirmed correctly out of scope: `main`'s Prisma schema has no `GraviExperimentWaveMetadata` model, and `ExperimentForm.tsx` still requires `accession_id` at creation time, so the null-accession case this exists to handle can't occur via `main`'s UI. Re-deferred with a note, not implemented — this is tied to a separate, not-yet-started wave-scoped-metadata-linking initiative.
2. **Missing `plates.csv`/`sections.csv`** — production writes 3 CSVs per wave subfolder; `main` wrote only `metadata.csv`. Ported the other two independently, byte-identical column headers to production, only written when there's data (matching production's "don't hand analysts empty files" behavior).
3. **Target-directory contract** — production auto-resolves `app.getPath('downloads')`; `main` required an explicit `targetDir`. Made it optional with a Downloads-folder default, since no renderer currently calls this function (confirmed: zero call sites in `src/renderer/`) — this is purely additive and lets a future renderer match production's simpler one-click-download contract without another signature change later. `targetDir` still takes priority when explicitly provided.

## Changes

- `src/main/graviscan/image-handlers.ts`: `downloadImages()` now writes `plates.csv` (`experiment,wave_number,plate_id,accession,transplant_date,custom_note`) and `sections.csv` (`experiment,wave_number,plate_id,section_id,plant_qr,medium`) per wave subfolder, alongside the existing `metadata.csv`. `targetDir` defaults to `app.getPath('downloads')` when omitted.
- OpenSpec proposal `add-download-images-csv-exports`, validated strict.

**Deliberate deviation from production**: the two new CSVs get the same UTF-8 BOM prefix `main`'s existing `metadata.csv` already uses (confirmed via `git log -S` to predate this branch — a genuine existing `main` convention, not invented here), even though production's originals have no BOM. Chose consistency with `main`'s own established file-family convention over byte-for-byte production parity.

## Testing

- TDD: 5 new tests (empty/no-sections/full CSV cases, explicit-vs-default targetDir).
- `npx vitest run tests/unit/graviscan/image-handlers.test.ts`: 27/27 passing.
- Full `tests/unit/graviscan/` suite: 246/248, 2 pre-existing unrelated failures (Windows path-separator assertions in untouched files).
- `tsc --noEmit`, `prettier --check`, `openspec validate --strict`: all clean.
- Task-level review and final whole-branch review: both clean, ready to merge — every specific claim (CSV headers vs. actual production source, BOM history, zero renderer callers, a genuinely-necessary pre-existing test-hygiene fix) independently re-verified by both reviewers, not just read from the report.

Two non-blocking suggestions from the final review, parked for a future pass: a log line when the Downloads-folder default is used (currently silent — fine today since nothing calls this function yet, but worth adding before a renderer does), and a multi-wave test for the new CSV partitioning logic.
