### PR TITLE
GraviScan: add wedge-response UI (roadmap Tier 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- GraviScan wedge-response UI: auto-pause and operator recovery for USB wedges (#244, #240, #228)
+  - When the `WedgeDetector` fires, the wedged scanner's worker is now automatically stopped and excluded from all subsequent cycles — no operator action required to stop the data loss
+  - App-wide `WedgeBanner` (visible regardless of which screen the operator is on) shows one entry per auto-paused scanner with its signature and error message
+  - Two operator actions per entry: **Dismiss** (acknowledge, no backend effect) and **Power-Cycled & Retry** (confirmation-gated respawn, only after the operator confirms the physical power-cycle is done)
+  - Session-scoped counter shows both total auto-pause events and distinct scanners affected, so a single chronically-re-wedging scanner isn't misread as a fleet-wide problem
+  - New `graviscan:wedge-detected` push event and `graviscan:retry-scanner` IPC handler; durable `scanLog()` entries record every auto-pause and retry attempt
+  - See `openspec/changes/add-graviscan-wedge-response-ui/` for full design rationale
+
 - Idle session timer to prevent scan misattribution in shared lab environments (#102, #116)
   - Main process `IdleTimer` class resets session state after 10 minutes of inactivity
   - Session fields (phenotyper, experiment, wave number, plant age, accession name) cleared on idle

--- a/docs/superpowers/plans/2026-08-03-graviscan-tier3-wedge-response-ui.md
+++ b/docs/superpowers/plans/2026-08-03-graviscan-tier3-wedge-response-ui.md
@@ -35,7 +35,7 @@ sign-off before Tier 3 relies on it, with a recommended backtest first.
 - Zero zero-byte output files among all 28,980 `.tif` files still on disk.
 - Zero individual scan-error log entries of any kind.
 
-Caveat for whoever reads this later: the rig runs the *production* branch, which
+Caveat for whoever reads this later: the rig runs the _production_ branch, which
 doesn't have main's coordinator-level row-timeout/file-verification checks at all
 — so this backtests the underlying physical failure conditions as the best
 available proxy, not an exact replay of the new code path. Small sample (one rig,

--- a/docs/superpowers/plans/2026-08-03-graviscan-tier3-wedge-response-ui.md
+++ b/docs/superpowers/plans/2026-08-03-graviscan-tier3-wedge-response-ui.md
@@ -1,0 +1,57 @@
+# Tier 3 — Wedge-Response UI: Pre-Proposal Notes
+
+**Roadmap:** `docs/superpowers/plans/2026-07-30-graviscan-renderer-roadmap.md`, Tier 3.
+**Depends on:** Tier 2 (merged, PR #274, commit `9805bba`). Does **not** need Tier 1's
+Configure Scanner screen or the full Tier 4 scan screen.
+**Related issues:** #244 ("permanent data loss, no recovery" for wedged time-lapse
+experiments), #240 (no in-UI wedge banner today).
+
+## Why this tier is fast-tracked
+
+Pulled out of the original Tier 4 bundle specifically because #244 describes real,
+irreversible data loss risk on a safety-relevant path, and bundling it into the
+larger, higher-rebuild-risk core scan screen would couple a safety fix's timeline
+to the tier most likely to slip.
+
+## Scope (from the roadmap)
+
+An in-UI wedge banner (#240) with resume/skip/retry affordances (#244), rendered
+against a minimal placeholder scan-state view — merged into the full Tier 4 screen
+once that lands, not held until then.
+
+## Prerequisite decision — resolved 2026-08-03
+
+Tier 2's granular event model made coordinator-originated scan errors (row-timeout,
+missing/zero-byte output file — see `scan-coordinator.ts`'s `scanOnce()`, 4 direct
+`emit('scan-error', ...)` call sites) visible to wedge detection for the first time.
+This was flagged in Tier 2's design doc (Open Question 2) as needing explicit
+sign-off before Tier 3 relies on it, with a recommended backtest first.
+
+**Backtest done, sign-off given.** Pulled the real production rig's logs
+(`graviscan@graviscan-ms-7c56.tail461d0e.ts.net:~/.bloom/logs/`, 2026-05-26 through
+2026-08-01, ~10 weeks):
+
+- Zero wedge alerts have ever fired on this rig in that window.
+- Zero zero-byte output files among all 28,980 `.tif` files still on disk.
+- Zero individual scan-error log entries of any kind.
+
+Caveat for whoever reads this later: the rig runs the *production* branch, which
+doesn't have main's coordinator-level row-timeout/file-verification checks at all
+— so this backtests the underlying physical failure conditions as the best
+available proxy, not an exact replay of the new code path. Small sample (one rig,
+~10 weeks); zero-byte files produced and later cleaned up wouldn't show up in a
+live-disk scan. With that caveat: no evidence of any relevant failure, ever, on
+this rig. **Proceed with Tier 3 without further gating on this question** — don't
+re-litigate it unless new evidence surfaces.
+
+## Next step
+
+Run `/new-feature` (this repo's brainstorm → OpenSpec proposal → `openspec-review`
+5-agent adversarial pass → user approval → `/openspec:apply` TDD → `/pre-merge` →
+PR → `/cleanup-merged` workflow). This worktree is already on its own branch
+(`add-graviscan-wedge-response-ui`, based on `main` @ `2d90a0c`) — a sibling
+`add-wave-scoped-metadata-linking` proposal is running in parallel in a different
+worktree (`../bloom-desktop-wave-metadata-linking`); they touch unrelated files
+(this tier is UI + wedge-detector consumption only, no DB schema), so no
+coordination note is expected, but confirm that's still true once this proposal's
+Impact section is drafted.

--- a/openspec/changes/add-graviscan-wedge-response-ui/design.md
+++ b/openspec/changes/add-graviscan-wedge-response-ui/design.md
@@ -1,0 +1,476 @@
+## Context
+
+No backend or renderer surface for wedge response exists today — confirmed
+by direct code reading, not assumed from the roadmap doc's "No new backend"
+framing (which, read against Tier 1's identical "preload wiring" framing
+for a Tier-1-sized change, turns out to describe forwarding/wiring work,
+not a full data-layer increment — consistent with what this change actually
+does). Specifically:
+
+- `setupWedgeDetection()`'s `onWedge` callback
+  (`src/main/graviscan/wiring.ts:265-277`) only calls `SlackNotifier.notify()`
+  and a log line. `setupCoordinatorEventForwarding()`'s forwarded-event list
+  (`wiring.ts:174-195`) does not include any wedge event, and nothing stops
+  the wedged scanner — per issue #228, the wedged subprocess "stays alive
+  in a broken state and re-hits the wedge every subsequent cycle."
+- `ScanCoordinator`'s public surface
+  (`src/main/graviscan/scan-coordinator.ts`) has `cancelAll()` (session-wide)
+  and `stopScanner()`/`addScanner()` (single-scanner), and nothing scoped to
+  a single job/row/plate.
+- `src/main/preload.ts`'s `graviAPI` object has no wedge-related method or
+  listener.
+- No renderer file references wedge state at all except a static env-config
+  label in `ConfigureScanner.tsx:409` ("Slack wedge alerts:
+  configured/not configured" — unrelated to a live wedge).
+
+Five questions were resolved with the user before/during drafting this
+proposal, since this is a data-loss-prevention safety feature and guessing
+wrong here has real consequences. The first four were resolved before the
+initial draft; the fifth (Decision 1, auto-pause) was resolved after a
+5-agent adversarial review of that draft surfaced a divergence from the
+source issues that the initial clarifying questions had not surfaced.
+
+## Decision 1: Auto-pause on wedge, not manual Skip
+
+**When a wedge is detected, the coordinator automatically stops that
+scanner's worker — no operator click required.** `setupWedgeDetection()`'s
+`onWedge` callback calls `coordinator.stopScanner(evt.scanner_id)`
+immediately (fire-and-forget, not awaited, and not gated behind the
+network-bound Slack notification), in addition to the existing enrich +
+Slack-notify + (new) renderer-forward pipeline.
+
+**Why this superseded an earlier draft.** The first draft of this proposal
+made "Skip" a manual operator action and left a wedged scanner in the
+active rotation (re-failing every cycle) until someone noticed and clicked
+it. Adversarial review checked that draft against the actual source issues
+and found it inverted their intent:
+
+- Issue #228 (the P0 root-cause issue `wedge-detector.ts` itself cites)
+  recommends: "Stop using that scanner automatically (mark as offline;
+  continue with remaining scanners)... Auto-resume when the scanner
+  re-enumerates fresh."
+- Issue #244 item 1 (the item this proposal implements) recommends: "when
+  a wedge fires... disable its inclusion in subsequent cycles, surface a
+  `Power-Cycled & Resume` button. On click: spawn a fresh worker."
+
+Both make the initial pause automatic — that half of this design matches
+both issues, and is the half that fixes the actual data-loss bug. They
+diverge on the _resume_ half, and this proposal follows #244, not #228,
+there: #228's step 4 ("Auto-resume when the scanner re-enumerates fresh")
+describes a fully automatic resume triggered by the OS detecting the
+physical device come back online after a power-cycle — this codebase has
+no such capability today (`src/main/lsusb-detection.ts`'s scanner
+detection is a one-shot poll, not an event-driven USB hotplug watcher), so
+building #228's literal design would mean adding new hotplug-detection
+infrastructure as part of a fast-tracked safety-UI tier. #244 item 1's
+design — an operator-clicked "Power-Cycled & Resume" button that spawns a
+fresh worker — needs no new infrastructure and is what this proposal
+implements (as "Power-Cycled & Retry", confirmation-gated per Decision 2).
+An earlier draft of this design doc described both issues as wanting "a
+manual action only for the respawn step," which is only true of #244; #228
+wants that step automatic too. Recorded here accurately rather than
+papering over the gap: this proposal's resume step is manual by choice
+(no hotplug infra exists to do otherwise), not because #228 asked for it.
+
+The pause half is the one this proposal is confident about regardless: the
+consequence of getting _that_ wrong is exactly what #244 is about — for a
+multi-day unattended continuous run (the primary use case), "the operator
+has to notice and act" is a much weaker safety property than "the app
+stops the bleeding immediately." A wedge signature already means "physical
+AC power-cycle required" (per #240's own suggested banner text) — the
+detector firing at all is already the signal that continuing to scan is
+useless, so there is no benefit to waiting for a human before stopping.
+
+**Why acting on the very first occurrence of any of the three signatures
+is scientifically justified, not just operationally convenient.** Each
+signature in `wedge-detector.ts` already encodes its own confirmation
+mechanism, tuned to that failure mode — auto-pausing on the first
+occurrence doesn't skip a "wait and see" step, it relies on a step that's
+already built into the signature itself:
+
+- `sane_start_invalid` fires on an exact string match
+  (`sane_start: Invalid argument`) tied to a specific, investigated root
+  cause (issue #228's own investigation) — the specificity is in the
+  string, not in repetition.
+- `device_io_120s_zero_bytes` requires a compound condition (matching
+  error text AND zero bytes received AND ≥120 seconds elapsed) — 120
+  continuous seconds of literally zero bytes is itself a conservative
+  threshold no ordinary transient hiccup would cross.
+- `consecutive_failures` is explicitly count-gated already (`>= 2` within
+  one cycle) — it isn't a single-occurrence signature to begin with.
+  No additional "wait for a second occurrence before pausing" layer is
+  justified on top of these; that would just re-implement, redundantly and
+  less precisely, confirmation logic each signature already has, while
+  reintroducing the delay-before-stopping problem this decision exists to
+  remove.
+
+**Consequence: two operator actions instead of three.** With pausing
+automatic, a manual "Skip" action becomes redundant (there's nothing left
+for it to do that auto-pause hasn't already done), which is why this
+revision has only:
+
+- **Dismiss** — hides the banner entry. No backend call. The scanner stays
+  paused regardless of whether or when the operator dismisses; dismissing
+  only affects what's shown, never coordinator state.
+- **Power-Cycled & Retry** — confirmation-gated respawn (Decision 2).
+
+This is a simplification relative to the first draft (one fewer IPC
+handler, one fewer UI action), not an addition — auto-pause replaces what
+Skip used to do, it doesn't sit alongside it.
+
+**Explicitly deferred, named rather than silently dropped:** #244 item 4
+(auto-cancel-on-N-wedges — an operator-configurable policy to remove a
+scanner after N wedges across a session) and item 5 (cancel the whole
+session + auto-restart with the same parameters) are not implemented here.
+Item 4's per-scanner exclusion already happens automatically and
+unconditionally on the _first_ wedge under this design, which is a
+stronger response than a configurable N-threshold — the configurable
+policy angle (letting an operator choose to tolerate N wedges before
+excluding) is a real but separate feature this proposal doesn't build.
+Item 5 is a session-level action orthogonal to per-scanner wedge response
+and would need its own scoping (what "same parameters" means across a
+partially-elapsed interval, whether already-completed cycles' data
+factors in, etc.) — out of scope for this fast-tracked tier.
+
+**Dismiss is the de facto "give up on this scanner" action, and that's
+intentional, not a gap.** There is no automatic N-failed-retries cutoff: a
+scanner that keeps re-wedging after every Retry will simply keep
+generating fresh `wedge-detected` events (each auto-pausing it again and
+replacing its banner entry, per Decision 4). An operator is never forced
+into that loop, though — Dismiss requires no confirmation, makes no
+backend call, and is available at any time regardless of retry history;
+the scanner stays safely paused either way. So there is always a manual
+escape route from a chronically-re-wedging scanner, it's just Dismiss
+rather than a separate "give up" button, since auto-pause already did the
+one thing a dedicated give-up action would otherwise need to do.
+
+**Accepted, bounded side effect of calling `stopScanner()` from `onWedge`:
+a wedge on the in-flight row can force that row to fall back to its
+90-second timeout instead of resolving via its own listeners.** A wedge
+signature can fire from a subprocess-relayed `scan-error` event while
+`scanOnce()`'s row-completion promise for that exact scanner/row is still
+awaiting its own `scan-complete`/`cycle-done`/`exit` listeners
+(`scan-coordinator.ts:522-562`). `stopScanner()`'s `sub.removeAllListeners()`
+(`scan-coordinator.ts:274-281`) strips those listeners as part of tearing
+the subprocess down — if this happens before the row's terminal event
+arrived, that row's promise can only resolve via `scanOnce()`'s own
+existing `SCAN_ROW_TIMEOUT_MS` (90s) fallback, stalling that row group
+(and anything sequenced after it in the same cycle) by up to 90 extra
+seconds. This is a real, new interaction introduced by making
+`stopScanner()` a side effect of detection rather than an operator's later
+click — accepted as a bounded, existing-safety-net-bounded cost (the 90s
+bound is pre-existing coordinator behavior, not a new unbounded risk;
+wedges are rare per the Tier 3 backtest) rather than deferring the
+auto-pause call to avoid it, which would reintroduce exactly the
+delay-before-stopping problem this decision removes — deferring doesn't
+even avoid the worst case, since a genuinely wedged row was headed for the
+90s timeout regardless of when `stopScanner()` is called. Not covered by
+an integration test in this change (section 2's tests exercise
+`setupWedgeDetection()` against a bare `EventEmitter` standing in for the
+coordinator, not a real `ScanCoordinator` with an in-flight `scanOnce()`)
+— reproducing the exact race would need real subprocess timing, which is
+a materially larger test-infrastructure investment than this UI-focused
+tier warrants; the 90s bound itself is already covered by
+`scan-coordinator.test.ts`'s existing row-timeout tests, unchanged by this
+proposal.
+
+Retry's respawn is safe to call at any point in a session because
+`addScanner()` already handles mid-cycle safety: if `isScanning`, it queues
+the spawn until the next `cycle-complete` event rather than disturbing the
+active cycle (`scan-coordinator.ts:228-268`, existing behavior, unchanged
+by this proposal).
+
+## Decision 2: Retry confirmation gating
+
+**Retry requires an explicit two-step confirmation in the UI before the
+respawn IPC call fires** ("Power-Cycled & Retry" → confirmation copy →
+"Confirm Retry"). This is UI-only state — no new backend flag or session
+field. Rationale: `addScanner()` blindly respawns a subprocess against the
+same physical USB port; if the hardware is still wedged, the respawned
+worker will very likely re-wedge on its next scan, spending a whole cycle
+to learn nothing. Issue #244's own proposed UI text ("Power-Cycled &
+Resume") already implies the button should be pressed only after the
+physical fix, not as a first response — the confirmation step makes that
+implicit precondition explicit rather than trusting the operator to
+self-gate. The confirmation sub-state SHALL render explicit explanatory
+text describing the precondition (not just two bare buttons) — a
+reviewer flagged that the scenarios alone don't force this, so it's called
+out here explicitly as an implementation requirement, and codified as its
+own spec scenario.
+
+**Confirmation resets if the underlying wedge is superseded.** If a _new_
+`wedge-detected` event for the same `scanner_id` arrives while a
+confirmation is pending (operator clicked "Power-Cycled & Retry" but
+hasn't clicked "Confirm" yet — necessarily a fresh wedge on a scanner that
+was itself just re-paused after a prior retry), the entry's confirmation
+sub-state resets to unconfirmed along with the entry's data being
+replaced (Decision 4). Confirming a retry the operator intended for an
+already-superseded wedge context would be misleading — better to make
+them re-initiate Retry against the current wedge.
+
+## Decision 3: Persistence scope
+
+**No new DB table — but the auto-pause action itself is durably logged.**
+`useWedgeEvents()` holds wedge state in React state local to Layout's
+render tree; nothing about the _banner_ is written to the database, and
+this matches `WedgeDetector`'s own lifecycle (torn down on
+`interval-complete`, nothing persisted — `wiring.ts:280-283`). Issue
+#244's item 2 (a `wedge_event` DB table for post-experiment audit) and
+item 3 (a `failure_reason=wedge` placeholder row in `GraviScan`) are both
+real, independently useful ideas but explicitly **not** part of this
+change — either would need its own proposal (new Prisma model/migration
+for item 2; a write-path change to the not-yet-built scan-completion
+handler for item 3), and bundling either here would contradict the
+pre-proposal notes' framing of this tier as UI + wedge-detector
+consumption only, no DB schema.
+
+That said, an earlier draft of this decision claimed the _only_ thing lost
+by staying in-memory was the transient banner — that undersold the gap.
+Before this revision, the operator's _response_ to a wedge (which action
+was taken, when) had no record anywhere, not even in a log file, once
+auto-pause is the app's own doing rather than an operator's explicit
+click that could at least be inferred from an audit trail elsewhere. To
+close that gap without taking on a DB table: `stopScanner()` on auto-pause
+and the `retry-scanner` handler's outcome both write a `scanLog()` line
+(scanner_id, action, session_id, cycle_number, and — for retry — success/
+failure) to the existing durable per-day log file
+(`src/main/graviscan/scan-logger.ts`, already retained ~180 days). This is
+a few lines, not a schema change, and directly serves the "traceability"
+value this tier is supposed to advance: a support engineer or PI reading
+the log after an incident can now see not just that a wedge was detected,
+but that the app paused the scanner and whether/when a retry was attempted
+and whether it succeeded.
+
+Consequence: a wedge _banner_ is still lost if the renderer reloads or the
+app restarts while it's showing — accepted, since the coordinator-level
+pause state and the new log line are both unaffected by losing the
+transient UI. `getScannerStatuses()` remains pollable for current state
+(a paused scanner is simply absent from the active worker map, same as
+any other stopped scanner — no new "paused" status is introduced by this
+change; that would be a reasonable follow-up but is out of scope here).
+
+## Decision 4: Banner scope, and no new placeholder route
+
+**App-wide, mounted in `Layout.tsx`, not scoped to a dedicated screen.**
+This directly supersedes the roadmap doc's "rendered against a minimal
+placeholder scan-state view" framing — recorded here as a deliberate scope
+change, not a silent deviation. Rationale: issue #240's actual complaint is
+that an operator elsewhere in the app (not watching the scan screen) misses
+the alert; a banner scoped to a new placeholder route would only fix that
+for operators already on that one screen, i.e. would not actually close the
+gap #240 describes. Making the banner app-wide instead means:
+
+- No new route is needed (nothing to navigate away from that would hide the
+  banner).
+- No new nav link is needed. This is also consistent with the roadmap's own
+  cross-cutting nav-ownership section, which does not name Tier 3 as owning
+  any workflow-step/nav-link change (only Tiers 1, 4, and 5 are named).
+- `App.tsx` is untouched by this change.
+
+Each `WedgeBanner` entry is self-contained (scanner*id/display_name,
+signature, error message, Dismiss/Retry buttons, and copy communicating
+the scanner has \_already been paused* — not that pausing is pending an
+operator action) — it doesn't need a host screen to show useful state,
+unlike (say) a live scan-progress view.
+
+**Layout/positioning**: entries render as a fixed, vertically-stacked list
+(each entry its own row) below the top nav so multiple entries never
+overlap each other or obscure navigation; this is called out explicitly
+here because no existing convention in this codebase dictates banner
+positioning for a persistent, potentially-multi-entry, app-wide banner
+(the existing inline-banner precedents — `ConfigureScanner.tsx`,
+`CaptureScan.tsx` — are all single-instance and scoped to one page's own
+layout flow).
+
+**Repeated wedges on the same scanner**: a new `wedge-detected` event for a
+scanner already showing a banner **replaces** that entry rather than
+stacking a second one, and resets its retry-confirmation sub-state to
+unconfirmed if one was pending (Decision 2). Rationale: the previous
+entry's information (older cycle number, possibly a different signature)
+is superseded by the new one; showing both would suggest two independent
+problems when it's the same scanner repeatedly failing. A bounded history
+list was considered and rejected as unnecessary complexity for what
+Decision 3 already treats as ephemeral, non-authoritative UI state — the
+durable trail now lives in the log file instead (Decision 3).
+
+**Session-end clearing**: all banner entries clear when `onIntervalComplete`
+or `onCancelled` fires. Retry is meaningless once the coordinator has
+stopped scanning; leaving a stale actionable button on screen after the
+session ended would be actively misleading (a Retry click after the
+session ended would respawn a subprocess with no active `scanInterval()`
+loop to ever schedule it into a cycle).
+
+**Session-level auto-pause counter, alongside the per-scanner entries.**
+Under the earlier manual-Skip draft, an operator's own sense of "this is
+the third scanner I've had to Skip this hour, something is systemically
+wrong" was an inherent side effect of having to act on each one by hand.
+Auto-pause removes that natural check-in point — an operator who
+dismisses each entry as it appears (or isn't watching closely) has no
+cheap way to notice that an unusually large number of wedges have occurred
+this session. `useWedgeEvents()` therefore also tracks two session-scoped
+numbers, neither decremented by Dismiss (unlike the per-scanner entries,
+these reflect history, not current unacknowledged state):
+
+- a running **event count**, incremented on every `wedge-detected` event,
+  including repeats for the same `scanner_id` (e.g. a scanner that
+  re-wedges after a failed Retry increments this again); and
+- a **distinct-scanner count**, the size of the set of unique `scanner_id`s
+  that have wedged at least once this session.
+
+Both are needed, not just one: a flat event count alone would be
+genuinely misleading for the exact judgment call this feature exists to
+support. A single flaky scanner retried three times and re-wedging each
+time produces 3 events but only 1 distinct scanner — a display that only
+said "3" (implying 3 units affected, as an earlier draft's example copy
+literally read, "3 scanners have auto-paused this session") would
+overstate how systemic the problem is. The indicator therefore shows both,
+e.g. "3 auto-pause events across 1 scanner this session" — accurate
+whether the events are concentrated on one unit or spread across several.
+Both numbers reset to zero on the same `interval-complete`/`cancelled`
+events that clear the per-scanner entries (Decision 4, above) — they're
+per-session figures, not persisted, consistent with Decision 3's
+in-memory-only scope. This does not add a policy decision (no threshold,
+no automatic action at any count) — it only restores the passive
+visibility manual-Skip used to provide for free, accurately.
+
+## Decision 5: Type sharing (no duplicated interface)
+
+`src/types/graviscan.ts` re-exports `wedge-detector.ts`'s existing
+`WedgeDetectedEvent` as `GraviWedgeEvent` via a **type-only** import
+(`import type { WedgeDetectedEvent } from '../main/wedge-detector'; export
+type GraviWedgeEvent = WedgeDetectedEvent;`). `import type` is fully erased
+at compile time — this does not pull `wedge-detector.ts`'s runtime code (or
+any transitive import) into the renderer bundle. Chosen over duplicating
+the interface because the two would otherwise be free to drift silently;
+`wedge-detector.ts` already declares itself "Pure logic. No I/O, no
+network, no DB," so it has no Electron/native dependency that would make a
+type-only cross-reference architecturally awkward.
+
+## Decision 6: `setupWedgeDetection()` signature change
+
+Add an optional third parameter, `getMainWindow: (() => BrowserWindow |
+null) | null = null`, mirroring `setupCoordinatorEventForwarding()`'s
+existing convention (`wiring.ts:170-172`) rather than reading the
+module-level `_getMainWindow` directly inside the function. This keeps
+`setupWedgeDetection()` callable in isolation the way `tests/unit/graviscan/
+main-wiring.test.ts` already calls it directly without Electron — passing
+`null` (or omitting the argument) preserves every existing test unmodified.
+The call site in `getOrCreateCoordinator()` (`wiring.ts:382`) passes the
+already-available `_getMainWindow`, matching how it's passed one line above
+to `setupCoordinatorEventForwarding()` (`wiring.ts:377`).
+
+Inside `onWedge`, the new logic is, in order:
+
+```ts
+onWedge: (evt) => {
+  // Auto-pause first, fire-and-forget — don't let a slow/failing Slack
+  // call or DB enrichment delay stopping the wedged scanner (Decision 1).
+  void coordinator.stopScanner(evt.scanner_id).catch((err) => {
+    console.error(`[WedgeDetector] Failed to auto-pause ${evt.scanner_id}:`, err);
+  });
+  // Pre-existing line (unchanged) — keep it; do not replace it with the
+  // auto-pause line below. tests/unit/graviscan/main-wiring.test.ts
+  // already asserts this exact message.
+  scanLog(
+    `[WedgeDetector] wedge-detected scanner=${evt.scanner_id} signature=${evt.signature} cycle=${evt.cycle_number}`
+  );
+  // New second line, added by this proposal, for the auto-pause action
+  // itself (Decision 3) — includes session_id to disambiguate cycle
+  // numbers across sessions that share a calendar-day log file.
+  scanLog(
+    `[WedgeDetector] auto-paused scanner=${evt.scanner_id} signature=${evt.signature} session=${evt.session_id} cycle=${evt.cycle_number}`
+  );
+
+  void (async () => {
+    const enriched = await enrichWedgeEvent(evt, db);
+    void slackNotifier.notify(enriched);
+    const win = getMainWindow?.();
+    if (win && !win.isDestroyed()) {
+      win.webContents.send('graviscan:wedge-detected', enriched);
+    }
+  })();
+},
+```
+
+`coordinator` is already in scope as `setupWedgeDetection()`'s first
+parameter — no new parameter is needed to reach it from `onWedge`. The
+enriched (display_name/usb_port-augmented) payload is still what's sent
+to both Slack and the renderer, so the renderer gets the same
+operator-friendly information Slack does, without a second DB round-trip.
+Note this is **two** `scanLog()` calls, not one replacing the other — an
+earlier version of this code sample dropped the pre-existing
+`wedge-detected` line, which would have broken an existing passing test
+if implemented literally; both lines now coexist.
+
+## Decision 7: `retry-scanner`'s saneName reconstruction and enabled check
+
+Extract the `saneName` string-construction (currently inlined at
+`register-handlers.ts:166`: `` `epkowa:interpreter:${busPadded}:${devicePadded}` ``)
+into an exported `buildSaneName(usbBus: number, usbDevice: number): string`
+in `scanner-handlers.ts`, and reuse it from both the existing
+spawn-on-discovery call site and the new `retry-scanner` handler.
+
+The retry handler reads `usb_bus`/`usb_device`/`enabled` **fresh from the
+DB** at retry-time (not from whatever was passed to `start-scan`, and not
+from the wedge event's payload — `WedgeDetectedEvent` doesn't carry USB
+fields at all, only `display_name`/`usb_port`), because a `reset-usb`
+performed after auto-pause (which clears and re-detects `usb_bus`/
+`usb_device`) would otherwise make a stale value wrong. Two failure cases,
+both returning an error without calling `addScanner`:
+
+- `usb_bus`/`usb_device` is null (e.g. mid `reset-usb`) — mirrors the
+  existing guard at `register-handlers.ts:159-164` for the identical
+  condition.
+- The scanner row's `enabled` field is `false` — per
+  `prisma/schema.prisma`'s own documented policy that scanner reads for
+  spawn decisions must filter on `enabled: true`. Without this check, an
+  operator who explicitly disabled a scanner (ConfigureScanner's "Remove"
+  action, `disable-scanner`) between the wedge firing and clicking Retry
+  on a stale banner could have Retry silently bring it back online against
+  their own prior action.
+
+`retryScanner()`'s `db` parameter is typed as a narrow interface (not the
+full `PrismaClient`), matching `wiring.ts`'s own `ScannerLookupDb`
+convention for this exact kind of "read one scanner row for a
+spawn-related decision" case, rather than `scanner-handlers.ts`'s
+`db: PrismaClient` + cast convention. `session-handlers.ts` currently has
+zero DB dependency at all; keeping the new dependency narrow avoids
+pulling `@prisma/client`'s types into a module that otherwise doesn't need
+them.
+
+`retryScanner()` still calls `stopScanner()` before `addScanner()` even
+though auto-pause (Decision 1) should already have torn the worker down by
+the time an operator clicks Retry — `stopScanner()` is a no-op if there's
+no worker (`scan-coordinator.ts:274-281` returns immediately), so this
+costs nothing in the normal case and defends against any timing edge case
+(e.g. the auto-pause call in `onWedge` hasn't resolved yet).
+
+**Accepted limitation, not addressed by this change:** `retry-scanner`
+resolving `{ success: true }` means the IPC call and the `addScanner()`
+call didn't throw — it does not mean the respawned worker actually came
+online. `scan-coordinator.ts:224-227` documents that `addScanner()`/
+`spawnSingleScanner()` deliberately "does not throw on spawn failure —
+errors surface via the `scanner-init-status` event," isolated into
+`initErrors`. If a respawned worker silently fails to initialize (as
+opposed to successfully spawning and then re-wedging, which _would_
+produce a fresh `wedge-detected` event), the banner is dismissed on
+apparent success with no further signal tying that failure back to the
+retry attempt. `scanner-init-status` is already forwarded to the renderer
+by the existing `setupCoordinatorEventForwarding()` (unchanged by this
+proposal) — a future tier could correlate it with a just-retried
+scanner_id, but this tier does not attempt that correlation.
+
+## Decision 8: Guard rails on `retry-scanner`
+
+`retry-scanner` requires `sessionFns.getScanSession()?.isActive` and a
+non-null coordinator; otherwise it returns `{ success: false, error:
+'...' }` without throwing. This matches `cancelScan`'s existing
+`try`/`catch` → `{ success, error }` **return-shape** convention
+(`session-handlers.ts:277-299`) — but, unlike an earlier draft of this
+decision claimed, the `isActive` check itself is **new**, not carried over
+from `cancelScan`: `cancelScan` guards only on `!coordinator` and
+succeeds even when `isActive` is already `false`
+(`session-handlers.test.ts` covers this directly). `retry-scanner` is
+stricter because respawning a worker with no active `scanInterval()`/
+`scanOnce()` loop to ever schedule it into a cycle would just leak a
+subprocess with nothing driving it.

--- a/openspec/changes/add-graviscan-wedge-response-ui/design.md
+++ b/openspec/changes/add-graviscan-wedge-response-ui/design.md
@@ -167,12 +167,23 @@ even avoid the worst case, since a genuinely wedged row was headed for the
 90s timeout regardless of when `stopScanner()` is called. Not covered by
 an integration test in this change (section 2's tests exercise
 `setupWedgeDetection()` against a bare `EventEmitter` standing in for the
-coordinator, not a real `ScanCoordinator` with an in-flight `scanOnce()`)
-— reproducing the exact race would need real subprocess timing, which is
-a materially larger test-infrastructure investment than this UI-focused
-tier warrants; the 90s bound itself is already covered by
-`scan-coordinator.test.ts`'s existing row-timeout tests, unchanged by this
-proposal.
+coordinator, not a real `ScanCoordinator` with an in-flight `scanOnce()`).
+**Correction (post-PR-#277-review):** an earlier revision of this section
+claimed reproducing this race would need real subprocess timing — that
+was wrong. `scan-coordinator.test.ts`'s existing row-timeout test already
+reproduces the same class of async-listener/timer race with fake timers
+and a mocked `ScannerSubprocess`, and this proposal's own
+`stopScanner()`/`addScanner()` retry-integration tests (added in a later
+commit on PR #277) prove the same file's mocked `ScannerSubprocess` is
+adequate for exactly this kind of test. The actual reason it isn't added
+here: this file's shared `createMockSubprocess()` helper stubs
+`removeAllListeners()` as a `vi.fn()` no-op rather than delegating to the
+real `EventEmitter.prototype.removeAllListeners`, so it can't yet
+faithfully reproduce listener-stripping without a small, shared change to
+that helper (which every other test in the file also depends on) — an
+unstaffed follow-up, not an infrastructure gap. The 90s bound itself is
+already covered by `scan-coordinator.test.ts`'s existing row-timeout
+tests, unchanged by this proposal.
 
 Retry's respawn is safe to call at any point in a session because
 `addScanner()` already handles mid-cycle safety: if `isScanning`, it queues

--- a/openspec/changes/add-graviscan-wedge-response-ui/proposal.md
+++ b/openspec/changes/add-graviscan-wedge-response-ui/proposal.md
@@ -1,0 +1,190 @@
+## Why
+
+Today, when the `WedgeDetector` (`src/main/wedge-detector.ts`) detects a V600
+USB wedge, the **only** thing that happens is a Slack post
+(`setupWedgeDetection()`, `src/main/graviscan/wiring.ts:253-339`). Nothing
+reaches the renderer, and nothing stops the wedged scanner: the subprocess
+"stays alive in a broken state and re-hits the wedge every subsequent
+cycle" (issue #228, the root-cause investigation this detector was built
+from) — `ScanCoordinator.scanOnce()` keeps re-scanning it every cycle for
+the rest of the session.
+
+This is a real, filed, P0 gap. Issue #228 recommends the app "stop using
+that scanner automatically... continue with remaining scanners... auto-
+resume when the scanner re-enumerates fresh." Issue #244 documents the
+consequence as "permanent data loss, no recovery": these are continuous
+time-lapse experiments, so a missed cycle on a wedged scanner cannot be
+recovered later — a "re-scan" would capture a different plant growth
+timepoint, not the missed one — and lists a per-scanner pause indicator
+with a `Power-Cycled & Resume` button as its highest-value proposed fix.
+Issue #240 documents the narrower problem that an operator physically at
+the rig, not watching Slack, has no in-app indication a wedge even
+happened.
+
+Roadmap Tier 3 (`docs/superpowers/plans/2026-07-30-graviscan-renderer-roadmap.md`)
+scopes this as its own fast-tracked tier, pulled out of the larger Tier 4
+scan-operation screen specifically so a safety fix isn't coupled to the
+tier most likely to slip. It depends only on Tier 2 (merged, PR #274),
+whose granular per-job event model made coordinator-originated errors
+visible to wedge detection for the first time — the prerequisite question
+this raised in Tier 2's design doc was backtested against the production
+rig's logs and signed off 2026-08-03: zero wedge alerts and zero zero-byte
+files across ~10 weeks, so this change proceeds without further gating on
+that question.
+
+## What Changes
+
+An earlier draft of this proposal made the operator manually click a
+"Skip" action to exclude a wedged scanner from future cycles, leaving it
+re-failing every cycle until someone noticed. Adversarial review against
+the actual source issues (#228, #244) surfaced that both describe
+**auto-pause by default** instead — this revision adopts that, since it's
+both safer for the unattended multi-day runs #244 is about and, once
+adopted, simpler (two operator actions instead of three; no separate
+"Skip" handler needed since pausing no longer waits on a human). The two
+issues diverge on the _resume_ half, though: #228 wants a fully automatic
+resume triggered by USB re-enumeration, which would need new hotplug-
+detection infrastructure this codebase doesn't have; this proposal follows
+#244's simpler manual-confirmed-retry design instead (see design.md
+Decision 1 for the full reasoning).
+
+- **Auto-pause on wedge detection.** `setupWedgeDetection()`'s `onWedge`
+  callback now calls `coordinator.stopScanner(scanner_id)` immediately
+  when a wedge fires — fire-and-forget, not gated behind the (network-
+  bound, potentially slow) Slack notification — in addition to, not
+  instead of, the existing `SlackNotifier.notify()` call. Because
+  `scanOnce()` iterates live over `this.subprocesses`
+  (`scan-coordinator.ts:479`), this excludes the scanner from all later
+  cycles in the session with no separate "exclusion" bookkeeping needed,
+  until a subsequent Retry re-adds it. Accepted tradeoff: calling
+  `stopScanner()` at detection time — rather than waiting for the
+  in-flight row to finish — can occasionally force that one row to fall
+  back to its existing 90-second timeout instead of resolving faster via
+  its own listeners (see design.md Decision 1 for why this bounded cost is
+  preferable to deferring the pause). A durable `scanLog()` line records
+  the auto-pause (scanner_id, session_id, cycle_number, signature),
+  alongside — not replacing — the pre-existing wedge-detected log line,
+  so the action has a forensic trail beyond the transient UI, addressing a
+  traceability gap the scientific-rigor review flagged.
+- **Forward wedge events to the renderer.** The same `onWedge` callback
+  sends `graviscan:wedge-detected` (the enriched payload already sent to
+  Slack — `scanner_id`, `signature`, `session_id`, `cycle_number`,
+  `timestamp`, `error_message`, `display_name`, `usb_port`) to the
+  renderer via an optional new `getMainWindow` parameter on
+  `setupWedgeDetection()`. Best-effort: a missing/destroyed window never
+  blocks the Slack path or the auto-pause.
+- **Add one new IPC handler, `graviscan:retry-scanner`**, backed by
+  `ScanCoordinator`'s existing `addScanner()` (no new coordinator methods).
+  Given a `scannerId`, it stops any worker defensively (idempotent no-op
+  in the normal case, since auto-pause already tore it down) and respawns
+  using a `saneName` rebuilt from a **fresh** database read of the
+  scanner's current `usb_bus`/`usb_device` (not a value cached from
+  session start — a `reset-usb` performed after auto-pause would otherwise
+  make a stale value wrong), reusing the exact construction already
+  inlined in the save-scanners-db handler (`register-handlers.ts:166`),
+  extracted into a shared `buildSaneName()` helper. The handler checks the
+  scanner row's `enabled` flag and fails without respawning if it's
+  `false` — a scanner an operator explicitly disabled via ConfigureScanner
+  should not be silently brought back by a stale wedge banner's Retry
+  button. The action requires an active session and a live coordinator. A
+  durable `scanLog()` line records the retry attempt and its outcome.
+- **Two operator actions per banner entry, not three:**
+  - **Dismiss** — hides that banner entry. Makes no backend call; the
+    scanner is already paused (by auto-pause, not by this click) and
+    stays paused regardless of whether the operator dismisses.
+  - **Power-Cycled & Retry** — gated behind an explicit confirmation step
+    ("I have power-cycled this scanner" → "Confirm Retry") before calling
+    `retry-scanner`, so a click before the physical power-cycle is done
+    doesn't blindly respawn into an immediate re-wedge. If a _new_ wedge
+    event for the same scanner arrives while a confirmation is pending,
+    the confirmation resets to unconfirmed — confirming a retry meant for
+    an already-superseded wedge would be misleading.
+- **Add an app-wide `WedgeBanner`**, mounted in `Layout.tsx` gated on
+  `mode === 'graviscan'` (not scoped to any one screen), so an operator
+  browsing scans or editing metadata still sees an active wedge. One
+  banner entry per wedged `scanner_id` (a new wedge for an
+  already-shown scanner replaces, not stacks); all entries clear on
+  `interval-complete`/`cancelled` (Retry is meaningless once the session
+  has ended). Alongside the per-scanner entries, a small, non-dismissible
+  session indicator tracks two numbers — total wedge events and distinct
+  scanners affected (e.g. "3 auto-pause events across 1 scanner this
+  session") — since a flat event count alone would overstate how systemic
+  a problem is when it's really one unit repeatedly re-wedging after
+  failed retries. Auto-pause removes the natural check-in point an
+  operator got for free under the old manual-Skip design (having to click
+  Skip N times made "this is happening a lot" obvious; a dismissed banner
+  doesn't), so this restores that visibility cheaply and accurately, without adding
+  any new automatic policy.
+- **In-memory only, no DB.** The banner itself is not persisted — lost on
+  app restart, matching `WedgeDetector`'s existing in-memory-only
+  lifecycle. Unlike the earlier draft, the auto-pause _action_ itself now
+  has a durable trail via `scanLog()` (see above), even though the banner
+  UI state does not. Issue #244's `wedge_event` DB-table idea (item 2) and
+  wedge-skip placeholder-row idea (item 3) are both explicitly deferred to
+  a future tier/ticket — a `scanLog()` line is a meaningfully smaller
+  commitment than either and doesn't preempt that future work.
+- **No new route, no placeholder scan-state screen.** The roadmap's
+  original framing ("rendered against a minimal placeholder scan-state
+  view") is refined here: because the banner is app-wide and
+  self-contained, it doesn't need a host screen. Tier 4 still builds the
+  real scan-operation screen; this tier adds zero new routes or nav links.
+- **Explicitly out of scope, named rather than silently dropped:** #244's
+  item 4 (auto-cancel-on-N-wedges policy) and item 5 (cancel + full-session
+  auto-restart with the same parameters) are not implemented by this
+  change. Auto-pause (this proposal) already gives an operator the
+  information and the manual lever item 4 would otherwise need to be
+  automatic about; item 5 is a session-level action orthogonal to
+  per-scanner wedge response and would need its own scoping.
+- **Share the wedge-event type with the renderer** via a type-only
+  re-export (`GraviWedgeEvent` in `src/types/graviscan.ts`, sourced from
+  `wedge-detector.ts`'s existing `WedgeDetectedEvent`) rather than a
+  duplicate interface, so the two can't drift.
+
+## Impact
+
+- Affected specs: `scanning` (ADDED — wedge auto-pause, wedge-event
+  forwarding, retry-scanner requirements), `ui-management-pages` (ADDED —
+  wedge banner and wedge-response-actions UI requirements).
+- Affected code: `src/main/graviscan/wiring.ts`, `src/main/graviscan/
+session-handlers.ts`, `src/main/graviscan/register-handlers.ts`,
+  `src/main/graviscan/scanner-handlers.ts` (new `buildSaneName()` helper),
+  `src/types/graviscan.ts`, `src/types/electron.d.ts`, `src/main/
+preload.ts`, `src/renderer/hooks/useWedgeEvents.ts` (new),
+  `src/renderer/components/WedgeBanner.tsx` (new), `src/renderer/
+Layout.tsx`. No Prisma schema changes. No changes to `App.tsx` (no new
+  route). No changes to `python/graviscan/scan_worker.py` — this change
+  consumes existing wedge-detector output; it does not touch detection
+  logic or hardware-facing code.
+- Also affected (existing tests that must be updated, not just new tests
+  added): `tests/unit/graviscan/register-handlers.test.ts` (its hardcoded
+  channel count changes), `tests/unit/pages/Layout.test.tsx` and
+  `tests/unit/pages/App.test.tsx` (their graviscan-mode `window.electron`
+  mocks currently omit `gravi.onWedgeDetected`/`onIntervalComplete`/
+  `onCancelled`; both files render `Layout`/`App` in `mode: 'graviscan'`
+  today and will throw once `WedgeBanner` mounts unconditionally in that
+  mode unless their mocks are extended first), `tests/unit/preload-gravi.test.ts`
+  (the dedicated preload channel-mapping test; extending it is how a
+  channel-name typo in the real `preload.ts` implementation gets caught,
+  since the renderer-side tests only exercise a mock), and
+  `tests/unit/graviscan/main-wiring.test.ts` (its 13 independently-declared
+  mock coordinators in the `setupWedgeDetection` describe block have no
+  `stopScanner` method today; they need a shared factory refactor before
+  `onWedge` is updated to call it, or those 13 tests throw).
+- **Coordination note:** this change touches two of the four files that
+  have needed rebase coordination between parallel GraviScan tracks before
+  (`src/main/preload.ts` — new `onWedgeDetected`/`retryScanner` entries on
+  the `graviAPI` object — and `src/renderer/Layout.tsx` — new
+  `<WedgeBanner />` mount). `src/types/electron.d.ts` is also touched (new
+  `GraviAPI` members), which is not one of the four named files but is the
+  direct type counterpart of the `preload.ts` change. `App.tsx` is **not**
+  touched. Two other tracks are running in parallel right now, each in its
+  own worktree/branch off `main`: a wave-scoped-metadata-linking backend
+  change (confirmed unrelated — schema + `database-handlers.ts` only, no
+  renderer code) and a CylinderScan finalization effort (scope still being
+  figured out as of this writing — cannot yet confirm whether it touches
+  `Layout.tsx`/`preload.ts`/`electron.d.ts`). Whoever merges second among
+  any of these should rebase onto the other rather than assume
+  independence, per the roadmap's existing coordination convention.
+- Downstream: none of Tiers 4/5 depend on this change's specific handlers —
+  Tier 4 will integrate this tier's `WedgeBanner`/`useWedgeEvents` rather
+  than rebuilding wedge-response UI, per the roadmap.

--- a/openspec/changes/add-graviscan-wedge-response-ui/specs/scanning/spec.md
+++ b/openspec/changes/add-graviscan-wedge-response-ui/specs/scanning/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: GraviScan Wedge Auto-Pause on Detection
+
+When the `WedgeDetector` emits a `wedge-detected` event, `setupWedgeDetection()` SHALL immediately stop that scanner's worker subprocess via the coordinator's existing `stopScanner(scanner_id)`, excluding it from all subsequent scan cycles in the active session unless and until a later `retry-scanner` call (see below) respawns it — without waiting for any operator action to trigger the initial pause.
+
+The auto-pause call SHALL NOT be gated behind (or delayed by) the Slack notification or the renderer-forwarding path: a slow or failing Slack webhook SHALL NOT delay stopping the wedged scanner. A durable log entry (via the existing `scanLog()` facility) SHALL record the auto-pause, including the scanner_id, signature, session_id, and cycle_number, in addition to — not instead of — the pre-existing `wedge-detected` log entry.
+
+#### Scenario: Wedge detection auto-pauses the scanner
+
+- **GIVEN** an active scan session with a running worker for scanner `sc-1`
+- **WHEN** the `WedgeDetector` emits a `wedge-detected` event for `sc-1`
+- **THEN** `coordinator.stopScanner('sc-1')` SHALL be called
+- **AND** subsequent scan cycles SHALL NOT include `sc-1`
+- **AND** a log entry recording the auto-pause SHALL be written
+
+#### Scenario: Auto-pause is not delayed by a slow Slack notification
+
+- **GIVEN** the configured `SlackNotifier.notify()` call would hang or reject
+- **WHEN** the `WedgeDetector` emits a `wedge-detected` event
+- **THEN** `coordinator.stopScanner()` SHALL still be called for the wedged scanner without waiting for the Slack call to settle
+
+---
+
+### Requirement: GraviScan Wedge Event Forwarding to Renderer
+
+`setupWedgeDetection()` SHALL forward every `wedge-detected` event emitted by the `WedgeDetector` to the renderer, in addition to — not instead of — the existing `SlackNotifier.notify()` call and the auto-pause action.
+
+The forwarded event SHALL be sent as a `graviscan:wedge-detected` IPC message carrying the same enriched payload (including `display_name`/`usb_port` when available) that is sent to Slack. Forwarding SHALL be best-effort: a missing or destroyed main window SHALL NOT throw or block the Slack notification or the auto-pause.
+
+#### Scenario: Wedge event reaches Slack, the renderer, and triggers auto-pause
+
+- **GIVEN** a `WedgeDetector` wired via `setupWedgeDetection(coordinator, db, getMainWindow)` with a live, non-destroyed main window
+- **WHEN** the detector emits a `wedge-detected` event
+- **THEN** `SlackNotifier.notify()` SHALL be called with the enriched event
+- **AND** `getMainWindow().webContents.send('graviscan:wedge-detected', ...)` SHALL be called with the same enriched event
+- **AND** `coordinator.stopScanner()` SHALL be called for the wedged scanner
+
+#### Scenario: No main window available
+
+- **GIVEN** a `WedgeDetector` wired via `setupWedgeDetection(coordinator, db)` with no third argument (or a `getMainWindow` that returns `null` or a destroyed window)
+- **WHEN** the detector emits a `wedge-detected` event
+- **THEN** the Slack notification path and the auto-pause SHALL be unaffected
+- **AND** no `webContents.send` call SHALL occur
+- **AND** no error SHALL be thrown
+
+---
+
+### Requirement: GraviScan Retry-Scanner Action
+
+The system SHALL provide a `graviscan:retry-scanner` IPC handler that, given a `scannerId`, stops that scanner's worker (`stopScanner`, a no-op if already stopped by auto-pause) and respawns it (`addScanner`) using a `saneName` rebuilt from a fresh database read of the scanner's current `usb_bus`/`usb_device` (not a value cached from session start). The action SHALL require an active scan session and a live coordinator. If the scanner's `usb_bus` or `usb_device` is null (e.g. mid `reset-usb`), the scanner row's `enabled` field is `false`, or the scanner row cannot be found, the handler SHALL fail without calling `addScanner`. The handler SHALL write a durable log entry (via `scanLog()`) recording the retry attempt and its outcome.
+
+#### Scenario: Retry respawns the worker with a fresh saneName
+
+- **GIVEN** an active scan session with a running coordinator
+- **AND** the database's `GraviScanner` row for `sc-1` has `usb_bus: 3, usb_device: 7, enabled: true`
+- **WHEN** `graviscan:retry-scanner` is invoked with `scannerId: 'sc-1'`
+- **THEN** `coordinator.stopScanner('sc-1')` SHALL be called
+- **AND** `coordinator.addScanner({ scannerId: 'sc-1', saneName: 'epkowa:interpreter:003:007', plates: [] })` SHALL be called
+- **AND** the handler SHALL resolve `{ success: true }`
+- **AND** a log entry recording the successful retry SHALL be written
+
+#### Scenario: Retry fails without respawning when USB identity is unknown
+
+- **GIVEN** an active scan session with a running coordinator
+- **AND** the database's `GraviScanner` row for `sc-1` has `usb_bus: null` (e.g. a `reset-usb` is in progress)
+- **WHEN** `graviscan:retry-scanner` is invoked with `scannerId: 'sc-1'`
+- **THEN** the handler SHALL resolve `{ success: false, error: '...' }`
+- **AND** `coordinator.addScanner` SHALL NOT be called
+
+#### Scenario: Retry fails without respawning a disabled scanner
+
+- **GIVEN** an active scan session with a running coordinator
+- **AND** the database's `GraviScanner` row for `sc-1` has `enabled: false` (the operator disabled it via ConfigureScanner's "Remove" action)
+- **WHEN** `graviscan:retry-scanner` is invoked with `scannerId: 'sc-1'`
+- **THEN** the handler SHALL resolve `{ success: false, error: '...' }`
+- **AND** `coordinator.addScanner` SHALL NOT be called
+
+#### Scenario: Retry fails when the scanner row cannot be found
+
+- **GIVEN** an active scan session with a running coordinator
+- **AND** no `GraviScanner` row exists for `sc-1`
+- **WHEN** `graviscan:retry-scanner` is invoked with `scannerId: 'sc-1'`
+- **THEN** the handler SHALL resolve `{ success: false, error: '...' }`
+- **AND** neither `coordinator.stopScanner` nor `coordinator.addScanner` SHALL be called
+
+#### Scenario: Retry fails cleanly with no active session or no coordinator
+
+- **GIVEN** either no active scan session (or a session with `isActive: false`), or no live coordinator
+- **WHEN** `graviscan:retry-scanner` is invoked with any `scannerId`
+- **THEN** the handler SHALL resolve `{ success: false, error: '...' }` without throwing
+- **AND** the database SHALL NOT be queried and `coordinator.addScanner` SHALL NOT be called
+
+#### Scenario: A rejected respawn is caught and surfaced, not left unhandled
+
+- **GIVEN** an active scan session with a running coordinator
+- **AND** the database's `GraviScanner` row for `sc-1` has valid `usb_bus`/`usb_device`/`enabled: true`
+- **WHEN** `graviscan:retry-scanner` is invoked with `scannerId: 'sc-1'`
+- **AND** `coordinator.addScanner()` rejects
+- **THEN** the handler SHALL resolve `{ success: false, error: msg }` (the rejection SHALL be caught, not left as an unhandled promise rejection)
+- **AND** a log entry recording the failed retry SHALL be written

--- a/openspec/changes/add-graviscan-wedge-response-ui/specs/ui-management-pages/spec.md
+++ b/openspec/changes/add-graviscan-wedge-response-ui/specs/ui-management-pages/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: GraviScan Wedge Banner
+
+While in GraviScan mode, the app SHALL display a `WedgeBanner`, mounted app-wide in `Layout.tsx` (not scoped to any single screen), showing one inline banner entry per scanner with an active, unacknowledged wedge. Each entry SHALL display the scanner's identity (`display_name` if available, else `scanner_id`), the detected `signature`, and the originating `error_message`, and SHALL communicate that the scanner has already been automatically paused (not that pausing is pending an operator action). Entries SHALL be styled with the existing inline error-severity convention (red border/background, matching `ConfigureScanner.tsx`'s `saveError` banner) — no toast, per this codebase's existing inline-banner convention. Multiple entries SHALL render as a vertically-stacked list that does not overlap the top navigation or other entries.
+
+A new wedge event for a scanner that already has an entry SHALL replace that entry rather than adding a second one, and SHALL reset that entry's retry-confirmation sub-state (if any was pending) to unconfirmed. All entries SHALL be cleared when the active scan session ends (on the coordinator's `interval-complete` or `cancelled` events).
+
+#### Scenario: Wedge banner appears app-wide, not screen-scoped
+
+- **GIVEN** GraviScan mode is active and a `wedge-detected` event arrives for scanner `sc-1`
+- **WHEN** the operator is on any page (e.g. Browse Scans, Experiments) — not a dedicated scan screen
+- **THEN** a banner entry for `sc-1` SHALL be visible
+
+#### Scenario: Banner communicates the scanner is already paused
+
+- **GIVEN** a `wedge-detected` event arrives for scanner `sc-1`
+- **WHEN** the banner entry for `sc-1` renders
+- **THEN** its copy SHALL indicate the scanner has already stopped/been paused, not that pausing awaits an operator click
+
+#### Scenario: Multiple entries stack without overlapping
+
+- **GIVEN** `wedge-detected` events arrive for two different scanners
+- **WHEN** both banner entries are showing
+- **THEN** they SHALL render as a vertically-stacked list with no overlap between entries or with the top navigation
+
+#### Scenario: Repeated wedge on the same scanner replaces, not stacks, and resets confirmation
+
+- **GIVEN** a banner entry is already showing for scanner `sc-1` from cycle 3, with a pending retry confirmation
+- **WHEN** a new `wedge-detected` event arrives for `sc-1` from cycle 5
+- **THEN** there SHALL be exactly one banner entry for `sc-1`, showing cycle 5's data
+- **AND** its retry-confirmation sub-state SHALL be reset to unconfirmed
+
+#### Scenario: Banner clears when the session ends
+
+- **GIVEN** one or more banner entries are showing
+- **WHEN** the coordinator emits `interval-complete` or `cancelled`
+- **THEN** all banner entries SHALL be removed
+
+---
+
+### Requirement: GraviScan Session Auto-Pause Counter
+
+While in GraviScan mode, in addition to the per-scanner banner entries, the app SHALL track and display two session-scoped numbers: the total count of `wedge-detected` events this session, and the count of distinct `scanner_id`s that have wedged at least once this session. Both SHALL be shown together in a small, non-dismissible indicator whenever the event count is greater than zero (e.g. "3 auto-pause events across 1 scanner this session"). A flat event count alone SHALL NOT be displayed without the distinct-scanner count, since a single scanner re-wedging after repeated failed retries would otherwise be indistinguishable from multiple scanners each wedging once — the two numbers exist specifically so an operator can tell an isolated, chronically-re-wedging unit apart from a systemic, multi-scanner problem. Neither number SHALL decrease when an entry is dismissed — both reflect cumulative session history, not current unacknowledged state. Both SHALL reset to zero on the same `interval-complete`/`cancelled` events that clear the per-scanner entries.
+
+#### Scenario: Event count increments on each wedge and survives dismissal
+
+- **GIVEN** the session event count is currently 1 (one prior wedge this session)
+- **WHEN** a `wedge-detected` event arrives for a second scanner, and its banner entry is then dismissed
+- **THEN** the displayed event count SHALL be 2
+- **AND** dismissing the entry SHALL NOT decrease either number
+
+#### Scenario: Repeated wedges on the same scanner increment the event count without inflating the distinct-scanner count
+
+- **GIVEN** scanner `sc-1` has wedged once this session (event count 1, distinct-scanner count 1)
+- **WHEN** `sc-1` is retried and then wedges again
+- **THEN** the displayed event count SHALL be 2
+- **AND** the displayed distinct-scanner count SHALL remain 1
+
+#### Scenario: Indicator is hidden when zero and resets with the session
+
+- **GIVEN** no `wedge-detected` event has occurred this session
+- **WHEN** the operator is in GraviScan mode
+- **THEN** no counter indicator SHALL be shown
+- **WHEN** at least one wedge has occurred and the coordinator then emits `interval-complete` or `cancelled`
+- **THEN** both numbers SHALL reset to zero and the indicator SHALL be hidden again
+
+---
+
+### Requirement: GraviScan Wedge Response Actions
+
+Each `WedgeBanner` entry SHALL offer two actions: **Dismiss** (hides the entry; makes no IPC call — the scanner is already paused by auto-pause, independent of whether or when the operator dismisses) and **Power-Cycled & Retry** (requires an explicit confirmation step, displaying explanatory text about the power-cycle precondition, before calling `retryScanner(scannerId)`; removes the entry on success, and shows the returned error inline without removing the entry on failure).
+
+#### Scenario: Dismiss hides the entry without any backend call
+
+- **GIVEN** a banner entry for scanner `sc-1`
+- **WHEN** the operator clicks "Dismiss"
+- **THEN** the entry SHALL be removed
+- **AND** `retryScanner` SHALL NOT be called
+- **AND** the scanner's paused state SHALL be unaffected (it was already paused by auto-pause)
+
+#### Scenario: Retry requires confirmation with explanatory text before the IPC call fires
+
+- **GIVEN** a banner entry for scanner `sc-1`
+- **WHEN** the operator clicks "Power-Cycled & Retry"
+- **THEN** `retryScanner` SHALL NOT be called yet
+- **AND** the entry SHALL show a confirmation sub-state that renders explanatory text describing the power-cycle precondition
+- **AND** the confirmation sub-state SHALL show distinct "Confirm Retry" and "Cancel" controls
+
+#### Scenario: Confirming retry calls the backend and removes the entry on success
+
+- **GIVEN** a banner entry for scanner `sc-1` in the retry-confirmation sub-state
+- **WHEN** the operator clicks "Confirm Retry"
+- **AND** `retryScanner('sc-1')` resolves `{ success: true }`
+- **THEN** the entry SHALL be removed
+
+#### Scenario: Retry failure keeps the entry visible with an inline error
+
+- **GIVEN** a banner entry for scanner `sc-1` in the retry-confirmation sub-state
+- **WHEN** the operator clicks "Confirm Retry"
+- **AND** `retryScanner('sc-1')` resolves `{ success: false, error: msg }`
+- **THEN** the entry SHALL remain visible
+- **AND** `msg` SHALL be shown inline on that entry
+
+#### Scenario: Cancelling the retry confirmation calls nothing
+
+- **GIVEN** a banner entry for scanner `sc-1` in the retry-confirmation sub-state
+- **WHEN** the operator clicks "Cancel"
+- **THEN** the entry SHALL revert to its unconfirmed state
+- **AND** `retryScanner` SHALL NOT be called

--- a/openspec/changes/add-graviscan-wedge-response-ui/tasks.md
+++ b/openspec/changes/add-graviscan-wedge-response-ui/tasks.md
@@ -1,0 +1,337 @@
+## 1. Shared type: `GraviWedgeEvent`
+
+- [x] 1.1 In `src/types/graviscan.ts`, add
+      `import type { WedgeDetectedEvent } from '../main/wedge-detector';`
+      and `export type GraviWedgeEvent = WedgeDetectedEvent;` (design.md
+      Decision 5). This is a type-only declaration — no dedicated test file;
+      it's exercised transitively by every test in sections 6-9 that
+      imports it. Confirm `npx tsc --noEmit` is clean immediately after
+      adding it (before anything consumes it yet).
+
+## 2. Main-process auto-pause + wedge forwarding (`wiring.ts`)
+
+- [x] 2.0 In `tests/unit/graviscan/main-wiring.test.ts`, the
+      `describe('setupWedgeDetection', ...)` block has **13 separate,
+      independently-declared** `const coordinator = new EventEmitter();`
+      mock coordinators (one per `it()`, not a shared `beforeEach`/factory)
+      — none has a `stopScanner` method today. Introduce a shared
+      `createMockWedgeCoordinator()` helper (an `EventEmitter` with
+      `stopScanner: vi.fn().mockResolvedValue(undefined)` attached, e.g.
+      via `Object.assign`) and refactor **all 13** of those call sites to
+      use it instead of constructing a bare `new EventEmitter()` inline —
+      matching the spirit of `session-handlers.test.ts`'s
+      `createMockCoordinator()` factory (that file bakes the mock directly
+      into a returned object literal rather than via `Object.assign` on an
+      `EventEmitter`, since it isn't event-based — the mechanism differs
+      but the "one shared factory, not 13 inline copies" principle is the
+      same). This must land before 2.1 — patching only some of the 13 sites
+      leaves the rest throwing `TypeError: coordinator.stopScanner is not a
+function` once `onWedge` calls it (task 2.7).
+- [x] 2.1 Add a failing test: drive the coordinator through the existing
+      sane_start_invalid wedge scenario (reuse the existing event sequence
+      from the current passing test). Assert `coordinator.stopScanner` is
+      called exactly once with the wedged scanner's id (spy on the mock
+      coordinator's `stopScanner` from 2.0). Confirm it fails (current
+      `onWedge` never calls `stopScanner`).
+- [x] 2.2 Add a failing test: the `stopScanner` call happens even if
+      `SlackNotifier.notify()` would reject/hang — assert `stopScanner` is
+      called synchronously within the `onWedge` callback's own call stack,
+      not nested inside the async enrich/notify IIFE (i.e. mock
+      `enrichWedgeEvent`/the notifier to never resolve, and still assert
+      `stopScanner` was called).
+- [x] 2.3 Add a failing test: `setupWedgeDetection(coordinator, db,
+getMainWindowMock)` where `getMainWindowMock` returns a mock
+      `BrowserWindow`-like object with a spyable `webContents.send`. Assert
+      `webContents.send` is called with `('graviscan:wedge-detected',
+expect.objectContaining({ scanner_id: 'sc-1', signature:
+'sane_start_invalid', session_id, cycle_number, error_message }))`.
+      Confirm it fails (current signature has no third parameter, no send
+      call).
+- [x] 2.4 Add a failing test: same wedge scenario, but call
+      `setupWedgeDetection(coordinator, db)` (no third argument — the
+      existing call shape). Assert no throw, and `stopScanner`/`slackNotifier
+.notify` still fire exactly as in 2.1/existing behavior. Confirm it
+      passes once 2.7 is implemented without any behavior change for
+      omitted-argument callers.
+- [x] 2.5 Add a failing test: `getMainWindow` provided but returns a window
+      whose `isDestroyed()` is `true` (or returns `null`). Assert `send` is
+      NOT called, `stopScanner` and Slack notify still fire, and nothing
+      throws.
+- [x] 2.6 Add a failing test: on the same sane_start_invalid wedge scenario,
+      assert `scanLog` is called with a message matching `/auto-paused
+scanner=sc-1 signature=sane_start_invalid session=.* cycle=1/` — the
+      NEW log line this proposal adds — **in addition to** the existing,
+      already-passing assertion that `scanLog` is still called with the
+      pre-existing `wedge-detected ...` message (do not remove or replace
+      that existing assertion/call). Confirm the new assertion fails
+      (the line doesn't exist yet) while the pre-existing one still passes.
+- [x] 2.7 Implement: inside `onWedge`, call `coordinator.stopScanner(evt
+.scanner_id)` fire-and-forget with a `.catch()` logging any rejection.
+      Keep the existing `scanLog('[WedgeDetector] wedge-detected ...')` line
+      unchanged, and add a **second**, new `scanLog(...)` line recording the
+      auto-pause (`scanner_id`, `signature`, `session_id`, `cycle_number`) —
+      per design.md Decision 1, Decision 3, and Decision 6's code sample.
+      Add the optional third parameter `getMainWindow` to
+      `setupWedgeDetection()`'s signature (default `null`); inside the
+      existing async enrich+notify IIFE, add the guarded
+      `win.webContents.send('graviscan:wedge-detected', enriched)` call per
+      design.md Decision 6. Update the call site in
+      `getOrCreateCoordinator()` (`wiring.ts:382`) to pass `_getMainWindow`.
+      Confirm 2.1-2.6 pass.
+- [x] 2.8 Run the full existing `main-wiring.test.ts` suite (all wedge
+      signature tests: sane_start, device-I/O, consecutive-failures,
+      cycle-boundary reset, dedup, recovered-scan, idempotent cycle-start,
+      including the pre-existing `wedge-detected` scanLog assertion).
+      Confirm every previously-passing test still passes unmodified — this
+      is a pure addition to `onWedge`, not a change to detection logic.
+- [x] 2.9 Checkpoint: `npm run lint && npx tsc --noEmit && npm run
+test:unit`.
+
+## 3. `buildSaneName()` extraction
+
+- [x] 3.1 In `tests/unit/graviscan/scanner-handlers.test.ts`, add a failing
+      test for a new export `buildSaneName(usbBus: number, usbDevice:
+number): string`: `buildSaneName(3, 7)` → `'epkowa:interpreter:003:007'`,
+      plus `buildSaneName(123, 45)` → `'epkowa:interpreter:123:045'`
+      (confirms zero-padding on both sides independently). Confirm it
+      fails (export doesn't exist yet).
+- [x] 3.2 Implement `buildSaneName()` in `src/main/graviscan/
+scanner-handlers.ts`, matching the exact format currently inlined at
+      `register-handlers.ts:166`. Confirm 3.1 passes.
+- [x] 3.3 Refactor `register-handlers.ts`'s spawn-on-discovery block
+      (~line 166) to call `buildSaneName(saved.usb_bus, saved.usb_device)`
+      instead of the inline template string. Run the existing
+      `register-handlers.test.ts` / `graviscan-ipc-integration.test.ts`
+      suites covering `save-scanners-db`'s spawn-on-discovery path — confirm
+      they still pass unmodified (pure refactor, identical output).
+- [x] 3.4 Checkpoint: `npm run lint && npx tsc --noEmit && npm run
+test:unit` (this refactor touches production code on the
+      spawn-on-discovery path; gate it before section 4 begins).
+
+## 4. `retry-scanner` handler
+
+- [x] 4.1 In `tests/unit/graviscan/session-handlers.test.ts`, add a failing
+      test: `retryScanner(coordinator, db, sessionFns, 'sc-1')` with an
+      active session, a coordinator mock, and a `db.graviScanner.findUnique`
+      mock resolving `{ usb_bus: 3, usb_device: 7, enabled: true }` → calls
+      `coordinator.stopScanner('sc-1')` then `coordinator.addScanner({
+scannerId: 'sc-1', saneName: 'epkowa:interpreter:003:007', plates: []
+})`, resolves `{ success: true }`, and writes a `scanLog()` line
+      recording the successful retry. Confirm it fails (export doesn't
+      exist).
+- [x] 4.2 Add a failing test: `db.graviScanner.findUnique` resolves `null`
+      (scanner row not found) → resolves `{ success: false, error: '...' }`;
+      `stopScanner`/`addScanner` NOT called.
+- [x] 4.3 Add a failing test: found row has `usb_bus: null` (or
+      `usb_device: null`, e.g. mid reset-usb) → resolves `{ success: false,
+error: '...' }` without calling `addScanner` (design.md Decision 7).
+- [x] 4.4 Add a failing test: found row has `enabled: false` → resolves
+      `{ success: false, error: '...' }` without calling `addScanner`
+      (design.md Decision 7's `enabled` check — a scanner explicitly
+      disabled via ConfigureScanner's "Remove" action must not be silently
+      respawned by a stale wedge banner).
+- [x] 4.5 Add a failing test: no active session (`sessionFns
+.getScanSession()` returns `null` or `{ isActive: false, ... }`) →
+      resolves `{ success: false, error: '...' }` without calling
+      `findUnique`/`stopScanner`/`addScanner`.
+- [x] 4.6 Add a failing test: `coordinator` is `null` → resolves
+      `{ success: false, error: '...' }` without throwing.
+- [x] 4.7 Add a failing test: `stopScanner` resolves but `addScanner`
+      rejects → surfaced as `{ success: false, error: msg }` (caught, not
+      an unhandled rejection), and a `scanLog()` line records the failed
+      retry attempt.
+- [x] 4.8 Implement `retryScanner()` in `session-handlers.ts`, using
+      `buildSaneName()` from section 3 and a narrow `db` parameter type
+      (design.md Decision 7 — not the full `PrismaClient`). Confirm
+      4.1-4.7 pass.
+- [x] 4.9 In `tests/unit/graviscan/register-handlers.test.ts`, add a failing
+      test analogous to the existing `cancel-scan` registration test,
+      asserting `ipcMain.handle('graviscan:retry-scanner', ...)` wires the
+      DB handle and `sessionFns` through to `sessionHandlers.retryScanner`
+      and returns its result via the existing `wrapHandler` shape. Confirm
+      it fails (channel not registered).
+- [x] 4.10 Update `register-handlers.test.ts`'s hardcoded `CHANNELS` array
+      (currently 21 entries, asserted via `toHaveBeenCalledTimes(21)`) to
+      add `'graviscan:retry-scanner'` and bump the expected count to 22.
+      This existing test WILL fail once 4.11 registers the new channel if
+      this task is skipped.
+- [x] 4.11 Implement the `ipcMain.handle('graviscan:retry-scanner', ...)`
+      registration in `register-handlers.ts`, alongside the existing
+      session handlers (~line 318, near `cancel-scan`). Update the file's
+      own docstring (`register-handlers.ts:4`, "21 IPC channels") to say 22. Confirm 4.9-4.10 pass.
+- [x] 4.12 Checkpoint: `npm run lint && npx tsc --noEmit && npm run
+test:unit`.
+
+## 5. `preload.ts` + `electron.d.ts`
+
+- [x] 5.1 In `tests/unit/preload-gravi.test.ts`, extend the existing
+      `invokeMethods` array (currently 17 entries) with `retryScanner` →
+      `'graviscan:retry-scanner'`, and the existing `listenerMethods` array
+      (currently 13 entries) with `onWedgeDetected` →
+      `'graviscan:wedge-detected'`, following the file's existing per-method
+      pattern (e.g. `getScannerStatus`'s invoke-method assertion,
+      `onScanStarted`'s listener-registration/cleanup/payload-forwarding
+      assertions). Confirm these fail (the methods don't exist in
+      `preload.ts` yet) — this is the test that actually exercises the real
+      `preload.ts` module (not a mock), so it's what catches a channel-name
+      typo in the implementation.
+- [x] 5.2 Add `onWedgeDetected`, `retryScanner` to the `graviAPI` object in
+      `src/main/preload.ts`, following the existing `onScanError`/
+      `cancelScan` patterns exactly (listener + cleanup function for the
+      former; `ipcRenderer.invoke` for the latter). Confirm 5.1 passes.
+- [x] 5.3 Add matching members to the `GraviAPI` interface in
+      `src/types/electron.d.ts`: `onWedgeDetected: (callback: (event:
+GraviWedgeEvent) => void) => () => void;`, `retryScanner: (scannerId:
+string) => Promise<{ success: true } | { success: false; error:
+string }>;`.
+- [x] 5.4 Checkpoint: `npx tsc --noEmit` — this gates all renderer work
+      below, which imports `window.electron.gravi.*` through these types.
+
+## 6. Renderer hook: `useWedgeEvents`
+
+- [x] 6.1 Create `tests/unit/hooks/useWedgeEvents.test.ts`. Add a failing
+      test: mocking `window.electron.gravi.onWedgeDetected` to synchronously
+      invoke its callback with a sample `GraviWedgeEvent` on mount, assert
+      the hook's returned state contains one entry keyed by `scanner_id`.
+      Confirm it fails (hook doesn't exist).
+- [x] 6.2 Add a failing test: firing a second `onWedgeDetected` event for
+      the same `scanner_id` (different `cycle_number`/`signature`) results
+      in exactly one entry for that scanner, with the newer event's data,
+      and any in-progress retry-confirmation sub-state for that entry reset
+      to unconfirmed (design.md Decision 2/4).
+- [x] 6.3 Add a failing test: firing `onWedgeDetected` for two different
+      `scanner_id`s results in two independent entries, and dismissing (or
+      confirming retry on) one leaves the other's data and confirmation
+      state untouched.
+- [x] 6.4 Add a failing test: after at least one wedge event, firing the
+      mocked `onIntervalComplete` callback clears all entries.
+- [x] 6.5 Add a failing test: after at least one wedge event, firing the
+      mocked `onCancelled` callback clears all entries.
+- [x] 6.6 Add a failing test: the hook exposes a `dismiss(scannerId)`
+      function that removes exactly that entry (backs the Dismiss action —
+      no IPC call from the hook itself for this path).
+- [x] 6.7 Add a failing test: unmounting the hook calls all three returned
+      cleanup functions (`onWedgeDetected`, `onIntervalComplete`,
+      `onCancelled` unsubscribes) — no leaked listeners.
+- [x] 6.8 Add a failing test: the hook also returns a session-scoped
+      `totalAutoPauseEvents` count (design.md Decision 4's "session-level
+      auto-pause counter") that increments on every `onWedgeDetected` event
+      — including repeats for the same `scanner_id`, unlike the per-scanner
+      entry map — and is unaffected by `dismiss()`.
+- [x] 6.9 Add a failing test: the hook also returns a
+      `totalScannersAffected` count — the size of the set of distinct
+      `scanner_id`s that have fired at least one `onWedgeDetected` event
+      this session. Firing a second event for a scanner already counted
+      (e.g. after a retry) SHALL increment `totalAutoPauseEvents` but SHALL
+      NOT increment `totalScannersAffected`; firing an event for a new
+      `scanner_id` SHALL increment both.
+- [x] 6.10 Add a failing test: both `totalAutoPauseEvents` and
+      `totalScannersAffected` reset to `0` when the mocked
+      `onIntervalComplete` or `onCancelled` callback fires, at the same
+      time the per-scanner entries clear.
+- [x] 6.11 Implement `src/renderer/hooks/useWedgeEvents.ts`. Confirm
+      6.1-6.10 pass.
+
+## 7. `WedgeBanner` component
+
+- [x] 7.1 Create `tests/unit/components/WedgeBanner.test.tsx`. Add a
+      failing test: given one active wedge event (via a mocked
+      `useWedgeEvents` return value or the real hook + mocked IPC), the
+      component renders a banner showing `scanner_id`/`display_name`,
+      `signature`, and `error_message`, with copy indicating the scanner
+      has already been paused (not that pausing is pending), styled with
+      the existing error severity convention (`bg-red-50 border-2
+border-red-500`, matching `ConfigureScanner.tsx`'s `saveError`
+      banner). Confirm it fails (component doesn't exist).
+- [x] 7.2 Add a failing test: given two active wedge events (different
+      scanners), two banner entries render as a vertically-stacked list
+      (design.md Decision 4 — no overlap), each independently actionable.
+- [x] 7.3 Add a failing test: clicking "Dismiss" on an entry calls the
+      hook's `dismiss(scannerId)` and removes that entry; asserts
+      `window.electron.gravi.retryScanner` is NOT called.
+- [x] 7.4 Add a failing test: clicking "Power-Cycled & Retry" does NOT call
+      `retryScanner` yet — it shows a confirmation sub-state containing
+      explicit explanatory text about the power-cycle precondition (not
+      just bare buttons — design.md Decision 2) plus distinct "Confirm
+      Retry" and "Cancel" controls.
+- [x] 7.5 Add a failing test: from the confirmation sub-state, clicking
+      "Confirm Retry" calls `window.electron.gravi.retryScanner(scannerId)`;
+      on `{ success: true }` the entry is removed.
+- [x] 7.6 Add a failing test: from the confirmation sub-state, clicking
+      "Cancel" reverts to the unconfirmed state without calling
+      `retryScanner`.
+- [x] 7.7 Add a failing test: clicking "Confirm Retry" when `retryScanner`
+      resolves `{ success: false, error }` leaves the entry in place (still
+      in the confirmed-but-failed state) and shows the error inline.
+- [x] 7.8 Add a failing test: when the hook's `totalAutoPauseEvents` is `0`,
+      no counter indicator renders; when it is greater than `0` (e.g.
+      `totalAutoPauseEvents: 3, totalScannersAffected: 1`), a small,
+      non-dismissible indicator renders showing **both** numbers together
+      (e.g. "3 auto-pause events across 1 scanner this session") — not the
+      event count alone, since that alone would misrepresent one
+      repeatedly-re-wedging scanner as a multi-scanner problem. Distinct
+      from, and not removable by dismissing, any per-scanner entry.
+- [x] 7.9 Implement `src/renderer/components/WedgeBanner.tsx`, including the
+      counter indicator from 7.8. Confirm 7.1-7.8 pass.
+
+## 8. Layout wiring (and fixing pre-existing tests it would otherwise break)
+
+- [x] 8.1 Update `tests/unit/pages/Layout.test.tsx`'s `beforeEach` mock of
+      `window.electron` to include a `gravi` object with no-op
+      `onWedgeDetected`/`onIntervalComplete`/`onCancelled` (each returning
+      an unsubscribe no-op) and a `retryScanner` stub. **This must land
+      before task 8.3** — the file's one existing graviscan-mode test
+      (rendering `Layout` with `mode="graviscan"`, at line 41) will
+      otherwise throw once `WedgeBanner` mounts unconditionally in that
+      mode and `useWedgeEvents()` calls `window.electron.gravi
+.onWedgeDetected` on `undefined`.
+- [x] 8.2 Update `tests/unit/pages/App.test.tsx`'s `mockGraviAPI` (used by
+      its three graviscan-mode tests, which render the real `App`→`Layout`
+      tree) with the same three no-op methods, for the same reason as 8.1.
+- [x] 8.3 In `tests/unit/pages/Layout.test.tsx`, add a failing test:
+      rendering `Layout` with `mode === 'graviscan'` renders `WedgeBanner`
+      (assert via a test id or mocked-module render check); rendering with
+      `mode === 'cylinderscan'` does NOT render it. Confirm it fails
+      (not wired yet).
+- [x] 8.4 Add a failing test: rendering `Layout` with `mode === 'graviscan'`
+      and an arbitrary child route (e.g. the existing `"Home content"`
+      stub used elsewhere in this file), with `onWedgeDetected` mocked to
+      fire an event on mount — assert the banner's text is visible
+      alongside the child route's content. This is the test that actually
+      proves the "app-wide, not screen-scoped" requirement (design.md
+      Decision 4) — a component-level test of `WedgeBanner` alone (section 7) doesn't prove it renders regardless of which route is active.
+- [x] 8.5 Wire `<WedgeBanner />` into `src/renderer/Layout.tsx`, gated on
+      `mode === 'graviscan'`, following the existing `showGraviscanLinks`
+      conditional pattern (`Layout.tsx:217-227`). Position it as a fixed,
+      vertically-stacked strip below the top nav (design.md Decision 4).
+      Confirm 8.1-8.4 pass.
+- [x] 8.6 Checkpoint: `npm run lint && npx tsc --noEmit && npm run
+test:unit`.
+
+## 9. Full regression + spec validation
+
+- [x] 9.1 Run `npm run test:unit` in full. Confirm zero regressions —
+      document the before/after test count (by test ID, not just totals),
+      matching Tier 1/2's convention.
+- [x] 9.2 Run `npm run lint && npx tsc --noEmit`.
+- [x] 9.3 Confirm this change adds no `database.*`/`db:*` IPC handlers, so
+      the `tests/e2e/renderer-database-ipc.e2e.ts` static coverage gate
+      (which reads only `src/main/database-handlers.ts` per
+      `scripts/check-ipc-coverage.py`) is unaffected — the new
+      `graviscan:retry-scanner` handler lives in `register-handlers.ts`,
+      outside that gate's scope. Verified at proposal time; no task needed.
+- [x] 9.4 Document (do not attempt) E2E infeasibility: a Playwright E2E
+      scenario exercising a real wedge (mock hardware → wedge fires →
+      banner appears → Retry) is not attempted in this change.
+      `python/graviscan/scan_worker.py`'s mock path (`_mock_scan()`) always
+      succeeds and has no fault-injection mechanism (no env var/flag that
+      forces a `sane_start`-style exception, a zero-byte file, or a
+      row-timeout) — triggering a wedge signature deterministically through
+      the existing mock-hardware harness would require adding new
+      production fault-injection code to the Python worker, which is out of
+      scope for this change (and would pull `python/tests/`'s 80% coverage
+      requirement into a UI/IPC-wiring change that otherwise touches no
+      Python at all). Rely on sections 2 (main-wiring), 4 (handler), and
+      6-8 (renderer) instead.
+- [x] 9.5 `openspec validate add-graviscan-wedge-response-ui --strict` —
+      resolve every issue before requesting review.

--- a/openspec/changes/add-graviscan-wedge-response-ui/tasks.md
+++ b/openspec/changes/add-graviscan-wedge-response-ui/tasks.md
@@ -335,3 +335,15 @@ test:unit`.
       6-8 (renderer) instead.
 - [x] 9.5 `openspec validate add-graviscan-wedge-response-ui --strict` —
       resolve every issue before requesting review.
+- [x] 9.6 Added post-implementation, during pre-merge review: real-
+      coordinator-level tests for `stopScanner()` + `addScanner()` — the
+      exact sequence `retryScanner()` calls — in
+      `tests/unit/graviscan/scan-coordinator.test.ts`. Every other test of
+      this sequence in the codebase (main-wiring, register-handlers,
+      session-handlers) exercised it against a fully mocked
+      `ScanCoordinator`; this was flagged as a real gap (the PR's original
+      "Integration Tests: N/A" claim was wrong) before this task was added.
+      Two new tests: (1) stop-then-respawn while idle, (2) a retried
+      scanner's `addScanner()` call queuing correctly until
+      `cycle-complete` while a _different_ scanner is mid-cycle — the
+      actual "Retry clicked while the session keeps running" scenario.

--- a/openspec/specs/scanning/spec.md
+++ b/openspec/specs/scanning/spec.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 TBD - created by archiving change fix-scanner-event-listener-leak. Update Purpose after archive.
+
 ## Requirements
+
 ### Requirement: Scanner Event Listener Lifecycle
 
 Scanner event listeners SHALL be properly cleaned up when component unmounts or dependencies change to prevent memory leaks and duplicate event handling.
@@ -3598,4 +3600,3 @@ workflow steps.
 - **GIVEN** scanner mode is `cylinderscan`
 - **WHEN** the Layout sidebar renders
 - **THEN** no "Configure Scanner" nav link SHALL be rendered
-

--- a/openspec/specs/ui-management-pages/spec.md
+++ b/openspec/specs/ui-management-pages/spec.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 This specification defines the requirements for the UI management pages for both Scientists and Phenotypers. It covers the functionality and user experience for listing, creating, editing, and deleting Scientists and Phenotypers, ensuring that users can efficiently manage these entities through intuitive interfaces, robust validation, and clear feedback. The goal is to provide a unified, consistent, and reliable management experience for both Scientists and Phenotypers within the application.
+
 ## Requirements
+
 ### Requirement: Scientists List View
 
 The Scientists page SHALL display all scientists from the database in a clean, readable list format, with support for both empty and populated states.
@@ -2134,4 +2136,3 @@ presence is transmitted to the renderer).
   Slack state from the "configured" libusb-recovery state (e.g. via
   color or icon), so the operator does not need to read closely to
   notice a missing wedge-alert channel
-

--- a/src/main/graviscan/register-handlers.ts
+++ b/src/main/graviscan/register-handlers.ts
@@ -1,7 +1,7 @@
 /**
  * GraviScan IPC Handler Registration
  *
- * Wraps pure handler functions with ipcMain.handle() for 21 IPC channels.
+ * Wraps pure handler functions with ipcMain.handle() for 22 IPC channels.
  * This is the ONLY file where ipcMain.handle() calls exist for GraviScan.
  *
  * This is also where coordinator-aware orchestration around the DB-only
@@ -163,7 +163,10 @@ export function registerGraviScanHandlers(
             continue;
           }
 
-          const saneName = `epkowa:interpreter:${String(saved.usb_bus).padStart(3, '0')}:${String(saved.usb_device).padStart(3, '0')}`;
+          const saneName = scannerHandlers.buildSaneName(
+            saved.usb_bus,
+            saved.usb_device
+          );
           spawnChain = spawnChain.then(() => {
             console.log(
               `[GraviScan:SAVE] Spawning worker for newly-discovered scanner ${saved.id} (port ${saved.usb_port})`
@@ -319,6 +322,14 @@ export function registerGraviScanHandlers(
     wrapHandler(() =>
       sessionHandlers.cancelScan(getCoordinator(), sessionFns)
     )()
+  );
+
+  // Returns `retryScanner()`'s own `{ success, error? }` shape directly
+  // (matching `disable-scanner`'s convention above) rather than via
+  // `wrapHandler`, which would double-nest it inside a `{ success, data }`
+  // envelope — `retryScanner()` already does its own try/catch.
+  ipcMain.handle('graviscan:retry-scanner', (_event, scannerId: string) =>
+    sessionHandlers.retryScanner(getCoordinator(), db, sessionFns, scannerId)
   );
 
   // --- Image handlers ---

--- a/src/main/graviscan/scanner-handlers.ts
+++ b/src/main/graviscan/scanner-handlers.ts
@@ -30,6 +30,16 @@ const MOCK_SCANNER_COUNT = 2;
 /** Time to wait for USB bus to release after subprocess shutdown. */
 const USB_RELEASE_WAIT_MS = 5000;
 
+/**
+ * Build a SANE device name from a scanner's USB bus/device numbers,
+ * zero-padded to 3 digits each. Shared by the save-scanners-db spawn-on-
+ * discovery path and the wedge-response `retry-scanner` handler, so the
+ * format lives in exactly one place.
+ */
+export function buildSaneName(usbBus: number, usbDevice: number): string {
+  return `epkowa:interpreter:${String(usbBus).padStart(3, '0')}:${String(usbDevice).padStart(3, '0')}`;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers — mock-scanner construction & DB matching
 // ---------------------------------------------------------------------------

--- a/src/main/graviscan/session-handlers.ts
+++ b/src/main/graviscan/session-handlers.ts
@@ -334,12 +334,27 @@ export async function cancelScan(
  * than from any value cached at session start, since a `reset-usb`
  * performed after auto-pause would otherwise make a stale value wrong.
  */
+// Tracks scanner_ids with a retryScanner() call currently in flight. A
+// scanner can re-wedge (and its banner entry remount, resetting the UI's
+// own `retrying` guard) before a prior retry's stopScanner()+addScanner()
+// pair has resolved — without this guard, a second concurrent retry for
+// the same scannerId could race the first (addScanner() only dedupes
+// concurrent calls while a cycle is in flight; it does not when idle).
+const retriesInFlight = new Set<string>();
+
 export async function retryScanner(
   coordinator: ScanCoordinatorLike | null,
   db: ScannerRetryLookupDb,
   sessionFns: SessionFns,
   scannerId: string
 ): Promise<{ success: boolean; error?: string }> {
+  if (retriesInFlight.has(scannerId)) {
+    return {
+      success: false,
+      error: `Retry already in progress for scanner ${scannerId}`,
+    };
+  }
+  retriesInFlight.add(scannerId);
   try {
     if (!sessionFns.getScanSession()?.isActive) {
       return { success: false, error: 'No active scan session' };
@@ -374,5 +389,7 @@ export async function retryScanner(
       `[WedgeResponse] retry failed scanner=${scannerId} error=${message}`
     );
     return { success: false, error: message };
+  } finally {
+    retriesInFlight.delete(scannerId);
   }
 }

--- a/src/main/graviscan/session-handlers.ts
+++ b/src/main/graviscan/session-handlers.ts
@@ -8,10 +8,29 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { PlateConfig, ScannerConfig } from '../../types/graviscan';
+import { buildSaneName } from './scanner-handlers';
+import { scanLog } from './scan-logger';
 
 // ---------------------------------------------------------------------------
 // Interface types
 // ---------------------------------------------------------------------------
+
+/**
+ * Minimal shape `retryScanner()` needs to read a scanner's current USB
+ * identity and enabled state. Deliberately narrower than `PrismaClient`
+ * (design.md Decision 7) — `session-handlers.ts` otherwise has zero DB
+ * dependency, matching `wiring.ts`'s `ScannerLookupDb` convention for the
+ * same kind of "read one scanner row for a spawn-related decision" case.
+ */
+export interface ScannerRetryLookupDb {
+  graviScanner: {
+    findUnique: (args: { where: { id: string } }) => Promise<{
+      usb_bus: number | null;
+      usb_device: number | null;
+      enabled: boolean;
+    } | null>;
+  };
+}
 
 export interface ScanCoordinatorLike {
   readonly isScanning: boolean;
@@ -295,5 +314,65 @@ export async function cancelScan(
       success: false,
       error: error instanceof Error ? error.message : 'Cancel failed',
     };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// retryScanner
+// ---------------------------------------------------------------------------
+
+/**
+ * Respawn a scanner after an operator confirms it has been physically
+ * power-cycled following a wedge auto-pause (design.md Decisions 1, 2, 7).
+ *
+ * Stricter than `cancelScan`'s guard: requires an active session, not just
+ * a live coordinator — respawning a worker with no active `scanInterval()`/
+ * `scanOnce()` loop to schedule it into a cycle would just leak a
+ * subprocess with nothing driving it (design.md Decision 8).
+ *
+ * Reads `usb_bus`/`usb_device`/`enabled` fresh from the database rather
+ * than from any value cached at session start, since a `reset-usb`
+ * performed after auto-pause would otherwise make a stale value wrong.
+ */
+export async function retryScanner(
+  coordinator: ScanCoordinatorLike | null,
+  db: ScannerRetryLookupDb,
+  sessionFns: SessionFns,
+  scannerId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    if (!sessionFns.getScanSession()?.isActive) {
+      return { success: false, error: 'No active scan session' };
+    }
+    if (!coordinator) {
+      return { success: false, error: 'ScanCoordinator not initialized' };
+    }
+
+    const row = await db.graviScanner.findUnique({ where: { id: scannerId } });
+    if (!row) {
+      return { success: false, error: `Scanner ${scannerId} not found` };
+    }
+    if (row.usb_bus == null || row.usb_device == null) {
+      return {
+        success: false,
+        error: `Scanner ${scannerId} is missing usb_bus/usb_device (likely mid reset-usb)`,
+      };
+    }
+    if (!row.enabled) {
+      return { success: false, error: `Scanner ${scannerId} is disabled` };
+    }
+
+    const saneName = buildSaneName(row.usb_bus, row.usb_device);
+    await coordinator.stopScanner(scannerId);
+    await coordinator.addScanner({ scannerId, saneName, plates: [] });
+
+    scanLog(`[WedgeResponse] retry succeeded scanner=${scannerId}`);
+    return { success: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Retry failed';
+    scanLog(
+      `[WedgeResponse] retry failed scanner=${scannerId} error=${message}`
+    );
+    return { success: false, error: message };
   }
 }

--- a/src/main/graviscan/wiring.ts
+++ b/src/main/graviscan/wiring.ts
@@ -252,7 +252,8 @@ export function setupCoordinatorEventForwarding(
  */
 export function setupWedgeDetection(
   coordinator: ScanCoordinator,
-  db: ScannerLookupDb | null = null
+  db: ScannerLookupDb | null = null,
+  getMainWindow: (() => BrowserWindow | null) | null = null
 ): void {
   const slackNotifier = new SlackNotifier({
     webhookUrl: process.env.BLOOM_GRAVISCAN_SLACK_WEBHOOK_URL,
@@ -265,13 +266,35 @@ export function setupWedgeDetection(
     wedgeDetector = new WedgeDetector({
       sessionId,
       onWedge: (evt) => {
-        void (async () => {
-          const enriched = await enrichWedgeEvent(evt, db);
-          void slackNotifier.notify(enriched);
-        })();
+        // Auto-pause first, fire-and-forget — don't let a slow/failing
+        // Slack call or DB enrichment delay stopping the wedged scanner
+        // (design.md Decision 1). `coordinator` is already in scope as
+        // this function's first parameter.
+        void coordinator.stopScanner(evt.scanner_id).catch((err) => {
+          console.error(
+            `[WedgeDetector] Failed to auto-pause ${evt.scanner_id}:`,
+            err
+          );
+        });
+        // Pre-existing line — unchanged.
         scanLog(
           `[WedgeDetector] wedge-detected scanner=${evt.scanner_id} signature=${evt.signature} cycle=${evt.cycle_number}`
         );
+        // New line for the auto-pause action itself (design.md Decision
+        // 3) — includes session_id to disambiguate cycle numbers across
+        // sessions that share a calendar-day log file.
+        scanLog(
+          `[WedgeDetector] auto-paused scanner=${evt.scanner_id} signature=${evt.signature} session=${evt.session_id} cycle=${evt.cycle_number}`
+        );
+
+        void (async () => {
+          const enriched = await enrichWedgeEvent(evt, db);
+          void slackNotifier.notify(enriched);
+          const win = getMainWindow?.();
+          if (win && !win.isDestroyed()) {
+            win.webContents.send('graviscan:wedge-detected', enriched);
+          }
+        })();
       },
     });
     lastSeenCycleNumber = -1;
@@ -378,8 +401,10 @@ export async function getOrCreateCoordinator(): Promise<ScanCoordinator> {
     }
 
     // Wire wedge detection + Slack notification (#236), enriched with
-    // scanner display_name/usb_port when a db handle is available (#4)
-    setupWedgeDetection(scanCoordinator, _db);
+    // scanner display_name/usb_port when a db handle is available (#4),
+    // and forwarded to the renderer + auto-pausing the wedged scanner
+    // when a main window getter is available (Tier 3 wedge-response UI)
+    setupWedgeDetection(scanCoordinator, _db, _getMainWindow);
 
     return scanCoordinator;
   })();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -371,6 +371,8 @@ const graviAPI = {
   markJobRecorded: (jobKey: string) =>
     ipcRenderer.invoke('graviscan:mark-job-recorded', jobKey),
   cancelScan: () => ipcRenderer.invoke('graviscan:cancel-scan'),
+  retryScanner: (scannerId: string) =>
+    ipcRenderer.invoke('graviscan:retry-scanner', scannerId),
 
   // Image operations
   getOutputDir: () => ipcRenderer.invoke('graviscan:get-output-dir'),
@@ -453,6 +455,12 @@ const graviAPI = {
     ipcRenderer.on('graviscan:download-progress', listener);
     return () =>
       ipcRenderer.removeListener('graviscan:download-progress', listener);
+  },
+  onWedgeDetected: (callback: (event: any) => void) => {
+    const listener = (_event: unknown, data: any) => callback(data);
+    ipcRenderer.on('graviscan:wedge-detected', listener);
+    return () =>
+      ipcRenderer.removeListener('graviscan:wedge-detected', listener);
   },
 };
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -40,6 +40,8 @@ import type {
   ScanFilters,
   PaginatedScanFilters,
 } from '../types/database';
+// eslint-disable-next-line import/no-unresolved
+import type { GraviWedgeEvent } from '../types/graviscan';
 
 /**
  * Python backend API exposed to renderer
@@ -456,8 +458,8 @@ const graviAPI = {
     return () =>
       ipcRenderer.removeListener('graviscan:download-progress', listener);
   },
-  onWedgeDetected: (callback: (event: any) => void) => {
-    const listener = (_event: unknown, data: any) => callback(data);
+  onWedgeDetected: (callback: (event: GraviWedgeEvent) => void) => {
+    const listener = (_event: unknown, data: GraviWedgeEvent) => callback(data);
     ipcRenderer.on('graviscan:wedge-detected', listener);
     return () =>
       ipcRenderer.removeListener('graviscan:wedge-detected', listener);

--- a/src/renderer/Layout.tsx
+++ b/src/renderer/Layout.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { NavLink, Outlet, useNavigate } from 'react-router-dom';
+import { WedgeBanner } from './components/WedgeBanner';
 
 /** Maps scanner_mode values to human-readable labels */
 function modeLabel(mode: string | null): string {
@@ -304,6 +305,7 @@ export function Layout({ mode = null }: LayoutProps) {
 
       {/* Main content */}
       <div className="flex-1 overflow-auto">
+        {showGraviscanLinks && <WedgeBanner />}
         <Outlet />
       </div>
     </div>

--- a/src/renderer/components/WedgeBanner.tsx
+++ b/src/renderer/components/WedgeBanner.tsx
@@ -1,0 +1,142 @@
+/**
+ * Wedge Banner
+ *
+ * App-wide (mounted in Layout.tsx, gated on graviscan mode — design.md
+ * Decision 4) banner showing one entry per auto-paused scanner, plus a
+ * session-scoped auto-pause counter. See openspec/changes/
+ * add-graviscan-wedge-response-ui for the full design rationale.
+ */
+
+import { useState } from 'react';
+import { useWedgeEvents } from '../hooks/useWedgeEvents';
+import type { GraviWedgeEvent } from '../../types/graviscan';
+
+interface WedgeEntryRowProps {
+  event: GraviWedgeEvent;
+  onDismiss: (scannerId: string) => void;
+}
+
+function WedgeEntryRow({ event, onDismiss }: WedgeEntryRowProps) {
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [retrying, setRetrying] = useState(false);
+
+  async function handleConfirmRetry() {
+    setRetrying(true);
+    setError(null);
+    try {
+      const result = await window.electron.gravi.retryScanner(event.scanner_id);
+      if (result.success) {
+        onDismiss(event.scanner_id);
+      } else {
+        // Manual cast: this repo's tsconfig doesn't set strictNullChecks,
+        // so control-flow narrowing on the `success` discriminant doesn't
+        // apply here (matches ConfigureScanner.tsx's own workaround).
+        const err = (result as { success: false; error: string }).error;
+        setError(err);
+      }
+    } finally {
+      setRetrying(false);
+    }
+  }
+
+  return (
+    <div
+      data-testid={`wedge-entry-${event.scanner_id}`}
+      className="bg-red-50 border-2 border-red-500 rounded-lg p-4 text-red-800"
+    >
+      <div className="font-semibold">
+        {event.display_name ?? event.scanner_id} wedged (signature:{' '}
+        {event.signature}) — this scanner has been automatically paused.
+      </div>
+      <div className="text-sm mt-1">{event.error_message}</div>
+
+      {error && <div className="text-sm mt-2 text-red-900">{error}</div>}
+
+      {!confirming ? (
+        <div className="mt-3 flex gap-2">
+          <button
+            type="button"
+            className="px-3 py-1 rounded border border-red-500 text-red-700"
+            onClick={() => onDismiss(event.scanner_id)}
+          >
+            Dismiss
+          </button>
+          <button
+            type="button"
+            className="px-3 py-1 rounded bg-red-600 text-white"
+            onClick={() => setConfirming(true)}
+          >
+            Power-Cycled &amp; Retry
+          </button>
+        </div>
+      ) : (
+        <div className="mt-3">
+          <p className="text-sm mb-2">
+            Only click Confirm Retry after you have physically power-cycled this
+            scanner. Retrying before the power-cycle is done will very likely
+            wedge again immediately.
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="px-3 py-1 rounded border border-gray-400"
+              onClick={() => {
+                setConfirming(false);
+                setError(null);
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="px-3 py-1 rounded bg-red-600 text-white"
+              disabled={retrying}
+              onClick={handleConfirmRetry}
+            >
+              Confirm Retry
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function WedgeBanner() {
+  const { entries, totalAutoPauseEvents, totalScannersAffected, dismiss } =
+    useWedgeEvents();
+
+  const entryList = Object.values(entries);
+
+  if (entryList.length === 0 && totalAutoPauseEvents === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2 p-2">
+      {totalAutoPauseEvents > 0 && (
+        <div
+          data-testid="wedge-session-counter"
+          className="text-sm text-red-700"
+        >
+          {totalAutoPauseEvents} auto-pause event
+          {totalAutoPauseEvents === 1 ? '' : 's'} across {totalScannersAffected}{' '}
+          scanner
+          {totalScannersAffected === 1 ? '' : 's'} this session
+        </div>
+      )}
+      {entryList.map((event) => (
+        // Keying on scanner_id + cycle_number + timestamp intentionally
+        // remounts this row (resetting its local confirm/error state) when
+        // a new wedge for the same scanner supersedes the old one — design.md
+        // Decision 2/4's "confirmation resets on replace" requirement.
+        <WedgeEntryRow
+          key={`${event.scanner_id}:${event.cycle_number}:${event.timestamp}`}
+          event={event}
+          onDismiss={dismiss}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/renderer/components/WedgeBanner.tsx
+++ b/src/renderer/components/WedgeBanner.tsx
@@ -14,9 +14,18 @@ import type { GraviWedgeEvent } from '../../types/graviscan';
 interface WedgeEntryRowProps {
   event: GraviWedgeEvent;
   onDismiss: (scannerId: string) => void;
+  onDismissIfCurrent: (
+    scannerId: string,
+    cycleNumber: number,
+    timestamp: string
+  ) => void;
 }
 
-function WedgeEntryRow({ event, onDismiss }: WedgeEntryRowProps) {
+function WedgeEntryRow({
+  event,
+  onDismiss,
+  onDismissIfCurrent,
+}: WedgeEntryRowProps) {
   const [confirming, setConfirming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [retrying, setRetrying] = useState(false);
@@ -27,7 +36,14 @@ function WedgeEntryRow({ event, onDismiss }: WedgeEntryRowProps) {
     try {
       const result = await window.electron.gravi.retryScanner(event.scanner_id);
       if (result.success) {
-        onDismiss(event.scanner_id);
+        // Identity-checked: if a fresh wedge for this scanner_id superseded
+        // this entry while the retry call was in flight, don't dismiss the
+        // new (unaddressed) entry out from under the operator.
+        onDismissIfCurrent(
+          event.scanner_id,
+          event.cycle_number,
+          event.timestamp
+        );
       } else {
         // Manual cast: this repo's tsconfig doesn't set strictNullChecks,
         // so control-flow narrowing on the `success` discriminant doesn't
@@ -35,6 +51,8 @@ function WedgeEntryRow({ event, onDismiss }: WedgeEntryRowProps) {
         const err = (result as { success: false; error: string }).error;
         setError(err);
       }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Retry failed');
     } finally {
       setRetrying(false);
     }
@@ -81,6 +99,7 @@ function WedgeEntryRow({ event, onDismiss }: WedgeEntryRowProps) {
             <button
               type="button"
               className="px-3 py-1 rounded border border-gray-400"
+              disabled={retrying}
               onClick={() => {
                 setConfirming(false);
                 setError(null);
@@ -104,8 +123,13 @@ function WedgeEntryRow({ event, onDismiss }: WedgeEntryRowProps) {
 }
 
 export function WedgeBanner() {
-  const { entries, totalAutoPauseEvents, totalScannersAffected, dismiss } =
-    useWedgeEvents();
+  const {
+    entries,
+    totalAutoPauseEvents,
+    totalScannersAffected,
+    dismiss,
+    dismissIfCurrent,
+  } = useWedgeEvents();
 
   const entryList = Object.values(entries);
 
@@ -114,7 +138,12 @@ export function WedgeBanner() {
   }
 
   return (
-    <div className="flex flex-col gap-2 p-2">
+    // Sticky, not just fixed-in-flow: Layout.tsx mounts this inside its
+    // scrollable main-content container, so without `sticky top-0` this
+    // safety banner would scroll out of view on any page with enough
+    // content to scroll — defeating design.md Decision 4's "always visible
+    // regardless of screen" requirement.
+    <div className="sticky top-0 z-10 flex flex-col gap-2 p-2 bg-white/95">
       {totalAutoPauseEvents > 0 && (
         <div
           data-testid="wedge-session-counter"
@@ -135,6 +164,7 @@ export function WedgeBanner() {
           key={`${event.scanner_id}:${event.cycle_number}:${event.timestamp}`}
           event={event}
           onDismiss={dismiss}
+          onDismissIfCurrent={dismissIfCurrent}
         />
       ))}
     </div>

--- a/src/renderer/hooks/useWedgeEvents.ts
+++ b/src/renderer/hooks/useWedgeEvents.ts
@@ -15,6 +15,17 @@ export interface UseWedgeEventsResult {
   /** Hides a scanner's banner entry. No backend call — the scanner is
    * already paused by auto-pause, independent of dismissal. */
   dismiss: (scannerId: string) => void;
+  /** Like dismiss(), but only removes the entry if it still matches the
+   * given cycle_number/timestamp. Guards against a retryScanner() promise
+   * resolving after a fresh wedge for the same scanner_id has already
+   * superseded the entry it was called for — without this check, a stale
+   * "retry succeeded" callback would silently discard the operator's
+   * not-yet-addressed new wedge (see WedgeBanner.tsx's handleConfirmRetry). */
+  dismissIfCurrent: (
+    scannerId: string,
+    cycleNumber: number,
+    timestamp: string
+  ) => void;
 }
 
 /**
@@ -68,10 +79,30 @@ export function useWedgeEvents(): UseWedgeEventsResult {
     });
   }, []);
 
+  const dismissIfCurrent = useCallback(
+    (scannerId: string, cycleNumber: number, timestamp: string) => {
+      setEntries((prev) => {
+        const current = prev[scannerId];
+        if (
+          !current ||
+          current.cycle_number !== cycleNumber ||
+          current.timestamp !== timestamp
+        ) {
+          return prev;
+        }
+        const next = { ...prev };
+        delete next[scannerId];
+        return next;
+      });
+    },
+    []
+  );
+
   return {
     entries,
     totalAutoPauseEvents,
     totalScannersAffected: seenScannerIds.size,
     dismiss,
+    dismissIfCurrent,
   };
 }

--- a/src/renderer/hooks/useWedgeEvents.ts
+++ b/src/renderer/hooks/useWedgeEvents.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { GraviWedgeEvent } from '../../types/graviscan';
+
+export interface UseWedgeEventsResult {
+  /** Active, unacknowledged wedge entries keyed by scanner_id. A new wedge
+   * for a scanner already present replaces its entry (design.md Decision 4). */
+  entries: Record<string, GraviWedgeEvent>;
+  /** Session-scoped total wedge-event count — increments on every
+   * wedge-detected event, including repeats for the same scanner_id.
+   * Not decremented by dismiss(). */
+  totalAutoPauseEvents: number;
+  /** Session-scoped count of distinct scanner_ids that have wedged at
+   * least once this session. Not decremented by dismiss(). */
+  totalScannersAffected: number;
+  /** Hides a scanner's banner entry. No backend call — the scanner is
+   * already paused by auto-pause, independent of dismissal. */
+  dismiss: (scannerId: string) => void;
+}
+
+/**
+ * Subscribes to wedge-detected events for the lifetime of the component
+ * that calls this hook (typically Layout.tsx, so it's effectively
+ * session-lifetime — see design.md Decision 4).
+ */
+export function useWedgeEvents(): UseWedgeEventsResult {
+  const [entries, setEntries] = useState<Record<string, GraviWedgeEvent>>({});
+  const [totalAutoPauseEvents, setTotalAutoPauseEvents] = useState(0);
+  const [seenScannerIds, setSeenScannerIds] = useState<Set<string>>(
+    () => new Set()
+  );
+
+  useEffect(() => {
+    const unsubscribeWedge = window.electron.gravi.onWedgeDetected(
+      (event: GraviWedgeEvent) => {
+        setEntries((prev) => ({ ...prev, [event.scanner_id]: event }));
+        setTotalAutoPauseEvents((prev) => prev + 1);
+        setSeenScannerIds((prev) => {
+          if (prev.has(event.scanner_id)) return prev;
+          const next = new Set(prev);
+          next.add(event.scanner_id);
+          return next;
+        });
+      }
+    );
+
+    const clearAll = () => {
+      setEntries({});
+      setTotalAutoPauseEvents(0);
+      setSeenScannerIds(new Set());
+    };
+    const unsubscribeIntervalComplete =
+      window.electron.gravi.onIntervalComplete(clearAll);
+    const unsubscribeCancelled = window.electron.gravi.onCancelled(clearAll);
+
+    return () => {
+      unsubscribeWedge();
+      unsubscribeIntervalComplete();
+      unsubscribeCancelled();
+    };
+  }, []);
+
+  const dismiss = useCallback((scannerId: string) => {
+    setEntries((prev) => {
+      if (!(scannerId in prev)) return prev;
+      const next = { ...prev };
+      delete next[scannerId];
+      return next;
+    });
+  }, []);
+
+  return {
+    entries,
+    totalAutoPauseEvents,
+    totalScannersAffected: seenScannerIds.size,
+    dismiss,
+  };
+}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -48,6 +48,7 @@ import {
   SaveScannersToDBResult,
   GetScanStatusResult,
   GraviConfigInput,
+  GraviWedgeEvent,
 } from './graviscan';
 import type {
   GraviScanCreateInput,
@@ -653,6 +654,9 @@ export interface GraviAPI {
   >;
   markJobRecorded: (jobKey: string) => Promise<any>;
   cancelScan: () => Promise<any>;
+  retryScanner: (
+    scannerId: string
+  ) => Promise<{ success: true } | { success: false; error: string }>;
 
   // Image operations
   getOutputDir: () => Promise<any>;
@@ -674,6 +678,7 @@ export interface GraviAPI {
   onScanError: (callback: (data: any) => void) => () => void;
   onUploadProgress: (callback: (data: any) => void) => () => void;
   onDownloadProgress: (callback: (data: any) => void) => () => void;
+  onWedgeDetected: (callback: (event: GraviWedgeEvent) => void) => () => void;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 

--- a/src/types/graviscan.ts
+++ b/src/types/graviscan.ts
@@ -2,6 +2,13 @@
  * Type definitions for GraviScan functionality.
  */
 
+import type { WedgeDetectedEvent } from '../main/wedge-detector';
+
+/** Renderer-facing alias for the main-process wedge-detector's event shape.
+ * Type-only import — erased at compile time, so this does not pull
+ * wedge-detector.ts's runtime code into the renderer bundle. */
+export type GraviWedgeEvent = WedgeDetectedEvent;
+
 // =============================================================================
 // Scan Timing Constants
 // Empirical values from Epson Perfection V600 at 1200dpi with 2 scanners.

--- a/tests/unit/components/WedgeBanner.test.tsx
+++ b/tests/unit/components/WedgeBanner.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { WedgeBanner } from '../../../src/renderer/components/WedgeBanner';
+import type { GraviWedgeEvent } from '../../../src/types/graviscan';
+
+function makeEvent(overrides: Partial<GraviWedgeEvent> = {}): GraviWedgeEvent {
+  return {
+    scanner_id: 'sc-1',
+    signature: 'sane_start_invalid',
+    session_id: 'sess-1',
+    cycle_number: 1,
+    timestamp: '2026-08-03T00:00:00.000Z',
+    error_message: 'epkowa: sane_start: Invalid argument',
+    display_name: 'Bench 3',
+    ...overrides,
+  };
+}
+
+describe('WedgeBanner', () => {
+  let wedgeListeners: Array<(event: GraviWedgeEvent) => void>;
+  let intervalCompleteListeners: Array<() => void>;
+  let cancelledListeners: Array<() => void>;
+  let retryScanner: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    wedgeListeners = [];
+    intervalCompleteListeners = [];
+    cancelledListeners = [];
+    retryScanner = vi.fn().mockResolvedValue({ success: true });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const win = global.window as any;
+    win.electron.gravi = {
+      onWedgeDetected: vi.fn((cb: (event: GraviWedgeEvent) => void) => {
+        wedgeListeners.push(cb);
+        return () => {};
+      }),
+      onIntervalComplete: vi.fn((cb: () => void) => {
+        intervalCompleteListeners.push(cb);
+        return () => {};
+      }),
+      onCancelled: vi.fn((cb: () => void) => {
+        cancelledListeners.push(cb);
+        return () => {};
+      }),
+      retryScanner,
+    };
+  });
+
+  function fireWedge(event: GraviWedgeEvent) {
+    act(() => {
+      wedgeListeners.forEach((cb) => cb(event));
+    });
+  }
+
+  it('renders a banner entry showing identity/signature/error, with already-paused copy, in error styling', () => {
+    render(<WedgeBanner />);
+    fireWedge(makeEvent());
+
+    expect(screen.getByText(/Bench 3/)).toBeInTheDocument();
+    expect(screen.getByText(/sane_start_invalid/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/sane_start: Invalid argument/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/paused/i)).toBeInTheDocument();
+
+    const entry = screen.getByTestId('wedge-entry-sc-1');
+    expect(entry.className).toContain('bg-red-50');
+    expect(entry.className).toContain('border-red-500');
+  });
+
+  it('renders two independently-actionable entries as a vertically-stacked list', () => {
+    render(<WedgeBanner />);
+    fireWedge(makeEvent({ scanner_id: 'sc-1', display_name: 'Bench 1' }));
+    fireWedge(makeEvent({ scanner_id: 'sc-2', display_name: 'Bench 2' }));
+
+    expect(screen.getByTestId('wedge-entry-sc-1')).toBeInTheDocument();
+    expect(screen.getByTestId('wedge-entry-sc-2')).toBeInTheDocument();
+  });
+
+  it('Dismiss removes the entry without calling retryScanner', async () => {
+    const user = userEvent.setup();
+    render(<WedgeBanner />);
+    fireWedge(makeEvent());
+
+    await user.click(
+      screen.getByRole('button', { name: /dismiss/i, hidden: false })
+    );
+
+    expect(screen.queryByTestId('wedge-entry-sc-1')).not.toBeInTheDocument();
+    expect(retryScanner).not.toHaveBeenCalled();
+  });
+
+  it('Power-Cycled & Retry shows a confirmation sub-state with explanatory text, without calling retryScanner yet', async () => {
+    const user = userEvent.setup();
+    render(<WedgeBanner />);
+    fireWedge(makeEvent());
+
+    await user.click(
+      screen.getByRole('button', { name: /power-cycled.*retry/i })
+    );
+
+    expect(retryScanner).not.toHaveBeenCalled();
+    expect(screen.getByText(/power.cycl/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /confirm retry/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it('Confirm Retry calls retryScanner and removes the entry on success', async () => {
+    const user = userEvent.setup();
+    render(<WedgeBanner />);
+    fireWedge(makeEvent());
+
+    await user.click(
+      screen.getByRole('button', { name: /power-cycled.*retry/i })
+    );
+    await user.click(screen.getByRole('button', { name: /confirm retry/i }));
+
+    expect(retryScanner).toHaveBeenCalledWith('sc-1');
+    await waitFor(() =>
+      expect(screen.queryByTestId('wedge-entry-sc-1')).not.toBeInTheDocument()
+    );
+  });
+
+  it('Cancel reverts to the unconfirmed state without calling retryScanner', async () => {
+    const user = userEvent.setup();
+    render(<WedgeBanner />);
+    fireWedge(makeEvent());
+
+    await user.click(
+      screen.getByRole('button', { name: /power-cycled.*retry/i })
+    );
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    expect(retryScanner).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('button', { name: /power-cycled.*retry/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /confirm retry/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('a failed Confirm Retry leaves the entry in place and shows the error inline', async () => {
+    retryScanner.mockResolvedValue({ success: false, error: 'still wedged' });
+    const user = userEvent.setup();
+    render(<WedgeBanner />);
+    fireWedge(makeEvent());
+
+    await user.click(
+      screen.getByRole('button', { name: /power-cycled.*retry/i })
+    );
+    await user.click(screen.getByRole('button', { name: /confirm retry/i }));
+
+    expect(await screen.findByText(/still wedged/)).toBeInTheDocument();
+    expect(screen.getByTestId('wedge-entry-sc-1')).toBeInTheDocument();
+  });
+
+  it('shows no counter indicator when totalAutoPauseEvents is 0, and shows both numbers together once wedges occur', () => {
+    render(<WedgeBanner />);
+    expect(
+      screen.queryByTestId('wedge-session-counter')
+    ).not.toBeInTheDocument();
+
+    fireWedge(makeEvent({ scanner_id: 'sc-1' }));
+    fireWedge(makeEvent({ scanner_id: 'sc-1' }));
+    fireWedge(makeEvent({ scanner_id: 'sc-2' }));
+
+    const counter = screen.getByTestId('wedge-session-counter');
+    expect(counter).toHaveTextContent('3');
+    expect(counter).toHaveTextContent('2');
+  });
+});

--- a/tests/unit/components/WedgeBanner.test.tsx
+++ b/tests/unit/components/WedgeBanner.test.tsx
@@ -160,6 +160,80 @@ describe('WedgeBanner', () => {
     expect(screen.getByTestId('wedge-entry-sc-1')).toBeInTheDocument();
   });
 
+  it('a rejected Confirm Retry (IPC promise rejects, not resolves-with-error) shows an error and leaves the entry in place', async () => {
+    retryScanner.mockRejectedValue(new Error('IPC channel closed'));
+    const user = userEvent.setup();
+    render(<WedgeBanner />);
+    fireWedge(makeEvent());
+
+    await user.click(
+      screen.getByRole('button', { name: /power-cycled.*retry/i })
+    );
+    await user.click(screen.getByRole('button', { name: /confirm retry/i }));
+
+    expect(await screen.findByText(/IPC channel closed/)).toBeInTheDocument();
+    expect(screen.getByTestId('wedge-entry-sc-1')).toBeInTheDocument();
+  });
+
+  it('does not dismiss a fresh, superseding wedge entry when a stale in-flight retry for the same scanner later resolves successfully', async () => {
+    let resolveRetry!: (value: { success: true }) => void;
+    retryScanner.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRetry = resolve;
+        })
+    );
+    const user = userEvent.setup();
+    render(<WedgeBanner />);
+    fireWedge(makeEvent({ cycle_number: 1, signature: 'sane_start_invalid' }));
+
+    await user.click(
+      screen.getByRole('button', { name: /power-cycled.*retry/i })
+    );
+    await user.click(screen.getByRole('button', { name: /confirm retry/i }));
+
+    // A fresh wedge for the same scanner supersedes the entry before the
+    // first retry call resolves — e.g. the respawned worker re-wedged
+    // almost immediately because the physical power-cycle wasn't actually
+    // done yet.
+    fireWedge(
+      makeEvent({ cycle_number: 2, signature: 'device_io_120s_zero_bytes' })
+    );
+
+    // The stale retry call now resolves successfully.
+    await act(async () => {
+      resolveRetry({ success: true });
+    });
+
+    // The new, unaddressed wedge entry must still be showing — the stale
+    // "success" belongs to the superseded occurrence, not this one.
+    expect(screen.getByTestId('wedge-entry-sc-1')).toBeInTheDocument();
+    expect(screen.getByText(/device_io_120s_zero_bytes/)).toBeInTheDocument();
+  });
+
+  it('resets to the unconfirmed two-button view when a new wedge supersedes an entry mid-confirmation', async () => {
+    const user = userEvent.setup();
+    render(<WedgeBanner />);
+    fireWedge(makeEvent({ cycle_number: 1 }));
+
+    await user.click(
+      screen.getByRole('button', { name: /power-cycled.*retry/i })
+    );
+    expect(
+      screen.getByRole('button', { name: /confirm retry/i })
+    ).toBeInTheDocument();
+
+    fireWedge(makeEvent({ cycle_number: 2 }));
+
+    expect(
+      screen.queryByRole('button', { name: /confirm retry/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /power-cycled.*retry/i })
+    ).toBeInTheDocument();
+    expect(retryScanner).not.toHaveBeenCalled();
+  });
+
   it('shows no counter indicator when totalAutoPauseEvents is 0, and shows both numbers together once wedges occur', () => {
     render(<WedgeBanner />);
     expect(

--- a/tests/unit/graviscan/main-wiring.test.ts
+++ b/tests/unit/graviscan/main-wiring.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../../src/main/graviscan/scan-coordinator', () => {
     const emitter = new EventEmitter();
     return Object.assign(emitter, {
       shutdown: vi.fn().mockResolvedValue(undefined),
+      stopScanner: vi.fn().mockResolvedValue(undefined),
     });
   });
   return { ScanCoordinator: MockCoordinator };
@@ -68,6 +69,7 @@ describe('GraviScan wiring module', () => {
       const emitter = new EventEmitter();
       return Object.assign(emitter, {
         shutdown: vi.fn().mockResolvedValue(undefined),
+        stopScanner: vi.fn().mockResolvedValue(undefined),
       }) as unknown as InstanceType<typeof ScanCoordinator>;
     });
     vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -303,6 +305,19 @@ describe('GraviScan wiring module', () => {
       });
     }
 
+    // Shared mock coordinator for this block — an EventEmitter (the real
+    // setupWedgeDetection() only ever calls .on()/.emit() on its `coordinator`
+    // argument, so an EventEmitter models the surface it needs) with
+    // `stopScanner` attached, since auto-pause (design.md Decision 1) now
+    // calls `coordinator.stopScanner()` from inside `onWedge`.
+    function createMockWedgeCoordinator(): EventEmitter & {
+      stopScanner: ReturnType<typeof vi.fn>;
+    } {
+      return Object.assign(new EventEmitter(), {
+        stopScanner: vi.fn().mockResolvedValue(undefined),
+      });
+    }
+
     it('interval-start → scan-error (sane_start_invalid) → Slack POST + scanLog fire end-to-end, using the active session id', async () => {
       graviSessionFns.setScanSession({
         sessionId: 'sess-real-42',
@@ -310,7 +325,7 @@ describe('GraviScan wiring module', () => {
         jobs: {},
       } as any);
 
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       setupWedgeDetection(coordinator as any);
 
       coordinator.emit('interval-start', {
@@ -351,7 +366,7 @@ describe('GraviScan wiring module', () => {
     });
 
     it('falls back to a startedAt-based session id when no active scan session exists', async () => {
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       setupWedgeDetection(coordinator as any);
 
       coordinator.emit('interval-start', { startedAt: 999999 });
@@ -365,7 +380,7 @@ describe('GraviScan wiring module', () => {
     });
 
     it('routes two same-cycle scan-error events for one scanner to a single consecutive_failures wedge', async () => {
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       setupWedgeDetection(coordinator as any);
       coordinator.emit('interval-start', { startedAt: 1 });
 
@@ -389,7 +404,7 @@ describe('GraviScan wiring module', () => {
     });
 
     it('scan-complete resolves a scanner without triggering a wedge (recovered path) (task 11.2 — retargeted from scan-event)', async () => {
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       setupWedgeDetection(coordinator as any);
       coordinator.emit('interval-start', { startedAt: 1 });
 
@@ -405,7 +420,7 @@ describe('GraviScan wiring module', () => {
     });
 
     it('tears down the detector on interval-complete — a later scan-error no longer triggers a wedge', async () => {
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       setupWedgeDetection(coordinator as any);
       coordinator.emit('interval-start', { startedAt: 1 });
       coordinator.emit('interval-complete', {
@@ -422,7 +437,7 @@ describe('GraviScan wiring module', () => {
     });
 
     it('does not POST to Slack when scan-error fires before any interval-start (no detector yet) (task 11.2b — renamed from scan-event)', async () => {
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       setupWedgeDetection(coordinator as any);
 
       emitScanError(coordinator, { scanner_id: 'sc-too-early' });
@@ -434,7 +449,7 @@ describe('GraviScan wiring module', () => {
     it('does not POST to Slack when the webhook env var is unset (feature disabled)', async () => {
       delete process.env.BLOOM_GRAVISCAN_SLACK_WEBHOOK_URL;
 
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       setupWedgeDetection(coordinator as any);
       coordinator.emit('interval-start', { startedAt: 1 });
       emitScanError(coordinator, { scanner_id: 'sc-disabled' });
@@ -444,7 +459,7 @@ describe('GraviScan wiring module', () => {
     });
 
     it('enriches the Slack message with display_name/usb_port looked up from the db (final-review #4)', async () => {
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       const mockDb = {
         graviScanner: {
           findUnique: vi.fn().mockResolvedValue({
@@ -471,7 +486,7 @@ describe('GraviScan wiring module', () => {
     });
 
     it('falls back to the unenriched event when no db is passed', async () => {
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       setupWedgeDetection(coordinator as any); // no db arg — matches every other test in this block
 
       coordinator.emit('interval-start', { startedAt: 1 });
@@ -487,7 +502,7 @@ describe('GraviScan wiring module', () => {
     });
 
     it('falls back to the unenriched event when the scanner_id is not found in the db', async () => {
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       const mockDb = {
         graviScanner: { findUnique: vi.fn().mockResolvedValue(null) },
       };
@@ -505,7 +520,7 @@ describe('GraviScan wiring module', () => {
     });
 
     it('falls back to the unenriched event when the db lookup throws', async () => {
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       const mockDb = {
         graviScanner: {
           findUnique: vi.fn().mockRejectedValue(new Error('DB unavailable')),
@@ -521,7 +536,7 @@ describe('GraviScan wiring module', () => {
     });
 
     it('repeated scan-complete events for the same scanner never trigger a wedge (task 11.3 — onScanEnd success routing)', async () => {
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       setupWedgeDetection(coordinator as any);
       coordinator.emit('interval-start', { startedAt: 1 });
 
@@ -544,7 +559,7 @@ describe('GraviScan wiring module', () => {
     });
 
     it('a coordinator-originated scan-error (camelCase scannerId/plateIndex, no snake_case fields) reaches wedge detection and can contribute to consecutive_failures (task 11.4 — design.md Decision 2 found-bug fix)', async () => {
-      const coordinator = new EventEmitter();
+      const coordinator = createMockWedgeCoordinator();
       setupWedgeDetection(coordinator as any);
       coordinator.emit('interval-start', { startedAt: 1 });
 
@@ -573,6 +588,184 @@ describe('GraviScan wiring module', () => {
       );
       expect(body.text).toContain('sc-coord');
       expect(body.text).toContain('consecutive_failures');
+    });
+
+    // --- Tier 3 additions: auto-pause + renderer forwarding (design.md
+    // Decisions 1 and 6) ---
+
+    it('calls coordinator.stopScanner() to auto-pause the wedged scanner (design.md Decision 1)', async () => {
+      const coordinator = createMockWedgeCoordinator();
+      setupWedgeDetection(coordinator as any);
+
+      coordinator.emit('interval-start', { startedAt: 1 });
+      coordinator.emit('scan-started', {
+        scanner_id: 'sc-1',
+        plate_index: '00',
+        cycle_number: 1,
+      });
+      emitScanError(coordinator);
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(coordinator.stopScanner).toHaveBeenCalledTimes(1);
+      expect(coordinator.stopScanner).toHaveBeenCalledWith('sc-1');
+    });
+
+    it('calls stopScanner() immediately, without waiting for the async Slack/enrich pipeline to settle', () => {
+      const coordinator = createMockWedgeCoordinator();
+      // A db lookup that never resolves stands in for a slow/hanging
+      // enrich+Slack pipeline — if stopScanner() were nested inside that
+      // async chain rather than called synchronously first, it would not
+      // have fired yet at the point this test asserts (no await at all).
+      const mockDb = {
+        graviScanner: {
+          findUnique: vi.fn().mockImplementation(() => new Promise(() => {})),
+        },
+      };
+      setupWedgeDetection(coordinator as any, mockDb as any);
+
+      coordinator.emit('interval-start', { startedAt: 1 });
+      coordinator.emit('scan-started', {
+        scanner_id: 'sc-1',
+        plate_index: '00',
+        cycle_number: 1,
+      });
+      emitScanError(coordinator);
+
+      expect(coordinator.stopScanner).toHaveBeenCalledTimes(1);
+      expect(coordinator.stopScanner).toHaveBeenCalledWith('sc-1');
+    });
+
+    it('forwards the enriched wedge event to the renderer via getMainWindow (design.md Decision 6)', async () => {
+      const coordinator = createMockWedgeCoordinator();
+      const send = vi.fn();
+      const mockWindow = {
+        isDestroyed: () => false,
+        webContents: { send },
+      };
+      setupWedgeDetection(coordinator as any, null, () => mockWindow as any);
+
+      coordinator.emit('interval-start', { startedAt: 1 });
+      coordinator.emit('scan-started', {
+        scanner_id: 'sc-1',
+        plate_index: '00',
+        cycle_number: 1,
+      });
+      emitScanError(coordinator);
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(send).toHaveBeenCalledWith(
+        'graviscan:wedge-detected',
+        expect.objectContaining({
+          scanner_id: 'sc-1',
+          signature: 'sane_start_invalid',
+          session_id: 'session-1',
+          cycle_number: 1,
+          error_message: expect.stringContaining(
+            'sane_start: Invalid argument'
+          ),
+        })
+      );
+    });
+
+    it('omitting getMainWindow does not throw and preserves existing stopScanner/Slack behavior', async () => {
+      const coordinator = createMockWedgeCoordinator();
+      setupWedgeDetection(coordinator as any); // no db, no getMainWindow — existing call shape
+
+      expect(() => {
+        coordinator.emit('interval-start', { startedAt: 1 });
+        coordinator.emit('scan-started', {
+          scanner_id: 'sc-1',
+          plate_index: '00',
+          cycle_number: 1,
+        });
+        emitScanError(coordinator);
+      }).not.toThrow();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(coordinator.stopScanner).toHaveBeenCalledWith('sc-1');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not forward to a destroyed window, but still auto-pauses and notifies Slack', async () => {
+      const coordinator = createMockWedgeCoordinator();
+      const send = vi.fn();
+      const destroyedWindow = {
+        isDestroyed: () => true,
+        webContents: { send },
+      };
+      setupWedgeDetection(
+        coordinator as any,
+        null,
+        () => destroyedWindow as any
+      );
+
+      coordinator.emit('interval-start', { startedAt: 1 });
+      coordinator.emit('scan-started', {
+        scanner_id: 'sc-1',
+        plate_index: '00',
+        cycle_number: 1,
+      });
+      expect(() => emitScanError(coordinator)).not.toThrow();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(send).not.toHaveBeenCalled();
+      expect(coordinator.stopScanner).toHaveBeenCalledWith('sc-1');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not forward when getMainWindow returns null, but still auto-pauses and notifies Slack', async () => {
+      const coordinator = createMockWedgeCoordinator();
+      setupWedgeDetection(coordinator as any, null, () => null);
+
+      coordinator.emit('interval-start', { startedAt: 1 });
+      coordinator.emit('scan-started', {
+        scanner_id: 'sc-1',
+        plate_index: '00',
+        cycle_number: 1,
+      });
+      expect(() => emitScanError(coordinator)).not.toThrow();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(coordinator.stopScanner).toHaveBeenCalledWith('sc-1');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes a durable scanLog line for the auto-pause, in addition to the existing wedge-detected line (design.md Decision 3/6)', async () => {
+      graviSessionFns.setScanSession({
+        sessionId: 'sess-log-1',
+        isActive: true,
+        jobs: {},
+      } as any);
+
+      const coordinator = createMockWedgeCoordinator();
+      setupWedgeDetection(coordinator as any);
+
+      coordinator.emit('interval-start', {
+        totalCycles: 1,
+        intervalMs: 1000,
+        durationMs: 1000,
+        startedAt: 1,
+      });
+      coordinator.emit('scan-started', {
+        scanner_id: 'sc-1',
+        plate_index: '00',
+        cycle_number: 1,
+      });
+      emitScanError(coordinator);
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Pre-existing line — must still fire unchanged.
+      expect(scanLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[WedgeDetector] wedge-detected scanner=sc-1 signature=sane_start_invalid cycle=1'
+        )
+      );
+      // New line this proposal adds.
+      expect(scanLog).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /auto-paused scanner=sc-1 signature=sane_start_invalid session=sess-log-1 cycle=1/
+        )
+      );
     });
   });
 

--- a/tests/unit/graviscan/register-handlers.test.ts
+++ b/tests/unit/graviscan/register-handlers.test.ts
@@ -15,6 +15,12 @@ vi.mock('../../../src/main/graviscan/scanner-handlers', () => ({
   validateConfig: vi.fn().mockResolvedValue({ status: 'valid' }),
   resetUsb: vi.fn().mockResolvedValue({ success: true, scanners: [] }),
   getScannerStatus: vi.fn().mockResolvedValue({ success: true, scanners: [] }),
+  buildSaneName: vi
+    .fn()
+    .mockImplementation(
+      (usbBus: number, usbDevice: number) =>
+        `epkowa:interpreter:${String(usbBus).padStart(3, '0')}:${String(usbDevice).padStart(3, '0')}`
+    ),
 }));
 
 vi.mock('../../../src/main/graviscan/scanner-upsert', () => ({
@@ -27,6 +33,7 @@ vi.mock('../../../src/main/graviscan/session-handlers', () => ({
   getScanStatus: vi.fn().mockReturnValue(null),
   markJobRecorded: vi.fn(),
   cancelScan: vi.fn().mockResolvedValue({ success: true }),
+  retryScanner: vi.fn().mockResolvedValue({ success: true }),
 }));
 
 vi.mock('../../../src/main/graviscan/image-handlers', () => ({
@@ -81,6 +88,7 @@ const CHANNELS = [
   'graviscan:get-scan-status',
   'graviscan:mark-job-recorded',
   'graviscan:cancel-scan',
+  'graviscan:retry-scanner',
   'graviscan:get-output-dir',
   'graviscan:read-scan-image',
   'graviscan:upload-all-scans',
@@ -148,7 +156,7 @@ describe('registerGraviScanHandlers', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
-  it('registers all 21 IPC channels', () => {
+  it('registers all 22 IPC channels', () => {
     registerGraviScanHandlers(
       mockIpcMain as any,
       mockDb,
@@ -157,7 +165,7 @@ describe('registerGraviScanHandlers', () => {
       mockGetCoordinator
     );
 
-    expect(mockIpcMain.handle).toHaveBeenCalledTimes(21);
+    expect(mockIpcMain.handle).toHaveBeenCalledTimes(22);
     for (const channel of CHANNELS) {
       expect(mockIpcMain._handlers.has(channel)).toBe(true);
     }
@@ -228,6 +236,29 @@ describe('registerGraviScanHandlers', () => {
     it('graviscan:cancel-scan delegates to cancelScan', async () => {
       await mockIpcMain._invoke('graviscan:cancel-scan');
       expect(sessionHandlers.cancelScan).toHaveBeenCalled();
+    });
+
+    it('graviscan:retry-scanner wires the coordinator, db, sessionFns, and scannerId through to retryScanner, returning its result directly (not wrapHandler-wrapped)', async () => {
+      const coordinator = { fake: 'coordinator' };
+      mockGetCoordinator.mockReturnValue(coordinator);
+      vi.mocked(sessionHandlers.retryScanner).mockResolvedValueOnce({
+        success: false,
+        error: 'disabled',
+      });
+
+      const result = await mockIpcMain._invoke(
+        'graviscan:retry-scanner',
+        'sc-1'
+      );
+
+      expect(sessionHandlers.retryScanner).toHaveBeenCalledWith(
+        coordinator,
+        mockDb,
+        mockSessionFns,
+        'sc-1'
+      );
+      // Direct pass-through — no { success: true, data: {...} } envelope.
+      expect(result).toEqual({ success: false, error: 'disabled' });
     });
   });
 

--- a/tests/unit/graviscan/scan-coordinator.test.ts
+++ b/tests/unit/graviscan/scan-coordinator.test.ts
@@ -1037,6 +1037,83 @@ describe('ScanCoordinator', () => {
     });
   });
 
+  // Real-coordinator-level coverage for the exact `stopScanner()` +
+  // `addScanner()` sequence the wedge-response-ui feature's
+  // `retryScanner()` handler calls (session-handlers.ts). Every other
+  // test of this sequence in the codebase (main-wiring, register-handlers,
+  // session-handlers) exercises it against a fully mocked coordinator —
+  // this describe block is the first to exercise it against the real
+  // `ScanCoordinator` class, mocking only `ScannerSubprocess` beneath it.
+  describe('stopScanner() + addScanner() — retry-scanner integration', () => {
+    it('stopScanner() removes the worker, and addScanner() for the same id spawns a fresh subprocess while idle', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(1));
+      expect(coordinator.hasWorker('scanner-1')).toBe(true);
+      expect(createdSubprocesses).toHaveLength(1);
+
+      await coordinator.stopScanner('scanner-1');
+
+      expect(createdSubprocesses[0].shutdown).toHaveBeenCalled();
+      expect(coordinator.hasWorker('scanner-1')).toBe(false);
+
+      await coordinator.addScanner({
+        scannerId: 'scanner-1',
+        saneName: 'epkowa:interpreter:001:002',
+        plates: [],
+      });
+
+      expect(ScannerSubprocess).toHaveBeenCalledTimes(2);
+      expect(createdSubprocesses[1].spawn).toHaveBeenCalled();
+      expect(coordinator.hasWorker('scanner-1')).toBe(true);
+    });
+
+    it('addScanner() for a retried scanner while a different scanner is mid-cycle queues until cycle-complete, then respawns', async () => {
+      const coordinator = await createCoordinator();
+      await coordinator.initialize(makeScanners(2)); // scanner-1, scanner-2
+      expect(createdSubprocesses).toHaveLength(2);
+
+      // Simulate auto-pause: scanner-1 wedged and was auto-stopped
+      // (design.md Decision 1), leaving scanner-2 as the only one with
+      // plates for this cycle.
+      await coordinator.stopScanner('scanner-1');
+      expect(coordinator.hasWorker('scanner-1')).toBe(false);
+
+      const sub2 = createdSubprocesses[1];
+      sub2.scan.mockImplementation(() => {
+        // Delay cycle-done so isScanning is observably true while the
+        // operator's Retry click (addScanner) is in flight.
+        setTimeout(() => sub2.emit('cycle-done', {}), 50);
+      });
+
+      const platesMap = makePlatesMap(['scanner-2']);
+      const scanPromise = coordinator.scanOnce(platesMap);
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(coordinator.isScanning).toBe(true);
+
+      // Operator confirms "Power-Cycled & Retry" for scanner-1 while
+      // scanner-2's cycle is still in flight — this is retryScanner()'s
+      // exact call, `coordinator.addScanner({scannerId: 'scanner-1', ...})`.
+      const retryPromise = coordinator.addScanner({
+        scannerId: 'scanner-1',
+        saneName: 'epkowa:interpreter:001:002',
+        plates: [],
+      });
+
+      // Must NOT spawn immediately — queued until this cycle's
+      // cycle-complete, per addScanner()'s documented mid-scan safety.
+      expect(ScannerSubprocess).toHaveBeenCalledTimes(2);
+
+      await scanPromise; // scanOnce() emits 'cycle-complete' before resolving
+      await retryPromise;
+
+      expect(ScannerSubprocess).toHaveBeenCalledTimes(3);
+      expect(createdSubprocesses[2].scannerId).toBe('scanner-1');
+      expect(createdSubprocesses[2].spawn).toHaveBeenCalled();
+      expect(coordinator.hasWorker('scanner-1')).toBe(true);
+    });
+  });
+
   describe('implements ScanCoordinatorLike', () => {
     it('exposes all interface methods at runtime', async () => {
       // The `implements ScanCoordinatorLike` on the class is enforced by

--- a/tests/unit/graviscan/scanner-handlers.test.ts
+++ b/tests/unit/graviscan/scanner-handlers.test.ts
@@ -17,6 +17,7 @@ import {
   runStartupScannerValidation,
   getSessionValidationState,
   resetSessionValidation,
+  buildSaneName,
 } from '../../../src/main/graviscan/scanner-handlers';
 import type { DetectedScanner } from '../../../src/types/graviscan';
 
@@ -584,5 +585,15 @@ describe('scanner-handlers', () => {
       expect(freshState.detectedScanners).toHaveLength(1);
       expect(freshState.cachedScannerIds).toHaveLength(1);
     });
+  });
+});
+
+describe('buildSaneName', () => {
+  it('zero-pads both usb_bus and usb_device to 3 digits', () => {
+    expect(buildSaneName(3, 7)).toBe('epkowa:interpreter:003:007');
+  });
+
+  it('zero-pads independently when one value already has 3 digits', () => {
+    expect(buildSaneName(123, 45)).toBe('epkowa:interpreter:123:045');
   });
 });

--- a/tests/unit/graviscan/session-handlers.test.ts
+++ b/tests/unit/graviscan/session-handlers.test.ts
@@ -2,6 +2,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+vi.mock('../../../src/main/graviscan/scan-logger', () => ({
+  scanLog: vi.fn(),
+  cleanupOldLogs: vi.fn(),
+  closeScanLog: vi.fn(),
+}));
+
 // Types matching Ben's ScanCoordinator + PlateConfig
 interface ScanCoordinatorLike {
   readonly isScanning: boolean;
@@ -55,7 +61,23 @@ import {
   getScanStatus,
   markJobRecorded,
   cancelScan,
+  retryScanner,
 } from '../../../src/main/graviscan/session-handlers';
+import { scanLog } from '../../../src/main/graviscan/scan-logger';
+
+function createMockRetryDb(
+  row: {
+    usb_bus: number | null;
+    usb_device: number | null;
+    enabled: boolean;
+  } | null
+) {
+  return {
+    graviScanner: {
+      findUnique: vi.fn().mockResolvedValue(row),
+    },
+  };
+}
 
 describe('session-handlers', () => {
   let coordinator: ReturnType<typeof createMockCoordinator>;
@@ -413,6 +435,169 @@ describe('session-handlers', () => {
       const result = await cancelScan(coordinator, sessionFns);
 
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe('retryScanner', () => {
+    beforeEach(() => {
+      sessionFns.getScanSession.mockReturnValue({ isActive: true } as any);
+    });
+
+    it('stops then respawns the scanner using a fresh saneName from the db, and logs success', async () => {
+      const db = createMockRetryDb({
+        usb_bus: 3,
+        usb_device: 7,
+        enabled: true,
+      });
+
+      const result = await retryScanner(
+        coordinator,
+        db as any,
+        sessionFns,
+        'sc-1'
+      );
+
+      expect(coordinator.stopScanner).toHaveBeenCalledWith('sc-1');
+      expect(coordinator.addScanner).toHaveBeenCalledWith({
+        scannerId: 'sc-1',
+        saneName: 'epkowa:interpreter:003:007',
+        plates: [],
+      });
+      expect(result).toEqual({ success: true });
+      expect(scanLog).toHaveBeenCalledWith(expect.stringContaining('sc-1'));
+    });
+
+    it('fails without respawning when the scanner row cannot be found', async () => {
+      const db = createMockRetryDb(null);
+
+      const result = await retryScanner(
+        coordinator,
+        db as any,
+        sessionFns,
+        'sc-1'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(coordinator.stopScanner).not.toHaveBeenCalled();
+      expect(coordinator.addScanner).not.toHaveBeenCalled();
+    });
+
+    it('fails without respawning when usb_bus/usb_device is null (mid reset-usb)', async () => {
+      const db = createMockRetryDb({
+        usb_bus: null,
+        usb_device: null,
+        enabled: true,
+      });
+
+      const result = await retryScanner(
+        coordinator,
+        db as any,
+        sessionFns,
+        'sc-1'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(coordinator.addScanner).not.toHaveBeenCalled();
+    });
+
+    it('fails without respawning a disabled scanner', async () => {
+      const db = createMockRetryDb({
+        usb_bus: 3,
+        usb_device: 7,
+        enabled: false,
+      });
+
+      const result = await retryScanner(
+        coordinator,
+        db as any,
+        sessionFns,
+        'sc-1'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(coordinator.addScanner).not.toHaveBeenCalled();
+    });
+
+    it('fails cleanly with no active session, without querying the db', async () => {
+      sessionFns.getScanSession.mockReturnValue(null);
+      const db = createMockRetryDb({
+        usb_bus: 3,
+        usb_device: 7,
+        enabled: true,
+      });
+
+      const result = await retryScanner(
+        coordinator,
+        db as any,
+        sessionFns,
+        'sc-1'
+      );
+
+      expect(result.success).toBe(false);
+      expect(db.graviScanner.findUnique).not.toHaveBeenCalled();
+      expect(coordinator.addScanner).not.toHaveBeenCalled();
+    });
+
+    it('fails cleanly with an inactive session', async () => {
+      sessionFns.getScanSession.mockReturnValue({ isActive: false } as any);
+      const db = createMockRetryDb({
+        usb_bus: 3,
+        usb_device: 7,
+        enabled: true,
+      });
+
+      const result = await retryScanner(
+        coordinator,
+        db as any,
+        sessionFns,
+        'sc-1'
+      );
+
+      expect(result.success).toBe(false);
+      expect(coordinator.addScanner).not.toHaveBeenCalled();
+    });
+
+    it('fails cleanly when coordinator is null, without throwing', async () => {
+      const db = createMockRetryDb({
+        usb_bus: 3,
+        usb_device: 7,
+        enabled: true,
+      });
+
+      const result = await retryScanner(
+        null as any,
+        db as any,
+        sessionFns,
+        'sc-1'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('catches a rejected addScanner and surfaces it, logging the failed retry', async () => {
+      coordinator = createMockCoordinator({
+        addScanner: vi.fn().mockRejectedValue(new Error('spawn failed')),
+      } as any);
+      const db = createMockRetryDb({
+        usb_bus: 3,
+        usb_device: 7,
+        enabled: true,
+      });
+
+      const result = await retryScanner(
+        coordinator,
+        db as any,
+        sessionFns,
+        'sc-1'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('spawn failed');
+      expect(scanLog).toHaveBeenCalledWith(expect.stringContaining('sc-1'));
     });
   });
 });

--- a/tests/unit/graviscan/session-handlers.test.ts
+++ b/tests/unit/graviscan/session-handlers.test.ts
@@ -599,5 +599,69 @@ describe('session-handlers', () => {
       expect(result.error).toContain('spawn failed');
       expect(scanLog).toHaveBeenCalledWith(expect.stringContaining('sc-1'));
     });
+
+    it('rejects a second concurrent retry for the same scannerId while the first is still in flight, without a second stopScanner()+addScanner() pair', async () => {
+      let resolveAddScanner!: () => void;
+      coordinator = createMockCoordinator({
+        addScanner: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              resolveAddScanner = resolve;
+            })
+        ),
+      } as any);
+      const db = createMockRetryDb({
+        usb_bus: 3,
+        usb_device: 7,
+        enabled: true,
+      });
+
+      const first = retryScanner(coordinator, db as any, sessionFns, 'sc-1');
+      const second = await retryScanner(
+        coordinator,
+        db as any,
+        sessionFns,
+        'sc-1'
+      );
+
+      expect(second.success).toBe(false);
+      expect(second.error).toContain('already in progress');
+
+      // Let the first call's own await chain (findUnique, then
+      // stopScanner) actually reach its addScanner() call before we
+      // resolve it.
+      await new Promise((r) => setTimeout(r, 0));
+      resolveAddScanner();
+      const firstResult = await first;
+      expect(firstResult.success).toBe(true);
+      // Only the first call's addScanner() ever ran — the second was
+      // rejected by the in-flight guard before reaching the coordinator.
+      expect(coordinator.addScanner).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows a subsequent retry for the same scannerId once a prior retry has resolved', async () => {
+      const db = createMockRetryDb({
+        usb_bus: 3,
+        usb_device: 7,
+        enabled: true,
+      });
+
+      const first = await retryScanner(
+        coordinator,
+        db as any,
+        sessionFns,
+        'sc-1'
+      );
+      const second = await retryScanner(
+        coordinator,
+        db as any,
+        sessionFns,
+        'sc-1'
+      );
+
+      expect(first.success).toBe(true);
+      expect(second.success).toBe(true);
+      expect(coordinator.addScanner).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/tests/unit/hooks/useWedgeEvents.test.ts
+++ b/tests/unit/hooks/useWedgeEvents.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWedgeEvents } from '../../../src/renderer/hooks/useWedgeEvents';
+import type { GraviWedgeEvent } from '../../../src/types/graviscan';
+
+function makeEvent(overrides: Partial<GraviWedgeEvent> = {}): GraviWedgeEvent {
+  return {
+    scanner_id: 'sc-1',
+    signature: 'sane_start_invalid',
+    session_id: 'sess-1',
+    cycle_number: 1,
+    timestamp: '2026-08-03T00:00:00.000Z',
+    error_message: 'epkowa: sane_start: Invalid argument',
+    ...overrides,
+  };
+}
+
+describe('useWedgeEvents', () => {
+  let wedgeListeners: Array<(event: GraviWedgeEvent) => void>;
+  let intervalCompleteListeners: Array<() => void>;
+  let cancelledListeners: Array<() => void>;
+  let unsubscribeWedge: ReturnType<typeof vi.fn>;
+  let unsubscribeIntervalComplete: ReturnType<typeof vi.fn>;
+  let unsubscribeCancelled: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    wedgeListeners = [];
+    intervalCompleteListeners = [];
+    cancelledListeners = [];
+    unsubscribeWedge = vi.fn();
+    unsubscribeIntervalComplete = vi.fn();
+    unsubscribeCancelled = vi.fn();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const win = global.window as any;
+    win.electron.gravi = {
+      onWedgeDetected: vi.fn((cb: (event: GraviWedgeEvent) => void) => {
+        wedgeListeners.push(cb);
+        return unsubscribeWedge;
+      }),
+      onIntervalComplete: vi.fn((cb: () => void) => {
+        intervalCompleteListeners.push(cb);
+        return unsubscribeIntervalComplete;
+      }),
+      onCancelled: vi.fn((cb: () => void) => {
+        cancelledListeners.push(cb);
+        return unsubscribeCancelled;
+      }),
+    };
+  });
+
+  function fireWedge(event: GraviWedgeEvent) {
+    act(() => {
+      wedgeListeners.forEach((cb) => cb(event));
+    });
+  }
+
+  it('adds one entry keyed by scanner_id on a wedge event', () => {
+    const { result } = renderHook(() => useWedgeEvents());
+    fireWedge(makeEvent());
+
+    expect(Object.keys(result.current.entries)).toEqual(['sc-1']);
+    expect(result.current.entries['sc-1'].signature).toBe('sane_start_invalid');
+  });
+
+  it('replaces (not duplicates) the entry when a second wedge fires for the same scanner_id', () => {
+    const { result } = renderHook(() => useWedgeEvents());
+    fireWedge(makeEvent({ cycle_number: 3, signature: 'sane_start_invalid' }));
+    fireWedge(
+      makeEvent({ cycle_number: 5, signature: 'device_io_120s_zero_bytes' })
+    );
+
+    expect(Object.keys(result.current.entries)).toEqual(['sc-1']);
+    expect(result.current.entries['sc-1'].cycle_number).toBe(5);
+    expect(result.current.entries['sc-1'].signature).toBe(
+      'device_io_120s_zero_bytes'
+    );
+  });
+
+  it('tracks two different scanners as independent entries; dismissing one leaves the other untouched', () => {
+    const { result } = renderHook(() => useWedgeEvents());
+    fireWedge(makeEvent({ scanner_id: 'sc-1', cycle_number: 1 }));
+    fireWedge(makeEvent({ scanner_id: 'sc-2', cycle_number: 2 }));
+
+    expect(Object.keys(result.current.entries).sort()).toEqual([
+      'sc-1',
+      'sc-2',
+    ]);
+
+    act(() => {
+      result.current.dismiss('sc-1');
+    });
+
+    expect(Object.keys(result.current.entries)).toEqual(['sc-2']);
+    expect(result.current.entries['sc-2'].cycle_number).toBe(2);
+  });
+
+  it('clears all entries when onIntervalComplete fires', () => {
+    const { result } = renderHook(() => useWedgeEvents());
+    fireWedge(makeEvent());
+    expect(Object.keys(result.current.entries)).toHaveLength(1);
+
+    act(() => {
+      intervalCompleteListeners.forEach((cb) => cb());
+    });
+
+    expect(Object.keys(result.current.entries)).toHaveLength(0);
+  });
+
+  it('clears all entries when onCancelled fires', () => {
+    const { result } = renderHook(() => useWedgeEvents());
+    fireWedge(makeEvent());
+    expect(Object.keys(result.current.entries)).toHaveLength(1);
+
+    act(() => {
+      cancelledListeners.forEach((cb) => cb());
+    });
+
+    expect(Object.keys(result.current.entries)).toHaveLength(0);
+  });
+
+  it('dismiss(scannerId) removes exactly that entry with no IPC call', () => {
+    const { result } = renderHook(() => useWedgeEvents());
+    fireWedge(makeEvent());
+
+    act(() => {
+      result.current.dismiss('sc-1');
+    });
+
+    expect(Object.keys(result.current.entries)).toHaveLength(0);
+  });
+
+  it('unmount calls all three cleanup functions', () => {
+    const { unmount } = renderHook(() => useWedgeEvents());
+    unmount();
+
+    expect(unsubscribeWedge).toHaveBeenCalledTimes(1);
+    expect(unsubscribeIntervalComplete).toHaveBeenCalledTimes(1);
+    expect(unsubscribeCancelled).toHaveBeenCalledTimes(1);
+  });
+
+  it('totalAutoPauseEvents increments on every wedge, including repeats for the same scanner, and is unaffected by dismiss', () => {
+    const { result } = renderHook(() => useWedgeEvents());
+    fireWedge(makeEvent({ scanner_id: 'sc-1' }));
+    fireWedge(makeEvent({ scanner_id: 'sc-1' })); // retried, wedged again
+    fireWedge(makeEvent({ scanner_id: 'sc-2' }));
+
+    expect(result.current.totalAutoPauseEvents).toBe(3);
+
+    act(() => {
+      result.current.dismiss('sc-1');
+    });
+
+    expect(result.current.totalAutoPauseEvents).toBe(3);
+  });
+
+  it('totalScannersAffected counts distinct scanners, not events — a repeat on the same scanner does not inflate it', () => {
+    const { result } = renderHook(() => useWedgeEvents());
+    fireWedge(makeEvent({ scanner_id: 'sc-1' }));
+    expect(result.current.totalAutoPauseEvents).toBe(1);
+    expect(result.current.totalScannersAffected).toBe(1);
+
+    fireWedge(makeEvent({ scanner_id: 'sc-1' })); // same scanner again
+    expect(result.current.totalAutoPauseEvents).toBe(2);
+    expect(result.current.totalScannersAffected).toBe(1);
+
+    fireWedge(makeEvent({ scanner_id: 'sc-2' })); // new scanner
+    expect(result.current.totalAutoPauseEvents).toBe(3);
+    expect(result.current.totalScannersAffected).toBe(2);
+  });
+
+  it('resets both counters to 0 when the session ends (interval-complete/cancelled), same as the per-scanner entries', () => {
+    const { result } = renderHook(() => useWedgeEvents());
+    fireWedge(makeEvent({ scanner_id: 'sc-1' }));
+    fireWedge(makeEvent({ scanner_id: 'sc-2' }));
+    expect(result.current.totalAutoPauseEvents).toBe(2);
+    expect(result.current.totalScannersAffected).toBe(2);
+
+    act(() => {
+      intervalCompleteListeners.forEach((cb) => cb());
+    });
+
+    expect(result.current.totalAutoPauseEvents).toBe(0);
+    expect(result.current.totalScannersAffected).toBe(0);
+  });
+});

--- a/tests/unit/hooks/useWedgeEvents.test.ts
+++ b/tests/unit/hooks/useWedgeEvents.test.ts
@@ -130,6 +130,31 @@ describe('useWedgeEvents', () => {
     expect(Object.keys(result.current.entries)).toHaveLength(0);
   });
 
+  it('dismissIfCurrent removes the entry when cycle_number/timestamp still match', () => {
+    const { result } = renderHook(() => useWedgeEvents());
+    fireWedge(makeEvent({ cycle_number: 3, timestamp: 't1' }));
+
+    act(() => {
+      result.current.dismissIfCurrent('sc-1', 3, 't1');
+    });
+
+    expect(Object.keys(result.current.entries)).toHaveLength(0);
+  });
+
+  it('dismissIfCurrent is a no-op when a fresh wedge has superseded the entry (stale retry callback)', () => {
+    const { result } = renderHook(() => useWedgeEvents());
+    fireWedge(makeEvent({ cycle_number: 3, timestamp: 't1' }));
+    fireWedge(makeEvent({ cycle_number: 4, timestamp: 't2' }));
+
+    act(() => {
+      // Stale identity from the superseded (cycle 3) wedge.
+      result.current.dismissIfCurrent('sc-1', 3, 't1');
+    });
+
+    expect(Object.keys(result.current.entries)).toEqual(['sc-1']);
+    expect(result.current.entries['sc-1'].cycle_number).toBe(4);
+  });
+
   it('unmount calls all three cleanup functions', () => {
     const { unmount } = renderHook(() => useWedgeEvents());
     unmount();

--- a/tests/unit/pages/App.test.tsx
+++ b/tests/unit/pages/App.test.tsx
@@ -52,6 +52,13 @@ const mockGraviAPI = {
   onScanStarted: vi.fn().mockReturnValue(vi.fn()),
   onScanComplete: vi.fn().mockReturnValue(vi.fn()),
   onScanError: vi.fn().mockReturnValue(vi.fn()),
+  // Wedge-response UI (Tier 3) — without these, WedgeBanner mounting
+  // unconditionally in graviscan mode throws (this file renders the real
+  // App -> Layout tree, so Layout's WedgeBanner mounts for real here too).
+  onWedgeDetected: vi.fn().mockReturnValue(vi.fn()),
+  onIntervalComplete: vi.fn().mockReturnValue(vi.fn()),
+  onCancelled: vi.fn().mockReturnValue(vi.fn()),
+  retryScanner: vi.fn().mockResolvedValue({ success: true }),
 };
 
 beforeEach(() => {

--- a/tests/unit/pages/Layout.test.tsx
+++ b/tests/unit/pages/Layout.test.tsx
@@ -3,12 +3,16 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { Layout } from '../../../src/renderer/Layout';
+import type { GraviWedgeEvent } from '../../../src/types/graviscan';
+
+let wedgeListeners: Array<(event: GraviWedgeEvent) => void>;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  wedgeListeners = [];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const win = global.window as any;
   if (win) {
@@ -16,6 +20,19 @@ beforeEach(() => {
       ...win.electron,
       scanner: {
         getScannerId: vi.fn().mockResolvedValue('TestScanner'),
+      },
+      // Wedge-response UI (Tier 3) mocks — without these, WedgeBanner
+      // mounting unconditionally in graviscan mode throws
+      // TypeError: Cannot read properties of undefined (reading
+      // 'onWedgeDetected') against this file's otherwise-bare mock.
+      gravi: {
+        onWedgeDetected: vi.fn((cb: (event: GraviWedgeEvent) => void) => {
+          wedgeListeners.push(cb);
+          return () => {};
+        }),
+        onIntervalComplete: vi.fn(() => () => {}),
+        onCancelled: vi.fn(() => () => {}),
+        retryScanner: vi.fn().mockResolvedValue({ success: true }),
       },
     };
   }
@@ -53,5 +70,49 @@ describe('Layout nav links', () => {
     expect(
       screen.queryByRole('link', { name: /configure scanner/i })
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('Layout wedge banner wiring', () => {
+  it('mounts the wedge banner (subscribes to onWedgeDetected) in graviscan mode', async () => {
+    renderLayout('graviscan');
+    await waitFor(() => screen.getByText(/scanner:/i));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((window.electron.gravi as any).onWedgeDetected).toHaveBeenCalled();
+  });
+
+  it('does not mount the wedge banner (no onWedgeDetected subscription) in cylinderscan mode', async () => {
+    renderLayout('cylinderscan');
+    await waitFor(() => screen.getByText(/scanner:/i));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const gravi = window.electron.gravi as any;
+    expect(gravi.onWedgeDetected).not.toHaveBeenCalled();
+  });
+
+  it('renders the wedge banner app-wide — alongside whatever child route is active, not scoped to one screen', async () => {
+    renderLayout('graviscan');
+    await waitFor(() => screen.getByText(/scanner:/i));
+    expect(screen.getByText('Home content')).toBeInTheDocument();
+
+    act(() => {
+      wedgeListeners.forEach((cb) =>
+        cb({
+          scanner_id: 'sc-1',
+          signature: 'sane_start_invalid',
+          session_id: 'sess-1',
+          cycle_number: 1,
+          timestamp: '2026-08-03T00:00:00.000Z',
+          error_message: 'epkowa: sane_start: Invalid argument',
+        })
+      );
+    });
+
+    // The banner and the (unrelated) index route content are both visible
+    // at the same time — proves the banner isn't scoped to a dedicated
+    // scan screen (design.md Decision 4).
+    expect(screen.getByTestId('wedge-entry-sc-1')).toBeInTheDocument();
+    expect(screen.getByText('Home content')).toBeInTheDocument();
   });
 });

--- a/tests/unit/preload-gravi.test.ts
+++ b/tests/unit/preload-gravi.test.ts
@@ -55,9 +55,10 @@ describe('preload gravi namespace', () => {
       'uploadAllScans',
       'downloadImages',
       'getScannerStatus',
+      'retryScanner',
     ];
 
-    it('has all 17 invoke methods', () => {
+    it('has all 18 invoke methods', () => {
       for (const method of invokeMethods) {
         expect(typeof exposedAPI.gravi[method]).toBe('function');
       }
@@ -98,6 +99,14 @@ describe('preload gravi namespace', () => {
         { thumbnail: true }
       );
     });
+
+    it('retryScanner passes scannerId to the correct channel', async () => {
+      await exposedAPI.gravi.retryScanner('scanner-1');
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'graviscan:retry-scanner',
+        'scanner-1'
+      );
+    });
   });
 
   describe('event listeners', () => {
@@ -117,9 +126,10 @@ describe('preload gravi namespace', () => {
       'onScanError',
       'onUploadProgress',
       'onDownloadProgress',
+      'onWedgeDetected',
     ];
 
-    it('has all 13 event listener methods', () => {
+    it('has all 14 event listener methods', () => {
       for (const method of listenerMethods) {
         expect(typeof exposedAPI.gravi[method]).toBe('function');
       }
@@ -193,6 +203,44 @@ describe('preload gravi namespace', () => {
         'graviscan:scan-complete',
         expect.any(Function)
       );
+    });
+
+    it('onWedgeDetected registers listener on the correct channel', () => {
+      const callback = vi.fn();
+      exposedAPI.gravi.onWedgeDetected(callback);
+      expect(mockOn).toHaveBeenCalledWith(
+        'graviscan:wedge-detected',
+        expect.any(Function)
+      );
+    });
+
+    it('onWedgeDetected cleanup function calls removeListener', () => {
+      const callback = vi.fn();
+      const cleanup = exposedAPI.gravi.onWedgeDetected(callback);
+      cleanup();
+      expect(mockRemoveListener).toHaveBeenCalledWith(
+        'graviscan:wedge-detected',
+        expect.any(Function)
+      );
+    });
+
+    it('onWedgeDetected forwards the event payload to the callback', () => {
+      const callback = vi.fn();
+      exposedAPI.gravi.onWedgeDetected(callback);
+
+      const registeredListener = mockOn.mock.calls.find(
+        (call: any[]) => call[0] === 'graviscan:wedge-detected'
+      )?.[1];
+      expect(registeredListener).toBeTruthy();
+
+      registeredListener(
+        {},
+        { scanner_id: 'sc-1', signature: 'sane_start_invalid' }
+      );
+      expect(callback).toHaveBeenCalledWith({
+        scanner_id: 'sc-1',
+        signature: 'sane_start_invalid',
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Auto-pauses a wedged scanner immediately (no operator action required) and adds an app-wide banner with Dismiss / Power-Cycled & Retry actions, closing the "permanent data loss, no recovery" gap for continuous time-lapse GraviScan experiments.

## Changes

- **Auto-pause on wedge detection**: `setupWedgeDetection()`'s `onWedge` callback now calls `coordinator.stopScanner(scanner_id)` immediately, fire-and-forget, not gated behind the Slack notification. A durable `scanLog()` line records the auto-pause alongside the pre-existing wedge-detected line.
- **Forward wedge events to the renderer**: new `graviscan:wedge-detected` push event via an optional `getMainWindow` parameter on `setupWedgeDetection()`.
- **New `graviscan:retry-scanner` IPC handler**: stops (idempotent) and respawns a scanner using a `saneName` rebuilt from a fresh DB read of `usb_bus`/`usb_device` (not a cached value — safe across an intervening `reset-usb`). Checks the scanner's `enabled` flag so a stale banner can't silently revive a scanner the operator explicitly disabled.
- **`buildSaneName()` extracted** from the existing save-scanners-db spawn-on-discovery inline template, shared by both call sites.
- **`WedgeBanner` component** (app-wide, mounted in `Layout.tsx`, gated on `mode === 'graviscan'`): one entry per auto-paused scanner, each with **Dismiss** (no backend call) and **Power-Cycled & Retry** (confirmation-gated — requires an explicit "Confirm Retry" after explanatory text about the power-cycle precondition). A session-scoped indicator shows both total auto-pause events and distinct scanners affected, so a single chronically-re-wedging scanner isn't misread as a fleet-wide problem.
- **`useWedgeEvents` hook**: subscribes to `onWedgeDetected`/`onIntervalComplete`/`onCancelled`, tracks per-scanner entries plus the two session counters.
- In-memory only — no DB schema changes. Deferred: issue #244's `wedge_event` DB table (item 2), wedge-skip placeholder row (item 3), auto-cancel-on-N-wedges (item 4), and session-level cancel+auto-restart (item 5) — all explicitly named as out of scope, not silently dropped.
- **Chore commit included**: fixes pre-existing Prettier formatting drift in `openspec/specs/scanning/spec.md` and `openspec/specs/ui-management-pages/spec.md` (confirmed already broken on `main` itself, unrelated to this feature — whitespace/markdown normalization only) so this PR's Lint job can go green.
- **Test commit included** (added during pre-merge review): real-`ScanCoordinator`-level tests for the exact `stopScanner()` + `addScanner()` sequence `retryScanner()` calls — see Integration Tests below.

Closes #244, #240. Addresses #228's P0 recommendation for the auto-pause half; the resume half is a manual confirmed-retry button rather than #228's fully-automatic USB-re-enumeration design, since this codebase has no hotplug-detection infrastructure (see `design.md` Decision 1 for the full reasoning).

## OpenSpec Change

- Change ID: `add-graviscan-wedge-response-ui`
- Affected capabilities: `scanning` (ADDED — wedge auto-pause, event forwarding, retry-scanner requirements), `ui-management-pages` (ADDED — wedge banner, wedge-response-actions, session auto-pause counter requirements)
- Delta types: ADDED only, no BREAKING changes
- All `tasks.md` items complete: yes (63/63, including task 9.6 added during pre-merge review)
- Proposal went through 4 rounds of 5-agent adversarial review before implementation (see `design.md` for the full history, including a redesign from an earlier manual-"Skip" draft to the current auto-pause design after review found the draft inverted the source issues' intent)

## Testing

### TypeScript Tests

- [x] Unit tests pass — 1177 passed, 50 skipped (`npm run test:unit`)
- [!] 7 pre-existing failures on `main`, unrelated to this change (verified via file-touch analysis: none of the failing test files — `database-handlers.test.ts`, `config-store.test.ts`, `image-uploader.test.ts`, `scan-coordinator.test.ts` — are touched by this PR beyond adding new, passing tests; the `scan-coordinator.test.ts`/`image-uploader.test.ts` failures are Windows path-separator assertions (`/` vs `\`), `AccessionForm.test.tsx` is a timing-flaky test that passes 10/10 in isolation)
- [x] Unit tests added for new functionality — 93 new/updated tests across `main-wiring.test.ts`, `scanner-handlers.test.ts`, `session-handlers.test.ts`, `register-handlers.test.ts`, `preload-gravi.test.ts`, `scan-coordinator.test.ts`, `useWedgeEvents.test.ts` (new), `WedgeBanner.test.tsx` (new), `Layout.test.tsx`, `App.test.tsx`
- [ ] Coverage threshold check — not run separately; full suite shows no regression

### Python Tests

- [ ] N/A — no Python files touched (this change consumes existing wedge-detector output; it doesn't touch detection logic or hardware-facing code)

### Integration Tests

- [x] `tests/unit/graviscan/scan-coordinator.test.ts` — added two tests exercising the real `ScanCoordinator` class (mocking only `ScannerSubprocess` beneath it, same level as this file's existing coverage) for the exact `stopScanner()` + `addScanner()` sequence `retryScanner()` calls: (1) stop-then-respawn while idle, (2) a retried scanner's `addScanner()` correctly queuing until `cycle-complete` while a *different* scanner is mid-cycle — the real "Retry clicked while the session keeps running" scenario. *(An earlier revision of this PR incorrectly claimed N/A here — see PR comment for the correction.)*
- [ ] No `tests/integration/` (Python-subprocess-level) changes — the new `graviscan:retry-scanner` IPC surface doesn't cross the Node-Python boundary any differently from the existing `addScanner`/`stopScanner` usage that layer already covers

### E2E Tests

- [x] CI's existing E2E suite passes (confirmed green on macOS/ubuntu/windows dev builds)
- [ ] A real wedge scenario (mock hardware to wedge fires to banner to retry) is **not** exercised — `python/graviscan/scan_worker.py`'s mock path has no fault-injection mechanism, and adding one is out of scope for a UI/IPC-wiring change that otherwise touches no Python (documented in `tasks.md` task 9.4). **Tracked for manual rig verification in #279** before this is relied on for an unattended production run.

## Build & Packaging

- [x] TypeScript compiles without errors (`npx prisma generate && npx tsc --noEmit`)
- [ ] `npm run build:python` — not run; no Python changes
- [ ] Packaged app — not tested; no packaging/build-config/dependency changes

## Linting & Formatting

- [x] ESLint passes (`npm run lint`)
- [x] Prettier formatting applied (`npm run format:check`) — clean, including the two pre-existing-on-`main` files fixed in a separate chore commit in this PR

## Database Changes

- [x] No database changes

## Cross-Platform Compatibility

- [x] No platform-specific assumptions introduced (pure TS/React, no new file-path handling)
- [x] CI cross-platform run — green on Linux, macOS, Windows (Python build matrix + integration tests)

## Breaking Changes

- [x] No breaking changes — `setupWedgeDetection()`'s new third parameter is optional with a default; all new IPC channels and preload/`GraviAPI` members are additive

## Related Issues

Closes #244
Closes #240
Related to #228
Follow-up: #279 (manual rig verification of the wedge-response flow)

## Reviewer Notes

- `design.md` in the OpenSpec change directory has the full rationale, including two things worth double-checking: (1) Decision 1's tradeoff analysis of calling `stopScanner()` at wedge-detection time (can occasionally force an in-flight row to fall back to its existing 90s timeout instead of resolving via listeners — accepted as bounded/rare, not a new unbounded risk), and (2) the session-scoped counter's two-number design (event count + distinct-scanner count), added specifically so a single scanner re-wedging after failed retries doesn't read as a multi-scanner incident.
- `tests/unit/graviscan/main-wiring.test.ts` gained a shared `createMockWedgeCoordinator()` factory, refactored across all 13 existing test cases in the `setupWedgeDetection` describe block (previously each built its own bare `EventEmitter` with no `stopScanner` method).
